### PR TITLE
feat: 添加网站 favicon 图标

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,6 +18,11 @@ export const metadata: Metadata = {
   description: "极简AI跨境商品详情页生成工具，一键生成Amazon、Shopify等平台商品详情页",
   keywords: ["AI", "商品详情页", "跨境电商", "Amazon", "Shopify", "图片生成"],
   authors: [{ name: "OuraPix" }],
+  icons: {
+    icon: "/favicon.svg",
+    shortcut: "/favicon.svg",
+    apple: "/favicon.svg",
+  },
   openGraph: {
     title: "OuraPix - AI跨境商品详情页生成",
     description: "极简AI跨境商品详情页生成工具",

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <!-- Background rounded square -->
+  <rect width="32" height="32" rx="6" fill="#0f172a"/>
+
+  <!-- Image/photo frame -->
+  <rect x="5" y="7" width="22" height="18" rx="2" fill="#fff" fill-opacity="0.95"/>
+
+  <!-- Mountain/landscape shape -->
+  <path d="M5 21 L12 14 L17 19 L22 12 L27 21 L27 25 L5 25 Z" fill="#64748b"/>
+
+  <!-- Sun circle -->
+  <circle cx="11" cy="12" r="3" fill="#facc15"/>
+
+  <!-- AI sparkle star -->
+  <path d="M24 4 L25 6 L27 7 L25 8 L24 10 L23 8 L21 7 L23 6 Z" fill="#38bdf8"/>
+  <path d="M24 5 L24.5 6 L25 7 L24.5 8 L24 9 L23.5 8 L23 7 L23.5 6 Z" fill="#7dd3fc"/>
+</svg>


### PR DESCRIPTION
## Summary
- 为 OuraPix 网站设计并添加 favicon 图标
- favicon 采用 SVG 格式，包含深色背景、图片框、山峰、太阳和 AI 闪光元素
- 在 `app/layout.tsx` 的 metadata 中配置 favicon

## Test plan
- [ ] 启动开发服务器，检查浏览器标签页是否显示 favicon
- [ ] 测试不同浏览器兼容性（Chrome、Firefox、Safari）

🤖 Generated with [Claude Code](https://claude.com/claude-code)