### PR TITLE
feat: add generation history page

### DIFF
--- a/frontend/src/components/FilterBar.tsx
+++ b/frontend/src/components/FilterBar.tsx
@@ -1,0 +1,104 @@
+/**
+ * FilterBar Component
+ *
+ * Filter controls for generation history
+ */
+
+import type { TimeFilter, PlatformFilter, StatusFilter } from "@/hooks/useGenerations";
+
+interface FilterBarProps {
+  timeFilter: TimeFilter;
+  onTimeFilterChange: (filter: TimeFilter) => void;
+  platformFilter: PlatformFilter;
+  onPlatformFilterChange: (platform: PlatformFilter) => void;
+  statusFilter: StatusFilter;
+  onStatusFilterChange: (status: StatusFilter) => void;
+}
+
+const timeFilters: { value: TimeFilter; label: string }[] = [
+  { value: "all", label: "全部" },
+  { value: "today", label: "今天" },
+  { value: "week", label: "本周" },
+  { value: "month", label: "本月" },
+];
+
+const platformFilters: { value: PlatformFilter; label: string; icon: string }[] = [
+  { value: "all", label: "全部平台", icon: "🌐" },
+  { value: "amazon", label: "Amazon", icon: "🅰️" },
+  { value: "shopify", label: "Shopify", icon: "🛍️" },
+  { value: "ebay", label: "eBay", icon: "🏷️" },
+  { value: "etsy", label: "Etsy", icon: "🎨" },
+  { value: "generic", label: "通用", icon: "📦" },
+];
+
+const statusFilters: { value: StatusFilter; label: string; color: string }[] = [
+  { value: "all", label: "全部状态", color: "gray" },
+  { value: "success", label: "成功", color: "green" },
+  { value: "pending", label: "处理中", color: "yellow" },
+  { value: "failed", label: "失败", color: "red" },
+];
+
+export default function FilterBar({
+  timeFilter,
+  onTimeFilterChange,
+  platformFilter,
+  onPlatformFilterChange,
+  statusFilter,
+  onStatusFilterChange,
+}: FilterBarProps) {
+  return (
+    <div className="flex flex-col sm:flex-row gap-3 p-4 bg-stone-50 dark:bg-stone-900 rounded-xl">
+      {/* Time Filter */}
+      <div className="flex flex-wrap gap-1">
+        {timeFilters.map((f) => (
+          <button
+            key={f.value}
+            onClick={() => onTimeFilterChange(f.value)}
+            className={`px-3 py-1.5 text-sm rounded-lg transition-colors ${
+              timeFilter === f.value
+                ? "bg-amber-600 text-white"
+                : "bg-white dark:bg-stone-800 text-stone-600 dark:text-stone-400 hover:bg-stone-100 dark:hover:bg-stone-700"
+            }`}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Platform Filter */}
+      <div className="flex flex-wrap gap-1 sm:ml-auto">
+        {platformFilters.map((f) => (
+          <button
+            key={f.value}
+            onClick={() => onPlatformFilterChange(f.value)}
+            className={`px-3 py-1.5 text-sm rounded-lg transition-colors flex items-center gap-1 ${
+              platformFilter === f.value
+                ? "bg-amber-600 text-white"
+                : "bg-white dark:bg-stone-800 text-stone-600 dark:text-stone-400 hover:bg-stone-100 dark:hover:bg-stone-700"
+            }`}
+          >
+            <span>{f.icon}</span>
+            <span className="hidden sm:inline">{f.label}</span>
+          </button>
+        ))}
+      </div>
+
+      {/* Status Filter */}
+      <div className="flex flex-wrap gap-1">
+        {statusFilters.map((f) => (
+          <button
+            key={f.value}
+            onClick={() => onStatusFilterChange(f.value)}
+            className={`px-3 py-1.5 text-sm rounded-lg transition-colors ${
+              statusFilter === f.value
+                ? "bg-amber-600 text-white"
+                : "bg-white dark:bg-stone-800 text-stone-600 dark:text-stone-400 hover:bg-stone-100 dark:hover:bg-stone-700"
+            }`}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/GenerationCard.tsx
+++ b/frontend/src/components/GenerationCard.tsx
@@ -1,0 +1,198 @@
+/**
+ * GenerationCard Component
+ *
+ * Card display for a single generation record
+ */
+
+import { useState } from "react";
+import type { GenerationRecord } from "@/hooks/useGenerations";
+
+interface GenerationCardProps {
+  generation: GenerationRecord;
+  onViewDetail: (id: string) => void;
+  onRegenerate: (id: string) => void;
+  onDelete: (id: string) => void;
+}
+
+function formatTime(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 1) return "刚刚";
+  if (diffMins < 60) return `${diffMins}分钟前`;
+  if (diffHours < 24) return `${diffHours}小时前`;
+  if (diffDays < 7) return `${diffDays}天前`;
+  return date.toLocaleDateString("zh-CN");
+}
+
+function getStatusInfo(status: string): { label: string; color: string; bg: string } {
+  switch (status) {
+    case "success":
+    case "completed":
+      return { label: "已完成", color: "text-green-700", bg: "bg-green-100" };
+    case "processing":
+    case "pending":
+      return { label: "处理中", color: "text-yellow-700", bg: "bg-yellow-100" };
+    case "failed":
+    case "error":
+      return { label: "失败", color: "text-red-700", bg: "bg-red-100" };
+    default:
+      return { label: status, color: "text-gray-700", bg: "bg-gray-100" };
+  }
+}
+
+function getPlatformIcon(platform: string): string {
+  switch (platform) {
+    case "amazon":
+      return "🅰️";
+    case "shopify":
+      return "🛍️";
+    case "ebay":
+      return "🏷️";
+    case "etsy":
+      return "🎨";
+    default:
+      return "📦";
+  }
+}
+
+export default function GenerationCard({
+  generation,
+  onViewDetail,
+  onRegenerate,
+  onDelete,
+}: GenerationCardProps) {
+  const [showActions, setShowActions] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  const statusInfo = getStatusInfo(generation.status);
+  const platformIcon = getPlatformIcon(generation.platform);
+  const thumbnail = generation.productImageUrl || generation.generatedImages[0] || null;
+
+  const handleDelete = () => {
+    if (showDeleteConfirm) {
+      onDelete(generation.id);
+      setShowDeleteConfirm(false);
+    } else {
+      setShowDeleteConfirm(true);
+      setTimeout(() => setShowDeleteConfirm(false), 3000);
+    }
+  };
+
+  return (
+    <div
+      className="group relative bg-white dark:bg-stone-800 rounded-xl overflow-hidden shadow-sm hover:shadow-md transition-all duration-200 border border-stone-200 dark:border-stone-700"
+      onMouseEnter={() => setShowActions(true)}
+      onMouseLeave={() => {
+        setShowActions(false);
+        setShowDeleteConfirm(false);
+      }}
+    >
+      {/* Thumbnail */}
+      <div className="relative aspect-video bg-stone-100 dark:bg-stone-900 overflow-hidden">
+        {thumbnail ? (
+          <img
+            src={thumbnail}
+            alt="商品图"
+            className="w-full h-full object-cover"
+            loading="lazy"
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center text-stone-400">
+            <svg className="w-12 h-12" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+          </div>
+        )}
+
+        {/* Status Badge */}
+        <div className={`absolute top-2 left-2 px-2 py-0.5 rounded-full text-xs font-medium ${statusInfo.bg} ${statusInfo.color}`}>
+          {statusInfo.label}
+        </div>
+
+        {/* Image Count Badge */}
+        {generation.generatedImages.length > 0 && (
+          <div className="absolute top-2 right-2 px-2 py-0.5 rounded-full text-xs font-medium bg-black/60 text-white">
+            {generation.generatedImages.length} 张
+          </div>
+        )}
+
+        {/* Quick Actions Overlay */}
+        <div
+          className={`absolute inset-0 bg-black/40 flex items-center justify-center gap-2 transition-opacity duration-200 ${
+            showActions ? "opacity-100" : "opacity-0"
+          }`}
+        >
+          <button
+            onClick={() => onViewDetail(generation.id)}
+            className="p-2 rounded-full bg-white/90 hover:bg-white transition-colors"
+            title="查看详情"
+          >
+            <svg className="w-5 h-5 text-stone-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+            </svg>
+          </button>
+          <button
+            onClick={() => onRegenerate(generation.id)}
+            className="p-2 rounded-full bg-white/90 hover:bg-white transition-colors"
+            title="重新生成"
+          >
+            <svg className="w-5 h-5 text-stone-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+            </svg>
+          </button>
+          <button
+            onClick={handleDelete}
+            className={`p-2 rounded-full transition-colors ${
+              showDeleteConfirm
+                ? "bg-red-500 hover:bg-red-600 text-white"
+                : "bg-white/90 hover:bg-white text-stone-700"
+            }`}
+            title={showDeleteConfirm ? "再次点击确认删除" : "删除"}
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="p-3">
+        {/* Title / Prompt */}
+        <h3 className="text-sm font-medium text-stone-900 dark:text-stone-100 line-clamp-2 mb-2">
+          {generation.prompt || `生成任务 #${generation.id.slice(0, 8)}`}
+        </h3>
+
+        {/* Meta Info */}
+        <div className="flex items-center justify-between text-xs text-stone-500 dark:text-stone-400">
+          <div className="flex items-center gap-1">
+            <span>{platformIcon}</span>
+            <span className="capitalize">{generation.platform}</span>
+          </div>
+          <div>{formatTime(generation.createdAt)}</div>
+        </div>
+
+        {/* Style Tags */}
+        <div className="flex flex-wrap gap-1 mt-2">
+          <span className="px-1.5 py-0.5 text-xs bg-stone-100 dark:bg-stone-700 text-stone-600 dark:text-stone-300 rounded">
+            {generation.style}
+          </span>
+          <span className="px-1.5 py-0.5 text-xs bg-stone-100 dark:bg-stone-700 text-stone-600 dark:text-stone-300 rounded">
+            {generation.language}
+          </span>
+          {generation.count > 0 && (
+            <span className="px-1.5 py-0.5 text-xs bg-stone-100 dark:bg-stone-700 text-stone-600 dark:text-stone-300 rounded">
+              ×{generation.count}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/HistoryPage.tsx
+++ b/frontend/src/components/HistoryPage.tsx
@@ -1,0 +1,200 @@
+/**
+ * HistoryPage Component
+ *
+ * Main page component for generation history
+ */
+
+import { useCallback } from "react";
+import { useGenerations } from "@/hooks/useGenerations";
+import FilterBar from "./FilterBar";
+import GenerationCard from "./GenerationCard";
+import { deleteGeneration } from "@/lib/api";
+
+function SkeletonCard() {
+  return (
+    <div className="bg-white dark:bg-stone-800 rounded-xl overflow-hidden shadow-sm border border-stone-200 dark:border-stone-700 animate-pulse">
+      <div className="aspect-video bg-stone-200 dark:bg-stone-700" />
+      <div className="p-3 space-y-2">
+        <div className="h-4 bg-stone-200 dark:bg-stone-700 rounded w-3/4" />
+        <div className="flex justify-between">
+          <div className="h-3 bg-stone-200 dark:bg-stone-700 rounded w-1/4" />
+          <div className="h-3 bg-stone-200 dark:bg-stone-700 rounded w-1/4" />
+        </div>
+        <div className="flex gap-1">
+          <div className="h-5 bg-stone-200 dark:bg-stone-700 rounded w-12" />
+          <div className="h-5 bg-stone-200 dark:bg-stone-700 rounded w-12" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({ onGenerate }: { onGenerate: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 px-4">
+      <div className="w-24 h-24 mb-6 text-stone-300 dark:text-stone-600">
+        <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" className="w-full h-full">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1}
+            d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+          />
+        </svg>
+      </div>
+      <h3 className="text-lg font-medium text-stone-900 dark:text-stone-100 mb-2">
+        暂无生成记录
+      </h3>
+      <p className="text-stone-500 dark:text-stone-400 text-center mb-6 max-w-sm">
+        开始使用 AI 生成精美的商品详情页图片吧
+      </p>
+      <button
+        onClick={onGenerate}
+        className="px-6 py-2.5 bg-amber-600 hover:bg-amber-700 text-white rounded-lg font-medium transition-colors"
+      >
+        开始生成
+      </button>
+    </div>
+  );
+}
+
+export default function HistoryPage() {
+  const {
+    generations,
+    pagination,
+    isLoading,
+    error,
+    page,
+    setPage,
+    filter,
+    setFilter,
+    platform,
+    setPlatform,
+    status,
+    setStatus,
+    refresh,
+  } = useGenerations();
+
+  const handleViewDetail = useCallback((id: string) => {
+    window.location.href = `/generate?history=${id}`;
+  }, []);
+
+  const handleRegenerate = useCallback((id: string) => {
+    window.location.href = `/generate?regenerate=${id}`;
+  }, []);
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      try {
+        await deleteGeneration(id);
+        refresh();
+      } catch (err) {
+        console.error("Delete failed:", err);
+      }
+    },
+    [refresh]
+  );
+
+  const handleGenerate = useCallback(() => {
+    window.location.href = "/generate";
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-stone-100 dark:bg-stone-950">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-6">
+          <div>
+            <h1 className="text-2xl font-bold text-stone-900 dark:text-stone-100">
+              生成历史
+            </h1>
+            <p className="text-stone-500 dark:text-stone-400 text-sm mt-1">
+              {pagination ? `共 ${pagination.total} 条记录` : ""}
+            </p>
+          </div>
+          <button
+            onClick={handleGenerate}
+            className="px-4 py-2 bg-amber-600 hover:bg-amber-700 text-white rounded-lg font-medium transition-colors flex items-center gap-2"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+            </svg>
+            新建生成
+          </button>
+        </div>
+
+        {/* Filters */}
+        <FilterBar
+          timeFilter={filter}
+          onTimeFilterChange={setFilter}
+          platformFilter={platform}
+          onPlatformFilterChange={setPlatform}
+          statusFilter={status}
+          onStatusFilterChange={setStatus}
+        />
+
+        {/* Content */}
+        <div className="mt-6">
+          {error && (
+            <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg mb-4">
+              <p className="text-red-700 dark:text-red-400 text-sm">{error}</p>
+              <button
+                onClick={refresh}
+                className="mt-2 text-sm text-red-600 dark:text-red-400 underline hover:no-underline"
+              >
+                重试
+              </button>
+            </div>
+          )}
+
+          {isLoading ? (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+              {Array.from({ length: 8 }).map((_, i) => (
+                <SkeletonCard key={i} />
+              ))}
+            </div>
+          ) : generations.length === 0 ? (
+            <EmptyState onGenerate={handleGenerate} />
+          ) : (
+            <>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+                {generations.map((gen) => (
+                  <GenerationCard
+                    key={gen.id}
+                    generation={gen}
+                    onViewDetail={handleViewDetail}
+                    onRegenerate={handleRegenerate}
+                    onDelete={handleDelete}
+                  />
+                ))}
+              </div>
+
+              {/* Pagination */}
+              {pagination && pagination.totalPages > 1 && (
+                <div className="flex items-center justify-center gap-2 mt-8">
+                  <button
+                    onClick={() => setPage(page - 1)}
+                    disabled={page === 1}
+                    className="px-3 py-1.5 text-sm rounded-lg bg-white dark:bg-stone-800 border border-stone-200 dark:border-stone-700 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-stone-50 dark:hover:bg-stone-700 transition-colors"
+                  >
+                    上一页
+                  </button>
+                  <span className="text-sm text-stone-600 dark:text-stone-400">
+                    {page} / {pagination.totalPages}
+                  </span>
+                  <button
+                    onClick={() => setPage(page + 1)}
+                    disabled={page === pagination.totalPages}
+                    className="px-3 py-1.5 text-sm rounded-lg bg-white dark:bg-stone-800 border border-stone-200 dark:border-stone-700 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-stone-50 dark:hover:bg-stone-700 transition-colors"
+                  >
+                    下一页
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -19,6 +19,7 @@ export default function Navbar() {
   const navLinks = [
     { href: "/", label: m.home() },
     { href: "/generate", label: m.generate() },
+    { href: "/history", label: m.history_title?.() || "生成历史" },
     { href: "/pricing", label: m.pricing() },
   ];
 

--- a/frontend/src/hooks/useGenerations.ts
+++ b/frontend/src/hooks/useGenerations.ts
@@ -1,0 +1,137 @@
+/**
+ * useGenerations Hook
+ *
+ * Data fetching hook for generation history
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import { getGenerations } from "@/lib/api";
+import type { GenerationsListParams } from "@oura-pix/api-client";
+
+export type TimeFilter = "all" | "today" | "week" | "month";
+export type PlatformFilter = "all" | "amazon" | "shopify" | "ebay" | "etsy" | "generic";
+export type StatusFilter = "all" | "success" | "pending" | "failed";
+
+export interface GenerationRecord {
+  id: string;
+  prompt: string | null;
+  platform: string;
+  style: string;
+  language: string;
+  count: number;
+  productImageId: string | null;
+  productImageUrl: string | null;
+  referenceImageUrls: string[];
+  generatedImages: string[];
+  createdAt: string;
+  status: string;
+  errorMessage?: string | null;
+}
+
+export interface Pagination {
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+}
+
+interface UseGenerationsOptions {
+  initialPage?: number;
+  initialPageSize?: number;
+  initialFilter?: TimeFilter;
+  platform?: PlatformFilter;
+  status?: StatusFilter;
+}
+
+interface UseGenerationsReturn {
+  generations: GenerationRecord[];
+  pagination: Pagination | null;
+  isLoading: boolean;
+  error: string | null;
+  page: number;
+  setPage: (page: number) => void;
+  filter: TimeFilter;
+  setFilter: (filter: TimeFilter) => void;
+  platform: PlatformFilter;
+  setPlatform: (platform: PlatformFilter) => void;
+  status: StatusFilter;
+  setStatus: (status: StatusFilter) => void;
+  refresh: () => void;
+}
+
+export function useGenerations(options: UseGenerationsOptions = {}): UseGenerationsReturn {
+  const { initialPage = 1, initialPageSize = 20, initialFilter = "all" } = options;
+
+  const [generations, setGenerations] = useState<GenerationRecord[]>([]);
+  const [pagination, setPagination] = useState<Pagination | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(initialPage);
+  const [filter, setFilter] = useState<TimeFilter>(initialFilter);
+  const [platform, setPlatform] = useState<PlatformFilter>(options.platform || "all");
+  const [status, setStatus] = useState<StatusFilter>(options.status || "all");
+
+  const fetchGenerations = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const params: GenerationsListParams = {
+        page,
+        pageSize: initialPageSize,
+        filter,
+      };
+
+      // Note: Backend API currently only supports time filter
+      // Platform and status filtering will be done client-side for now
+      const response = await getGenerations(params);
+
+      if (response.success) {
+        let data = response.data as GenerationRecord[];
+
+        // Client-side filtering for platform
+        if (platform !== "all") {
+          data = data.filter((g) => g.platform === platform);
+        }
+
+        // Client-side filtering for status
+        if (status !== "all") {
+          data = data.filter((g) => g.status === status);
+        }
+
+        setGenerations(data);
+        setPagination(response.pagination as Pagination);
+      } else {
+        setError(response.error?.message || "Failed to fetch generations");
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [page, initialPageSize, filter, platform, status]);
+
+  useEffect(() => {
+    fetchGenerations();
+  }, [fetchGenerations]);
+
+  const refresh = useCallback(() => {
+    fetchGenerations();
+  }, [fetchGenerations]);
+
+  return {
+    generations,
+    pagination,
+    isLoading,
+    error,
+    page,
+    setPage,
+    filter,
+    setFilter,
+    platform,
+    setPlatform,
+    status,
+    setStatus,
+    refresh,
+  };
+}

--- a/frontend/src/pages/history.astro
+++ b/frontend/src/pages/history.astro
@@ -1,0 +1,11 @@
+---
+import Layout from "../layouts/Layout.astro";
+import HistoryPage from "../components/HistoryPage";
+import * as m from "@/paraglide/messages.js";
+
+const isLoggedIn = true; // TODO: Check session
+---
+
+<Layout title={m.history_title?.() || "生成历史"}>
+  <HistoryPage client:load />
+</Layout>

--- a/frontend/src/paraglide/messages.js
+++ b/frontend/src/paraglide/messages.js
@@ -249,3 +249,34 @@ export const upload_supportedFormats = ({ type, size }) => `支持 ${type}，最
 
 // Common
 export const common_custom = () => "自定义";
+
+// History page
+export const history_title = () => "生成历史";
+export const history_subtitle = () => "查看您的所有生成记录";
+export const history_empty = () => "暂无生成记录";
+export const history_emptyDescription = () => "开始使用 AI 生成精美的商品详情页图片吧";
+export const history_startGenerate = () => "开始生成";
+export const history_newGenerate = () => "新建生成";
+export const history_totalRecords = ({ count }) => `共 ${count} 条记录`;
+export const history_filterAll = () => "全部";
+export const history_filterToday = () => "今天";
+export const history_filterWeek = () => "本周";
+export const history_filterMonth = () => "本月";
+export const history_filterAllPlatforms = () => "全部平台";
+export const history_filterAllStatus = () => "全部状态";
+export const history_statusSuccess = () => "已完成";
+export const history_statusPending = () => "处理中";
+export const history_statusFailed = () => "失败";
+export const history_viewDetail = () => "查看详情";
+export const history_regenerate = () => "重新生成";
+export const history_delete = () => "删除";
+export const history_deleteConfirm = () => "再次点击确认删除";
+export const history_images = ({ count }) => `${count} 张`;
+export const history_minutesAgo = ({ count }) => `${count}分钟前`;
+export const history_hoursAgo = ({ count }) => `${count}小时前`;
+export const history_daysAgo = ({ count }) => `${count}天前`;
+export const history_justNow = () => "刚刚";
+export const history_previousPage = () => "上一页";
+export const history_nextPage = () => "下一页";
+export const history_retry = () => "重试";
+export const history_noImage = () => "无图片";


### PR DESCRIPTION
## 功能概述

新增生成历史页面，用户可以查看所有历史生成记录。

## 新增文件

### 页面
- `frontend/src/pages/history.astro` - 路由页面

### 组件
- `frontend/src/components/HistoryPage.tsx` - 主页面组件（卡片网格 + 分页）
- `frontend/src/components/GenerationCard.tsx` - 生成记录卡片
- `frontend/src/components/FilterBar.tsx` - 筛选栏（时间/平台/状态）

### Hooks
- `frontend/src/hooks/useGenerations.ts` - 数据获取 hook

### 修改
- `frontend/src/components/Navbar.tsx` - 添加历史链接
- `frontend/src/paraglide/messages.js` - 添加 i18n keys

## 实现优先级

- [x] P0: 基础卡片列表 + 分页
- [x] P1: 筛选功能（时间/平台/状态）
- [x] P2: 快捷操作（悬停菜单：查看/重新生成/删除）
- [ ] P3: 无限滚动优化（当前使用分页）

## 技术实现

- 复用现有 `GET /api/generations` API
- 客户端筛选（平台/状态），服务端筛选（时间）
- 响应式网格布局（1-4列）
- 骨架屏加载状态
- 空状态引导

## 验证

- [x] TypeScript 类型检查通过
- [x] ESLint 检查通过
- [ ] 浏览器测试