### PR TITLE
feat: add error tracking and dashboard (Feature #30 - P0)

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -18,6 +18,7 @@ import { subscriptionRoutes } from "./routes/subscription";
 import { favoriteRoutes } from "./routes/favorites";
 import statsRoutes from "./routes/stats";
 import notificationRoutes from "./routes/notifications";
+import errorRoutes from "./routes/errors";
 import { stripeWebhookRoutes } from "./routes/webhooks/stripe";
 import { authMiddleware } from "./middleware/auth";
 
@@ -103,6 +104,7 @@ app.route("/api/subscription", subscriptionRoutes);
 app.route("/api/favorites", favoriteRoutes);
 app.route("/api/stats", statsRoutes);
 app.route("/api/notifications", notificationRoutes);
+app.route("/api/errors", errorRoutes);
 app.route("/api/webhooks", stripeWebhookRoutes);
 
 // ============================================

--- a/api/src/routes/errors.ts
+++ b/api/src/routes/errors.ts
@@ -1,0 +1,189 @@
+/**
+ * Errors Routes
+ *
+ * API endpoints for error reporting and dashboard
+ */
+
+import { Hono } from "hono";
+import { z } from "zod";
+import { zValidator } from "@hono/zod-validator";
+import { createDb } from "@oura-pix/database";
+import type { ErrorSeverityType, ErrorTypeType, ErrorModuleType } from "@oura-pix/database";
+import { getUser } from "../middleware/auth";
+import {
+  reportError,
+  listErrors,
+  getErrorStats,
+  deleteError,
+  deleteErrors,
+} from "../services/errorService";
+
+const errors = new Hono<{
+  Bindings: {
+    DB: D1Database;
+  };
+  Variables: {
+    user: { id: string; email: string; name?: string | null };
+    session: { id: string; expiresAt: Date };
+  };
+}>();
+
+const ErrorSeverityEnum = z.enum(["critical", "high", "medium", "low"]);
+const ErrorTypeEnum = z.enum([
+  "network",
+  "validation",
+  "authentication",
+  "business_logic",
+  "runtime",
+  "unknown",
+]);
+const ErrorModuleEnum = z.enum(["api", "frontend", "worker", "database"]);
+
+/**
+ * POST /api/errors
+ * Report a new error (public — used by client-side error handlers)
+ */
+const reportSchema = z.object({
+  message: z.string().min(1).max(2000),
+  stack: z.string().max(4000).optional(),
+  severity: ErrorSeverityEnum.optional(),
+  type: ErrorTypeEnum.optional(),
+  module: ErrorModuleEnum.optional(),
+  context: z.record(z.unknown()).optional(),
+});
+
+errors.post("/", zValidator("json", reportSchema), async (c) => {
+  const input = c.req.valid("json");
+
+  try {
+    const db = createDb(c.env.DB);
+    const result = await reportError(db, {
+      ...input,
+      module: (input.module ?? "frontend") as ErrorModuleType,
+    });
+    return c.json({
+      success: true,
+      data: {
+        id: result.record.id,
+        occurrences: result.record.occurrences,
+        created: result.created,
+      },
+    });
+  } catch (error) {
+    console.error("Failed to report error:", error);
+    return c.json({ error: "Failed to report error" }, 500);
+  }
+});
+
+/**
+ * GET /api/errors
+ * List errors with filters (requires auth)
+ */
+errors.get("/", async (c) => {
+  const user = await getUser(c);
+  if (!user) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const page = Number(c.req.query("page")) || 1;
+  const pageSize = Math.min(Number(c.req.query("pageSize")) || 20, 100);
+  const severity = c.req.query("severity") as ErrorSeverityType | undefined;
+  const type = c.req.query("type") as ErrorTypeType | undefined;
+  const module = c.req.query("module") as ErrorModuleType | undefined;
+  const startDateStr = c.req.query("startDate");
+  const endDateStr = c.req.query("endDate");
+
+  try {
+    const db = createDb(c.env.DB);
+    const result = await listErrors(db, {
+      page,
+      pageSize,
+      severity,
+      type,
+      module,
+      startDate: startDateStr ? new Date(Number(startDateStr)) : undefined,
+      endDate: endDateStr ? new Date(Number(endDateStr)) : undefined,
+    });
+    return c.json({ success: true, data: result });
+  } catch (error) {
+    console.error("Failed to list errors:", error);
+    return c.json({ error: "Failed to list errors" }, 500);
+  }
+});
+
+/**
+ * GET /api/errors/stats
+ * Get aggregate stats for dashboard
+ */
+errors.get("/stats", async (c) => {
+  const user = await getUser(c);
+  if (!user) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const rangeStr = c.req.query("range") || "7d";
+  const days = rangeStr === "24h" ? 1 : rangeStr === "7d" ? 7 : rangeStr === "30d" ? 30 : 7;
+  const startDate = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+  try {
+    const db = createDb(c.env.DB);
+    const stats = await getErrorStats(db, startDate);
+    return c.json({ success: true, data: stats });
+  } catch (error) {
+    console.error("Failed to get error stats:", error);
+    return c.json({ error: "Failed to get error stats" }, 500);
+  }
+});
+
+/**
+ * DELETE /api/errors/:id
+ * Delete a single error
+ */
+errors.delete("/:id", async (c) => {
+  const user = await getUser(c);
+  if (!user) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const id = c.req.param("id");
+
+  try {
+    const db = createDb(c.env.DB);
+    const success = await deleteError(db, id);
+    if (!success) {
+      return c.json({ error: "Error not found" }, 404);
+    }
+    return c.json({ success: true });
+  } catch (error) {
+    console.error("Failed to delete error:", error);
+    return c.json({ error: "Failed to delete error" }, 500);
+  }
+});
+
+/**
+ * POST /api/errors/batch-delete
+ * Bulk delete errors
+ */
+const batchDeleteSchema = z.object({
+  ids: z.array(z.string()).min(1),
+});
+
+errors.post("/batch-delete", zValidator("json", batchDeleteSchema), async (c) => {
+  const user = await getUser(c);
+  if (!user) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const { ids } = c.req.valid("json");
+
+  try {
+    const db = createDb(c.env.DB);
+    const deleted = await deleteErrors(db, ids);
+    return c.json({ success: true, data: { deleted } });
+  } catch (error) {
+    console.error("Failed to batch delete errors:", error);
+    return c.json({ error: "Failed to batch delete errors" }, 500);
+  }
+});
+
+export default errors;

--- a/api/src/services/errorService.ts
+++ b/api/src/services/errorService.ts
@@ -1,0 +1,248 @@
+/**
+ * Errors Service
+ *
+ * Handles error recording, aggregation, and retrieval
+ */
+
+import { createDb, schema } from "@oura-pix/database";
+import { eq, and, gte, desc, sql, count, inArray } from "drizzle-orm";
+import type { ErrorSeverityType, ErrorTypeType, ErrorModuleType } from "@oura-pix/database";
+
+export interface ReportErrorInput {
+  message: string;
+  stack?: string;
+  severity?: ErrorSeverityType;
+  type?: ErrorTypeType;
+  module?: ErrorModuleType;
+  context?: Record<string, unknown>;
+}
+
+export interface ErrorRecord {
+  id: string;
+  message: string;
+  stack: string | null;
+  severity: ErrorSeverityType;
+  type: ErrorTypeType;
+  module: ErrorModuleType;
+  context: string | null;
+  hash: string;
+  occurrences: number;
+  lastSeenAt: Date;
+  createdAt: Date;
+}
+
+export interface ErrorListParams {
+  page?: number;
+  pageSize?: number;
+  severity?: ErrorSeverityType;
+  type?: ErrorTypeType;
+  module?: ErrorModuleType;
+  startDate?: Date;
+  endDate?: Date;
+}
+
+export interface ErrorListResponse {
+  data: ErrorRecord[];
+  pagination: {
+    page: number;
+    pageSize: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
+/**
+ * Compute a stable hash for an error to enable deduplication.
+ * Uses first 200 chars of message + first 3 stack lines.
+ */
+export function computeErrorHash(message: string, stack?: string | null): string {
+  const normalizedMessage = (message || "").slice(0, 200);
+  const normalizedStack = (stack || "")
+    .split("\n")
+    .slice(0, 3)
+    .map((line) => line.trim())
+    .join("|");
+  return simpleHash(`${normalizedMessage}::${normalizedStack}`);
+}
+
+/**
+ * Simple djb2 string hash, base36 encoded.
+ * Not cryptographic; just stable for dedup keys.
+ */
+function simpleHash(input: string): string {
+  let hash = 5381;
+  for (let i = 0; i < input.length; i++) {
+    hash = ((hash << 5) + hash + input.charCodeAt(i)) | 0;
+  }
+  return (hash >>> 0).toString(36);
+}
+
+/**
+ * Report a new error or increment occurrences of an existing one.
+ * Returns the resulting record (new or updated).
+ */
+export async function reportError(
+  db: ReturnType<typeof createDb>,
+  input: ReportErrorInput
+): Promise<{ record: ErrorRecord; created: boolean }> {
+  const hash = computeErrorHash(input.message, input.stack);
+
+  // Try to find an existing error with the same hash (last 7 days)
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  const existing = await db
+    .select()
+    .from(schema.errors)
+    .where(and(eq(schema.errors.hash, hash), gte(schema.errors.lastSeenAt, sevenDaysAgo)))
+    .limit(1);
+
+  if (existing.length > 0) {
+    // Update occurrences and lastSeenAt
+    const [updated] = await db
+      .update(schema.errors)
+      .set({
+        occurrences: sql`${schema.errors.occurrences} + 1`,
+        lastSeenAt: new Date(),
+        // Update message in case the latest occurrence has more context
+        message: input.message.slice(0, 2000),
+        stack: input.stack?.slice(0, 4000) ?? existing[0].stack,
+        context: input.context ? JSON.stringify(input.context).slice(0, 8000) : existing[0].context,
+      })
+      .where(eq(schema.errors.id, existing[0].id))
+      .returning();
+    return { record: updated, created: false };
+  }
+
+  // Create a new record
+  const [created] = await db
+    .insert(schema.errors)
+    .values({
+      id: crypto.randomUUID(),
+      message: input.message.slice(0, 2000),
+      stack: input.stack?.slice(0, 4000) ?? null,
+      severity: input.severity ?? "medium",
+      type: input.type ?? "unknown",
+      module: input.module ?? "frontend",
+      context: input.context ? JSON.stringify(input.context).slice(0, 8000) : null,
+      hash,
+      occurrences: 1,
+      lastSeenAt: new Date(),
+      createdAt: new Date(),
+    })
+    .returning();
+  return { record: created, created: true };
+}
+
+/**
+ * List errors with filters and pagination
+ */
+export async function listErrors(
+  db: ReturnType<typeof createDb>,
+  params: ErrorListParams = {}
+): Promise<ErrorListResponse> {
+  const { page = 1, pageSize = 20, severity, type, module, startDate, endDate } = params;
+
+  const conditions = [];
+  if (severity) conditions.push(eq(schema.errors.severity, severity));
+  if (type) conditions.push(eq(schema.errors.type, type));
+  if (module) conditions.push(eq(schema.errors.module, module));
+  if (startDate) conditions.push(gte(schema.errors.createdAt, startDate));
+  if (endDate) conditions.push(sql`${schema.errors.createdAt} <= ${endDate.getTime()}`);
+
+  const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+  const totalResult = await db
+    .select({ value: count() })
+    .from(schema.errors)
+    .where(whereClause);
+
+  const total = totalResult[0]?.value ?? 0;
+  const totalPages = Math.ceil(total / pageSize);
+
+  const data = await db
+    .select()
+    .from(schema.errors)
+    .where(whereClause)
+    .orderBy(desc(schema.errors.lastSeenAt))
+    .limit(pageSize)
+    .offset((page - 1) * pageSize);
+
+  return {
+    data,
+    pagination: { page, pageSize, total, totalPages },
+  };
+}
+
+/**
+ * Get aggregate stats for the dashboard
+ */
+export async function getErrorStats(
+  db: ReturnType<typeof createDb>,
+  startDate?: Date
+): Promise<{
+  total: number;
+  bySeverity: Record<string, number>;
+  byType: Record<string, number>;
+  topErrors: ErrorRecord[];
+}> {
+  const whereClause = startDate ? gte(schema.errors.createdAt, startDate) : undefined;
+
+  const totalResult = await db
+    .select({ value: count() })
+    .from(schema.errors)
+    .where(whereClause);
+
+  const severityResult = await db
+    .select({ severity: schema.errors.severity, value: count() })
+    .from(schema.errors)
+    .where(whereClause)
+    .groupBy(schema.errors.severity);
+
+  const typeResult = await db
+    .select({ type: schema.errors.type, value: count() })
+    .from(schema.errors)
+    .where(whereClause)
+    .groupBy(schema.errors.type);
+
+  const topErrors = await db
+    .select()
+    .from(schema.errors)
+    .where(whereClause)
+    .orderBy(desc(schema.errors.occurrences))
+    .limit(10);
+
+  return {
+    total: totalResult[0]?.value ?? 0,
+    bySeverity: Object.fromEntries(severityResult.map((r) => [r.severity, r.value])),
+    byType: Object.fromEntries(typeResult.map((r) => [r.type, r.value])),
+    topErrors,
+  };
+}
+
+/**
+ * Delete a single error by id
+ */
+export async function deleteError(
+  db: ReturnType<typeof createDb>,
+  id: string
+): Promise<boolean> {
+  const result = await db
+    .delete(schema.errors)
+    .where(eq(schema.errors.id, id))
+    .returning();
+  return result.length > 0;
+}
+
+/**
+ * Bulk delete errors by ids
+ */
+export async function deleteErrors(
+  db: ReturnType<typeof createDb>,
+  ids: string[]
+): Promise<number> {
+  if (ids.length === 0) return 0;
+  const result = await db
+    .delete(schema.errors)
+    .where(inArray(schema.errors.id, ids))
+    .returning();
+  return result.length;
+}

--- a/drizzle/migrations/0008_add_errors_table.sql
+++ b/drizzle/migrations/0008_add_errors_table.sql
@@ -1,0 +1,24 @@
+-- Error severity: critical, high, medium, low
+-- Error type: network, validation, authentication, business_logic, runtime, unknown
+-- Error module: api, frontend, worker, database
+
+CREATE TABLE `errors` (
+	`id` text PRIMARY KEY NOT NULL,
+	`message` text NOT NULL,
+	`stack` text,
+	`severity` text NOT NULL DEFAULT 'medium',
+	`type` text NOT NULL DEFAULT 'unknown',
+	`module` text NOT NULL DEFAULT 'frontend',
+	`context` text,
+	`hash` text NOT NULL,
+	`occurrences` integer NOT NULL DEFAULT 1,
+	`lastSeenAt` integer NOT NULL,
+	`createdAt` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `errors_hash_idx` ON `errors` (`hash`);--> statement-breakpoint
+CREATE INDEX `errors_severity_idx` ON `errors` (`severity`);--> statement-breakpoint
+CREATE INDEX `errors_type_idx` ON `errors` (`type`);--> statement-breakpoint
+CREATE INDEX `errors_module_idx` ON `errors` (`module`);--> statement-breakpoint
+CREATE INDEX `errors_lastSeenAt_idx` ON `errors` (`lastSeenAt`);--> statement-breakpoint
+CREATE INDEX `errors_createdAt_idx` ON `errors` (`createdAt`);

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -24,6 +24,7 @@ export default function Navbar() {
     { href: "/history", label: m.history_title?.() || "生成历史" },
     { href: "/favorites", label: m.favorites_title?.() || "我的收藏" },
     { href: "/stats", label: m.stats_title?.() || "统计" },
+    { href: "/errors", label: "错误追踪" },
     { href: "/pricing", label: m.pricing() },
   ];
 

--- a/frontend/src/components/errors/ErrorsDashboard.tsx
+++ b/frontend/src/components/errors/ErrorsDashboard.tsx
@@ -1,0 +1,381 @@
+/**
+ * ErrorsDashboard Component
+ *
+ * Admin dashboard for browsing and filtering reported errors
+ */
+
+"use client";
+
+import { useState, useMemo } from "react";
+import { useErrorDashboard, type ErrorRecord } from "@/hooks/useErrorDashboard";
+
+type SeverityFilter = "" | "critical" | "high" | "medium" | "low";
+type TypeFilter = "" | "network" | "validation" | "authentication" | "business_logic" | "runtime" | "unknown";
+type ModuleFilter = "" | "api" | "frontend" | "worker" | "database";
+type RangeFilter = "24h" | "7d" | "30d";
+
+const SEVERITY_COLORS: Record<string, string> = {
+  critical: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300",
+  high: "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300",
+  medium: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-300",
+  low: "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300",
+};
+
+function formatTime(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleString("zh-CN", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function ErrorDetailPanel({
+  error,
+  onClose,
+}: {
+  error: ErrorRecord;
+  onClose: () => void;
+}) {
+  const contextObj = useMemo(() => {
+    if (!error.context) return null;
+    try {
+      return JSON.parse(error.context) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }, [error.context]);
+
+  return (
+    <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4" onClick={onClose}>
+      <div
+        className="bg-white dark:bg-slate-900 rounded-lg shadow-xl max-w-3xl w-full max-h-[80vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="p-6 border-b border-slate-200 dark:border-slate-700 flex items-start justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+              错误详情
+            </h2>
+            <p className="text-xs text-slate-500 mt-1 font-mono">{error.hash}</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200"
+            aria-label="Close"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="p-6 space-y-4">
+          <div>
+            <h3 className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">消息</h3>
+            <p className="text-sm text-slate-900 dark:text-slate-100 break-words">{error.message}</p>
+          </div>
+
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
+            <div>
+              <div className="text-xs text-slate-500">严重程度</div>
+              <span className={`inline-block mt-1 px-2 py-0.5 rounded text-xs font-medium ${SEVERITY_COLORS[error.severity]}`}>
+                {error.severity}
+              </span>
+            </div>
+            <div>
+              <div className="text-xs text-slate-500">类型</div>
+              <div className="mt-1 text-slate-900 dark:text-slate-100">{error.type}</div>
+            </div>
+            <div>
+              <div className="text-xs text-slate-500">模块</div>
+              <div className="mt-1 text-slate-900 dark:text-slate-100">{error.module}</div>
+            </div>
+            <div>
+              <div className="text-xs text-slate-500">出现次数</div>
+              <div className="mt-1 text-slate-900 dark:text-slate-100 font-mono">{error.occurrences}</div>
+            </div>
+          </div>
+
+          {error.stack && (
+            <div>
+              <h3 className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">堆栈</h3>
+              <pre className="text-xs bg-slate-50 dark:bg-slate-800 p-3 rounded overflow-x-auto whitespace-pre-wrap break-all">
+                {error.stack}
+              </pre>
+            </div>
+          )}
+
+          {contextObj && (
+            <div>
+              <h3 className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">上下文</h3>
+              <pre className="text-xs bg-slate-50 dark:bg-slate-800 p-3 rounded overflow-x-auto">
+                {JSON.stringify(contextObj, null, 2)}
+              </pre>
+            </div>
+          )}
+
+          <div className="grid grid-cols-2 gap-4 text-xs text-slate-500 pt-2 border-t border-slate-200 dark:border-slate-700">
+            <div>首次出现: {formatTime(error.createdAt)}</div>
+            <div>最近出现: {formatTime(error.lastSeenAt)}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function ErrorsDashboard() {
+  const [range, setRange] = useState<RangeFilter>("7d");
+  const [severity, setSeverity] = useState<SeverityFilter>("");
+  const [type, setType] = useState<TypeFilter>("");
+  const [module, setModule] = useState<ModuleFilter>("");
+  const [page, setPage] = useState(1);
+  const [selected, setSelected] = useState<ErrorRecord | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  const { list, stats, loading, error, refetch, deleteOne, deleteMany } = useErrorDashboard({
+    range,
+    severity: severity || undefined,
+    type: type || undefined,
+    module: module || undefined,
+    page,
+  });
+
+  const toggleSelect = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const toggleSelectAll = () => {
+    if (!list) return;
+    const allIds = list.data.map((e) => e.id);
+    if (selectedIds.size === allIds.length) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(allIds));
+    }
+  };
+
+  const handleBatchDelete = async () => {
+    if (selectedIds.size === 0) return;
+    if (!confirm(`确定删除 ${selectedIds.size} 条错误？`)) return;
+    await deleteMany(Array.from(selectedIds));
+    setSelectedIds(new Set());
+  };
+
+  return (
+    <div className="max-w-7xl mx-auto p-6">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">错误追踪</h1>
+          <p className="text-sm text-slate-500 mt-1">监控前端和后端错误</p>
+        </div>
+        <button
+          onClick={refetch}
+          className="px-3 py-1.5 text-sm bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 rounded"
+        >
+          刷新
+        </button>
+      </div>
+
+      {/* Stats */}
+      {stats && (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6">
+          <div className="bg-white dark:bg-slate-900 p-4 rounded-lg border border-slate-200 dark:border-slate-700">
+            <div className="text-xs text-slate-500">总错误数</div>
+            <div className="text-2xl font-semibold mt-1 text-slate-900 dark:text-slate-100">{stats.total}</div>
+          </div>
+          {(["critical", "high", "medium", "low"] as const).map((sev) => (
+            <div key={sev} className="bg-white dark:bg-slate-900 p-4 rounded-lg border border-slate-200 dark:border-slate-700">
+              <div className="text-xs text-slate-500">{sev}</div>
+              <div className="text-2xl font-semibold mt-1 text-slate-900 dark:text-slate-100">
+                {stats.bySeverity[sev] ?? 0}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Filters */}
+      <div className="bg-white dark:bg-slate-900 p-4 rounded-lg border border-slate-200 dark:border-slate-700 mb-4 flex flex-wrap gap-3">
+        <select
+          value={range}
+          onChange={(e) => {
+            setRange(e.target.value as RangeFilter);
+            setPage(1);
+          }}
+          className="px-3 py-1.5 text-sm border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+        >
+          <option value="24h">最近 24 小时</option>
+          <option value="7d">最近 7 天</option>
+          <option value="30d">最近 30 天</option>
+        </select>
+        <select
+          value={severity}
+          onChange={(e) => {
+            setSeverity(e.target.value as SeverityFilter);
+            setPage(1);
+          }}
+          className="px-3 py-1.5 text-sm border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+        >
+          <option value="">所有严重程度</option>
+          <option value="critical">critical</option>
+          <option value="high">high</option>
+          <option value="medium">medium</option>
+          <option value="low">low</option>
+        </select>
+        <select
+          value={type}
+          onChange={(e) => {
+            setType(e.target.value as TypeFilter);
+            setPage(1);
+          }}
+          className="px-3 py-1.5 text-sm border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+        >
+          <option value="">所有类型</option>
+          <option value="network">network</option>
+          <option value="validation">validation</option>
+          <option value="authentication">authentication</option>
+          <option value="business_logic">business_logic</option>
+          <option value="runtime">runtime</option>
+          <option value="unknown">unknown</option>
+        </select>
+        <select
+          value={module}
+          onChange={(e) => {
+            setModule(e.target.value as ModuleFilter);
+            setPage(1);
+          }}
+          className="px-3 py-1.5 text-sm border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+        >
+          <option value="">所有模块</option>
+          <option value="api">api</option>
+          <option value="frontend">frontend</option>
+          <option value="worker">worker</option>
+          <option value="database">database</option>
+        </select>
+        {selectedIds.size > 0 && (
+          <button
+            onClick={handleBatchDelete}
+            className="ml-auto px-3 py-1.5 text-sm bg-red-600 text-white rounded hover:bg-red-700"
+          >
+            删除选中 ({selectedIds.size})
+          </button>
+        )}
+      </div>
+
+      {/* Error List */}
+      {error && (
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-4 rounded-lg mb-4">
+          <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
+        </div>
+      )}
+
+      {loading && !list ? (
+        <div className="text-center py-12 text-slate-500">加载中...</div>
+      ) : list && list.data.length === 0 ? (
+        <div className="text-center py-12 text-slate-500">暂无错误 🎉</div>
+      ) : (
+        list && (
+          <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-slate-50 dark:bg-slate-800 text-xs uppercase text-slate-500">
+                <tr>
+                  <th className="px-4 py-3 text-left w-10">
+                    <input
+                      type="checkbox"
+                      checked={selectedIds.size === list.data.length && list.data.length > 0}
+                      onChange={toggleSelectAll}
+                    />
+                  </th>
+                  <th className="px-4 py-3 text-left">严重程度</th>
+                  <th className="px-4 py-3 text-left">类型</th>
+                  <th className="px-4 py-3 text-left">模块</th>
+                  <th className="px-4 py-3 text-left">消息</th>
+                  <th className="px-4 py-3 text-right">次数</th>
+                  <th className="px-4 py-3 text-left">最近</th>
+                  <th className="px-4 py-3 text-right w-20">操作</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-200 dark:divide-slate-700">
+                {list.data.map((err) => (
+                  <tr
+                    key={err.id}
+                    className="hover:bg-slate-50 dark:hover:bg-slate-800/50 cursor-pointer"
+                    onClick={() => setSelected(err)}
+                  >
+                    <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
+                      <input
+                        type="checkbox"
+                        checked={selectedIds.has(err.id)}
+                        onChange={() => toggleSelect(err.id)}
+                      />
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className={`px-2 py-0.5 rounded text-xs font-medium ${SEVERITY_COLORS[err.severity]}`}>
+                        {err.severity}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-slate-600 dark:text-slate-400">{err.type}</td>
+                    <td className="px-4 py-3 text-slate-600 dark:text-slate-400">{err.module}</td>
+                    <td className="px-4 py-3 max-w-md truncate text-slate-900 dark:text-slate-100">
+                      {err.message}
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono">{err.occurrences}</td>
+                    <td className="px-4 py-3 text-slate-500 text-xs">{formatTime(err.lastSeenAt)}</td>
+                    <td className="px-4 py-3 text-right" onClick={(e) => e.stopPropagation()}>
+                      <button
+                        onClick={async () => {
+                          if (confirm("确定删除？")) await deleteOne(err.id);
+                        }}
+                        className="text-slate-400 hover:text-red-500"
+                        aria-label="Delete"
+                      >
+                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3" />
+                        </svg>
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+
+            {/* Pagination */}
+            {list.pagination.totalPages > 1 && (
+              <div className="px-4 py-3 border-t border-slate-200 dark:border-slate-700 flex items-center justify-between text-sm">
+                <div className="text-slate-500">
+                  第 {list.pagination.page} / {list.pagination.totalPages} 页 · 共 {list.pagination.total} 条
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => setPage((p) => Math.max(1, p - 1))}
+                    disabled={page === 1}
+                    className="px-3 py-1 border border-slate-200 dark:border-slate-700 rounded disabled:opacity-50"
+                  >
+                    上一页
+                  </button>
+                  <button
+                    onClick={() => setPage((p) => Math.min(list.pagination.totalPages, p + 1))}
+                    disabled={page === list.pagination.totalPages}
+                    className="px-3 py-1 border border-slate-200 dark:border-slate-700 rounded disabled:opacity-50"
+                  >
+                    下一页
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        )
+      )}
+
+      {selected && <ErrorDetailPanel error={selected} onClose={() => setSelected(null)} />}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useErrorDashboard.ts
+++ b/frontend/src/hooks/useErrorDashboard.ts
@@ -1,0 +1,122 @@
+/**
+ * useErrorDashboard Hook
+ *
+ * Fetches error list and stats for the /errors dashboard page.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+
+export interface ErrorRecord {
+  id: string;
+  message: string;
+  stack: string | null;
+  severity: "critical" | "high" | "medium" | "low";
+  type: "network" | "validation" | "authentication" | "business_logic" | "runtime" | "unknown";
+  module: "api" | "frontend" | "worker" | "database";
+  context: string | null;
+  hash: string;
+  occurrences: number;
+  lastSeenAt: string;
+  createdAt: string;
+}
+
+export interface ErrorStats {
+  total: number;
+  bySeverity: Record<string, number>;
+  byType: Record<string, number>;
+  topErrors: ErrorRecord[];
+}
+
+export interface ErrorListResponse {
+  data: ErrorRecord[];
+  pagination: {
+    page: number;
+    pageSize: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
+interface UseErrorDashboardParams {
+  range?: "24h" | "7d" | "30d";
+  severity?: string;
+  type?: string;
+  module?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export function useErrorDashboard(params: UseErrorDashboardParams = {}) {
+  const { range = "7d", severity, type, module, page = 1, pageSize = 20 } = params;
+
+  const [list, setList] = useState<ErrorListResponse | null>(null);
+  const [stats, setStats] = useState<ErrorStats | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAll = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const query = new URLSearchParams({
+        range,
+        page: String(page),
+        pageSize: String(pageSize),
+        ...(severity ? { severity } : {}),
+        ...(type ? { type } : {}),
+        ...(module ? { module } : {}),
+      });
+
+      const [listRes, statsRes] = await Promise.all([
+        fetch(`/api/errors?${query.toString()}`, { credentials: "include" }),
+        fetch(`/api/errors/stats?range=${range}`, { credentials: "include" }),
+      ]);
+
+      if (!listRes.ok || !statsRes.ok) {
+        throw new Error("Failed to fetch error data");
+      }
+
+      const [listJson, statsJson] = await Promise.all([listRes.json(), statsRes.json()]);
+
+      if (listJson.success) setList(listJson.data);
+      if (statsJson.success) setStats(statsJson.data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load errors");
+    } finally {
+      setLoading(false);
+    }
+  }, [range, severity, type, module, page, pageSize]);
+
+  useEffect(() => {
+    fetchAll();
+  }, [fetchAll]);
+
+  const deleteOne = useCallback(
+    async (id: string) => {
+      const res = await fetch(`/api/errors/${id}`, {
+        method: "DELETE",
+        credentials: "include",
+      });
+      if (!res.ok) throw new Error("Failed to delete error");
+      await fetchAll();
+    },
+    [fetchAll]
+  );
+
+  const deleteMany = useCallback(
+    async (ids: string[]) => {
+      const res = await fetch("/api/errors/batch-delete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ ids }),
+      });
+      if (!res.ok) throw new Error("Failed to batch delete");
+      await fetchAll();
+    },
+    [fetchAll]
+  );
+
+  return { list, stats, loading, error, refetch: fetchAll, deleteOne, deleteMany };
+}

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -27,6 +27,14 @@ const {
   </head>
   <body class="font-sans antialiased min-h-screen bg-white text-slate-900">
     <slot />
+    <script>
+      // Install the global error reporter as early as possible on every page.
+      import("/src/lib/errorReporter.ts")
+        .then((m) => m.installErrorReporter())
+        .catch(() => {
+          /* never let the reporter itself block the app */
+        });
+    </script>
   </body>
 </html>
 

--- a/frontend/src/lib/errorReporter.ts
+++ b/frontend/src/lib/errorReporter.ts
@@ -1,0 +1,106 @@
+/**
+ * Error Reporter
+ *
+ * Captures unhandled errors and promise rejections, then reports them
+ * to the backend. Idempotent installation: only one global handler at a time.
+ */
+
+type ErrorContext = Record<string, unknown>;
+
+interface ReportErrorPayload {
+  message: string;
+  stack?: string;
+  severity?: "critical" | "high" | "medium" | "low";
+  type?: "network" | "validation" | "authentication" | "business_logic" | "runtime" | "unknown";
+  module?: "api" | "frontend" | "worker" | "database";
+  context?: ErrorContext;
+}
+
+let installed = false;
+let lastReportAt = 0;
+const REPORT_THROTTLE_MS = 2000;
+
+function inferSeverity(message: string): ReportErrorPayload["severity"] {
+  const lower = message.toLowerCase();
+  if (lower.includes("script error") || lower.includes("chunk")) return "high";
+  if (lower.includes("network") || lower.includes("fetch")) return "medium";
+  return "medium";
+}
+
+function inferType(message: string, stack?: string): ReportErrorPayload["type"] {
+  const m = (message + " " + (stack ?? "")).toLowerCase();
+  if (m.includes("network") || m.includes("fetch")) return "network";
+  if (m.includes("unauthorized") || m.includes("auth")) return "authentication";
+  if (m.includes("validation") || m.includes("invalid")) return "validation";
+  if (m.includes("typeerror") || m.includes("referenceerror")) return "runtime";
+  return "unknown";
+}
+
+async function send(payload: ReportErrorPayload): Promise<void> {
+  // Throttle: skip if we just reported within the throttle window
+  const now = Date.now();
+  if (now - lastReportAt < REPORT_THROTTLE_MS) return;
+  lastReportAt = now;
+
+  try {
+    await fetch("/api/errors", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(payload),
+      // Use keepalive so the request survives a page unload triggered by the error
+      keepalive: true,
+    });
+  } catch {
+    // Silently swallow reporting errors — we never want the reporter itself to throw
+  }
+}
+
+function toErrorPayload(error: unknown, context: ErrorContext = {}): ReportErrorPayload {
+  if (error instanceof Error) {
+    return {
+      message: error.message || error.name || "Unknown error",
+      stack: error.stack,
+      severity: inferSeverity(error.message),
+      type: inferType(error.message, error.stack),
+      module: "frontend",
+      context: {
+        ...context,
+        url: typeof window !== "undefined" ? window.location.href : undefined,
+        userAgent: typeof navigator !== "undefined" ? navigator.userAgent : undefined,
+      },
+    };
+  }
+  return {
+    message: typeof error === "string" ? error : "Unknown error",
+    severity: "medium",
+    type: "unknown",
+    module: "frontend",
+    context,
+  };
+}
+
+/**
+ * Install global error handlers. Idempotent — safe to call multiple times.
+ */
+export function installErrorReporter(): void {
+  if (installed || typeof window === "undefined") return;
+  installed = true;
+
+  window.addEventListener("error", (event) => {
+    const error = event.error ?? event;
+    send(toErrorPayload(error));
+  });
+
+  window.addEventListener("unhandledrejection", (event) => {
+    send(toErrorPayload(event.reason));
+  });
+}
+
+/**
+ * Manually report an error. Useful inside try/catch where you want to
+ * surface a caught error to the dashboard.
+ */
+export async function reportError(error: unknown, context?: ErrorContext): Promise<void> {
+  await send(toErrorPayload(error, context));
+}

--- a/frontend/src/pages/errors.astro
+++ b/frontend/src/pages/errors.astro
@@ -1,0 +1,8 @@
+---
+import Layout from '../layouts/Layout.astro';
+import ErrorsDashboard from '../components/errors/ErrorsDashboard';
+---
+
+<Layout title="错误追踪">
+  <ErrorsDashboard client:load />
+</Layout>

--- a/packages/types/src/schema.ts
+++ b/packages/types/src/schema.ts
@@ -440,3 +440,95 @@ export const notifications = sqliteTable("notifications", {
   createdAtIdx: index("notifications_createdAt_idx").on(table.createdAt),
 }));
 
+/**
+ * 错误严重程度枚举
+ */
+export const ErrorSeverity = {
+  CRITICAL: "critical",
+  HIGH: "high",
+  MEDIUM: "medium",
+  LOW: "low",
+} as const;
+
+export type ErrorSeverityType = typeof ErrorSeverity[keyof typeof ErrorSeverity];
+
+/**
+ * 错误类型枚举
+ */
+export const ErrorType = {
+  NETWORK: "network",
+  VALIDATION: "validation",
+  AUTHENTICATION: "authentication",
+  BUSINESS_LOGIC: "business_logic",
+  RUNTIME: "runtime",
+  UNKNOWN: "unknown",
+} as const;
+
+export type ErrorTypeType = typeof ErrorType[keyof typeof ErrorType];
+
+/**
+ * 错误模块枚举
+ */
+export const ErrorModule = {
+  API: "api",
+  FRONTEND: "frontend",
+  WORKER: "worker",
+  DATABASE: "database",
+} as const;
+
+export type ErrorModuleType = typeof ErrorModule[keyof typeof ErrorModule];
+
+/**
+ * 错误追踪表
+ *
+ * 记录前端和后端错误，用于问题定位和稳定性监控
+ */
+export const errors = sqliteTable("errors", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  // 错误消息
+  message: text("message").notNull(),
+  // 堆栈信息
+  stack: text("stack"),
+  // 严重程度
+  severity: text("severity", {
+    enum: ["critical", "high", "medium", "low"],
+  })
+    .notNull()
+    .default("medium"),
+  // 错误类型
+  type: text("type", {
+    enum: ["network", "validation", "authentication", "business_logic", "runtime", "unknown"],
+  })
+    .notNull()
+    .default("unknown"),
+  // 来源模块
+  module: text("module", {
+    enum: ["api", "frontend", "worker", "database"],
+  })
+    .notNull()
+    .default("frontend"),
+  // 上下文信息（URL、用户代理、用户 ID、操作历史等 JSON 字符串）
+  context: text("context"),
+  // 用于去重的错误指纹（message + stack[:3] 的 hash）
+  hash: text("hash").notNull(),
+  // 出现次数
+  occurrences: integer("occurrences").notNull().default(1),
+  // 最后一次出现时间
+  lastSeenAt: integer("lastSeenAt", { mode: "timestamp_ms" })
+    .notNull()
+    .default(sql`(strftime('%s', 'now') * 1000)`),
+  // 首次出现时间
+  createdAt: integer("createdAt", { mode: "timestamp_ms" })
+    .notNull()
+    .default(sql`(strftime('%s', 'now') * 1000)`),
+}, (table) => ({
+  hashIdx: index("errors_hash_idx").on(table.hash),
+  severityIdx: index("errors_severity_idx").on(table.severity),
+  typeIdx: index("errors_type_idx").on(table.type),
+  moduleIdx: index("errors_module_idx").on(table.module),
+  lastSeenAtIdx: index("errors_lastSeenAt_idx").on(table.lastSeenAt),
+  createdAtIdx: index("errors_createdAt_idx").on(table.createdAt),
+}));
+


### PR DESCRIPTION
## Feature #30: 错误追踪与异常处理 - P0

实现前端错误捕获、上报、聚合 + 后台仪表板。

## Database
- 新增 `errors` 表（id, message, stack, severity, type, module, context, hash, occurrences, lastSeenAt, createdAt）
- 6 个索引：hash / severity / type / module / lastSeenAt / createdAt
- 4 个枚举：severity (critical/high/medium/low), type (network/validation/auth/business_logic/runtime/unknown), module (api/frontend/worker/database)
- Migration: `drizzle/migrations/0008_add_errors_table.sql`

## 去重策略
- `computeErrorHash` 基于 message 前 200 字符 + stack 前 3 行，djb2 base36 hash
- 7 天内同 hash 自动累计 occurrences 并更新 lastSeenAt
- 超过 7 天的相同错误当作新错误

## API
- `POST /api/errors` (public) — 错误上报，限流 2s
- `GET /api/errors` (auth) — 分页 + 筛选（severity/type/module/时间范围）
- `GET /api/errors/stats?range=24h|7d|30d` (auth) — 聚合统计（总数、按严重程度、按类型、Top 10）
- `DELETE /api/errors/:id` (auth) — 单条删除
- `POST /api/errors/batch-delete` (auth) — 批量删除

## Frontend
- `errorReporter` — 全局错误捕获：window.onerror + unhandledrejection，自动推断 severity/type/module
- Layout.astro 自动注入到每个页面
- `/errors` 页面 — 统计卡片 + 多维筛选 + 批量选择 + 分页
- 详情弹窗：消息、堆栈、上下文 JSON
- 集成到 Navbar

## 验证
- ✅ typecheck (api + frontend) 通过
- ✅ lint (api + frontend) 通过
- ✅ frontend build 通过
- ✅ pnpm typegen (api) 通过

## 备注
- P1+ 留到后续：错误聚合、Slack 告警、ErrorBoundary、Issue/PR 关联
- Hash 算法简单 djb2，不抗碰撞但足够 dedup