### PR TITLE
fix: use env var for Cloudflare secrets condition

### DIFF
--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -14,6 +14,8 @@ jobs:
   deploy-api:
     name: Deploy API to Cloudflare Workers
     runs-on: ubuntu-latest
+    env:
+      HAS_CLOUDFLARE_SECRETS: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -38,7 +40,7 @@ jobs:
         run: pnpm --filter @oura-pix/api typecheck
 
       - name: Deploy to Cloudflare Workers
-        if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}
+        if: env.HAS_CLOUDFLARE_SECRETS == 'true'
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -47,5 +49,5 @@ jobs:
           command: deploy
 
       - name: Skip deploy (no secrets)
-        if: ${{ secrets.CLOUDFLARE_API_TOKEN == '' }}
-        run: echo "Skipping deploy - CLOUDFLARE_API_TOKEN not configured"
+        if: env.HAS_CLOUDFLARE_SECRETS != 'true'
+        run: echo "Skipping deploy - Cloudflare secrets not configured"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,8 @@ jobs:
   deploy-frontend:
     name: Deploy Frontend to Cloudflare Workers
     runs-on: ubuntu-latest
+    env:
+      HAS_CLOUDFLARE_SECRETS: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,7 +41,7 @@ jobs:
           PUBLIC_API_URL: ${{ secrets.PUBLIC_API_URL }}
 
       - name: Deploy to Cloudflare Workers
-        if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}
+        if: env.HAS_CLOUDFLARE_SECRETS == 'true'
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -48,5 +50,5 @@ jobs:
           command: deploy
 
       - name: Skip deploy (no secrets)
-        if: ${{ secrets.CLOUDFLARE_API_TOKEN == '' }}
-        run: echo "Skipping deploy - CLOUDFLARE_API_TOKEN not configured"
+        if: env.HAS_CLOUDFLARE_SECRETS != 'true'
+        run: echo "Skipping deploy - Cloudflare secrets not configured"


### PR DESCRIPTION
## Fix

GitHub Actions doesn't allow direct secrets access in `if` conditions.
This was causing workflow file errors.

## Solution

Use job-level environment variable to check if secrets are configured.