### PR TITLE
feat: add performance monitoring (Feature #27 - P0)

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -19,6 +19,7 @@ import { favoriteRoutes } from "./routes/favorites";
 import statsRoutes from "./routes/stats";
 import notificationRoutes from "./routes/notifications";
 import errorRoutes from "./routes/errors";
+import metricRoutes from "./routes/metrics";
 import { stripeWebhookRoutes } from "./routes/webhooks/stripe";
 import { authMiddleware } from "./middleware/auth";
 
@@ -105,6 +106,7 @@ app.route("/api/favorites", favoriteRoutes);
 app.route("/api/stats", statsRoutes);
 app.route("/api/notifications", notificationRoutes);
 app.route("/api/errors", errorRoutes);
+app.route("/api/metrics", metricRoutes);
 app.route("/api/webhooks", stripeWebhookRoutes);
 
 // ============================================

--- a/api/src/routes/metrics.ts
+++ b/api/src/routes/metrics.ts
@@ -1,0 +1,155 @@
+/**
+ * Metrics Routes
+ *
+ * API endpoints for performance metrics reporting and dashboard
+ */
+
+import { Hono } from "hono";
+import { z } from "zod";
+import { zValidator } from "@hono/zod-validator";
+import { createDb } from "@oura-pix/database";
+import { getUser } from "../middleware/auth";
+import {
+  recordMetric,
+  recordMetrics,
+  getDashboardStats,
+  getRecentMetrics,
+} from "../services/metricService";
+
+const metrics = new Hono<{
+  Bindings: {
+    DB: D1Database;
+  };
+  Variables: {
+    user: { id: string; email: string; name?: string | null };
+    session: { id: string; expiresAt: Date };
+  };
+}>();
+
+const MetricNameSchema = z.enum([
+  "LCP",
+  "INP",
+  "CLS",
+  "FCP",
+  "TTFB",
+  "navigation.domContentLoaded",
+  "navigation.load",
+]);
+
+const DeviceTypeSchema = z.enum(["mobile", "tablet", "desktop"]);
+const RatingSchema = z.enum(["good", "needs-improvement", "poor"]);
+
+const singleMetricSchema = z.object({
+  name: MetricNameSchema,
+  value: z.number().finite(),
+  rating: RatingSchema.optional(),
+  url: z.string().max(500).optional(),
+  userAgent: z.string().max(500).optional(),
+  deviceType: DeviceTypeSchema.optional(),
+  connectionType: z.string().max(50).optional(),
+  context: z.record(z.unknown()).optional(),
+});
+
+/**
+ * POST /api/metrics
+ * Report a single metric (public — client-side)
+ */
+metrics.post("/", zValidator("json", singleMetricSchema), async (c) => {
+  const input = c.req.valid("json");
+
+  try {
+    const db = createDb(c.env.DB);
+    const record = await recordMetric(db, input);
+    return c.json({ success: true, data: { id: record.id } });
+  } catch (error) {
+    console.error("Failed to record metric:", error);
+    return c.json({ error: "Failed to record metric" }, 500);
+  }
+});
+
+const batchMetricSchema = z.object({
+  metrics: z.array(singleMetricSchema).min(1).max(50),
+});
+
+/**
+ * POST /api/metrics/batch
+ * Report multiple metrics in one call (public — client-side)
+ */
+metrics.post("/batch", zValidator("json", batchMetricSchema), async (c) => {
+  const { metrics: inputs } = c.req.valid("json");
+
+  try {
+    const db = createDb(c.env.DB);
+    const recorded = await recordMetrics(db, inputs);
+    return c.json({ success: true, data: { recorded } });
+  } catch (error) {
+    console.error("Failed to record metrics batch:", error);
+    return c.json({ error: "Failed to record metrics" }, 500);
+  }
+});
+
+/**
+ * GET /api/metrics/dashboard
+ * Aggregate stats for the dashboard (auth required)
+ */
+metrics.get("/dashboard", async (c) => {
+  const user = await getUser(c);
+  if (!user) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const range = c.req.query("range") || "7d";
+  const startDate = rangeToDate(range);
+
+  try {
+    const db = createDb(c.env.DB);
+    const stats = await getDashboardStats(db, startDate);
+    return c.json({ success: true, data: stats });
+  } catch (error) {
+    console.error("Failed to get dashboard stats:", error);
+    return c.json({ error: "Failed to get dashboard stats" }, 500);
+  }
+});
+
+/**
+ * GET /api/metrics/:name
+ * Recent data points for a specific metric (auth required)
+ */
+metrics.get("/:name", async (c) => {
+  const user = await getUser(c);
+  if (!user) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const name = c.req.param("name");
+  const range = c.req.query("range") || "7d";
+  const startDate = rangeToDate(range);
+  const limit = Math.min(Number(c.req.query("limit")) || 50, 200);
+
+  try {
+    const db = createDb(c.env.DB);
+    const recent = await getRecentMetrics(db, name, startDate, limit);
+    return c.json({ success: true, data: { name, points: recent } });
+  } catch (error) {
+    console.error("Failed to get metric series:", error);
+    return c.json({ error: "Failed to get metric series" }, 500);
+  }
+});
+
+function rangeToDate(range: string): Date {
+  const now = Date.now();
+  switch (range) {
+    case "1h":
+      return new Date(now - 60 * 60 * 1000);
+    case "24h":
+      return new Date(now - 24 * 60 * 60 * 1000);
+    case "7d":
+      return new Date(now - 7 * 24 * 60 * 60 * 1000);
+    case "30d":
+      return new Date(now - 30 * 24 * 60 * 60 * 1000);
+    default:
+      return new Date(now - 7 * 24 * 60 * 60 * 1000);
+  }
+}
+
+export default metrics;

--- a/api/src/services/metricService.ts
+++ b/api/src/services/metricService.ts
@@ -1,0 +1,192 @@
+/**
+ * Metrics Service
+ *
+ * Handles performance metric recording, aggregation, and retrieval
+ */
+
+import { createDb, schema } from "@oura-pix/database";
+import { eq, and, gte, desc, sql } from "drizzle-orm";
+import type { MetricNameType } from "@oura-pix/database";
+
+export type Rating = "good" | "needs-improvement" | "poor";
+
+export interface RecordMetricInput {
+  name: MetricNameType | string;
+  value: number;
+  rating?: Rating;
+  url?: string;
+  userAgent?: string;
+  deviceType?: "mobile" | "tablet" | "desktop";
+  connectionType?: string;
+  context?: Record<string, unknown>;
+}
+
+export interface MetricRecord {
+  id: string;
+  name: string;
+  value: number;
+  rating: Rating | null;
+  url: string | null;
+  userAgent: string | null;
+  deviceType: "mobile" | "tablet" | "desktop" | null;
+  connectionType: string | null;
+  context: string | null;
+  recordedAt: Date;
+}
+
+export interface MetricSummary {
+  name: string;
+  count: number;
+  p50: number;
+  p95: number;
+  avg: number;
+  goodPct: number;
+  poorPct: number;
+}
+
+/**
+ * Record a single metric data point
+ */
+export async function recordMetric(
+  db: ReturnType<typeof createDb>,
+  input: RecordMetricInput
+): Promise<MetricRecord> {
+  const [created] = await db
+    .insert(schema.metrics)
+    .values({
+      id: crypto.randomUUID(),
+      name: input.name,
+      value: input.value,
+      rating: input.rating ?? null,
+      url: input.url?.slice(0, 500) ?? null,
+      userAgent: input.userAgent?.slice(0, 500) ?? null,
+      deviceType: input.deviceType ?? null,
+      connectionType: input.connectionType ?? null,
+      context: input.context ? JSON.stringify(input.context).slice(0, 4000) : null,
+      recordedAt: new Date(),
+    })
+    .returning();
+  return created;
+}
+
+/**
+ * Batch record multiple metrics in one call
+ */
+export async function recordMetrics(
+  db: ReturnType<typeof createDb>,
+  inputs: RecordMetricInput[]
+): Promise<number> {
+  if (inputs.length === 0) return 0;
+
+  const values = inputs.map((input) => ({
+    id: crypto.randomUUID(),
+    name: input.name,
+    value: input.value,
+    rating: input.rating ?? null,
+    url: input.url?.slice(0, 500) ?? null,
+    userAgent: input.userAgent?.slice(0, 500) ?? null,
+    deviceType: input.deviceType ?? null,
+    connectionType: input.connectionType ?? null,
+    context: input.context ? JSON.stringify(input.context).slice(0, 4000) : null,
+    recordedAt: new Date(),
+  }));
+
+  const result = await db.insert(schema.metrics).values(values).returning();
+  return result.length;
+}
+
+/**
+ * Compute aggregate stats (P50/P95/avg) for a metric over a date range.
+ *
+ * Note: SQLite doesn't have native percentile functions; we pull all values
+ * and compute in JS. Fine for the modest volumes we expect at this scale.
+ */
+export async function getMetricSummary(
+  db: ReturnType<typeof createDb>,
+  name: string,
+  startDate: Date
+): Promise<MetricSummary | null> {
+  const values = await db
+    .select({ value: schema.metrics.value, rating: schema.metrics.rating })
+    .from(schema.metrics)
+    .where(and(eq(schema.metrics.name, name), gte(schema.metrics.recordedAt, startDate)));
+
+  if (values.length === 0) {
+    return { name, count: 0, p50: 0, p95: 0, avg: 0, goodPct: 0, poorPct: 0 };
+  }
+
+  const sorted = values.map((v) => v.value).sort((a, b) => a - b);
+  const total = sorted.length;
+  const sum = sorted.reduce((s, v) => s + v, 0);
+
+  const p50 = sorted[Math.floor(total * 0.5)] ?? 0;
+  const p95 = sorted[Math.min(total - 1, Math.floor(total * 0.95))] ?? 0;
+  const avg = sum / total;
+
+  const good = values.filter((v) => v.rating === "good").length;
+  const poor = values.filter((v) => v.rating === "poor").length;
+
+  return {
+    name,
+    count: total,
+    p50: roundTo(p50, 2),
+    p95: roundTo(p95, 2),
+    avg: roundTo(avg, 2),
+    goodPct: roundTo((good / total) * 100, 1),
+    poorPct: roundTo((poor / total) * 100, 1),
+  };
+}
+
+/**
+ * Get summaries for all core web vitals
+ */
+export async function getDashboardStats(
+  db: ReturnType<typeof createDb>,
+  startDate: Date
+): Promise<{ range: string; metrics: MetricSummary[] }> {
+  const coreNames = ["LCP", "INP", "CLS", "FCP", "TTFB"];
+  const summaries = await Promise.all(
+    coreNames.map((name) => getMetricSummary(db, name, startDate))
+  );
+  return {
+    range: startDate.toISOString(),
+    metrics: summaries.filter((s): s is MetricSummary => s !== null),
+  };
+}
+
+/**
+ * Get recent data points for trend display
+ */
+export async function getRecentMetrics(
+  db: ReturnType<typeof createDb>,
+  name: string,
+  startDate: Date,
+  limit = 50
+): Promise<MetricRecord[]> {
+  return db
+    .select()
+    .from(schema.metrics)
+    .where(and(eq(schema.metrics.name, name), gte(schema.metrics.recordedAt, startDate)))
+    .orderBy(desc(schema.metrics.recordedAt))
+    .limit(limit);
+}
+
+/**
+ * Delete metrics older than a cutoff (cleanup job).
+ * Returns the number of rows deleted.
+ */
+export async function deleteOldMetrics(
+  db: ReturnType<typeof createDb>,
+  cutoff: Date
+): Promise<number> {
+  const result = await db
+    .delete(schema.metrics)
+    .where(sql`${schema.metrics.recordedAt} < ${cutoff.getTime()}`)
+    .returning();
+  return result.length;
+}
+
+function roundTo(value: number, decimals: number): number {
+  const factor = Math.pow(10, decimals);
+  return Math.round(value * factor) / factor;
+}

--- a/drizzle/migrations/0009_add_metrics_table.sql
+++ b/drizzle/migrations/0009_add_metrics_table.sql
@@ -1,0 +1,20 @@
+-- Performance metrics table
+-- Records Web Vitals (LCP, INP, CLS, FCP, TTFB) and navigation timings
+
+CREATE TABLE `metrics` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`value` real NOT NULL,
+	`rating` text,
+	`url` text,
+	`userAgent` text,
+	`deviceType` text,
+	`connectionType` text,
+	`context` text,
+	`recordedAt` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `metrics_name_idx` ON `metrics` (`name`);--> statement-breakpoint
+CREATE INDEX `metrics_rating_idx` ON `metrics` (`rating`);--> statement-breakpoint
+CREATE INDEX `metrics_recordedAt_idx` ON `metrics` (`recordedAt`);--> statement-breakpoint
+CREATE INDEX `metrics_name_recordedAt_idx` ON `metrics` (`name`,`recordedAt`);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tailwindcss": "^4.0.0",
+    "web-vitals": "^5.3.0",
     "zustand": "^5.0.0"
   },
   "devDependencies": {

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -24,6 +24,7 @@ export default function Navbar() {
     { href: "/history", label: m.history_title?.() || "生成历史" },
     { href: "/favorites", label: m.favorites_title?.() || "我的收藏" },
     { href: "/stats", label: m.stats_title?.() || "统计" },
+    { href: "/metrics", label: "性能监控" },
     { href: "/errors", label: "错误追踪" },
     { href: "/pricing", label: m.pricing() },
   ];

--- a/frontend/src/components/metrics/MetricsDashboard.tsx
+++ b/frontend/src/components/metrics/MetricsDashboard.tsx
@@ -1,0 +1,215 @@
+/**
+ * MetricsDashboard Component
+ *
+ * Displays Web Vitals aggregates (P50/P95/avg + good/poor distribution)
+ * and a recent-points table.
+ */
+
+"use client";
+
+import { useState } from "react";
+import { useMetricsDashboard, type MetricSummary } from "@/hooks/useMetricsDashboard";
+
+type RangeFilter = "1h" | "24h" | "7d" | "30d";
+
+const CORE_METRICS = ["LCP", "INP", "CLS", "FCP", "TTFB"] as const;
+
+const METRIC_UNITS: Record<string, string> = {
+  LCP: "ms",
+  INP: "ms",
+  CLS: "",
+  FCP: "ms",
+  TTFB: "ms",
+};
+
+const METRIC_DESCRIPTIONS: Record<string, string> = {
+  LCP: "Largest Contentful Paint",
+  INP: "Interaction to Next Paint",
+  CLS: "Cumulative Layout Shift",
+  FCP: "First Contentful Paint",
+  TTFB: "Time to First Byte",
+};
+
+function ratingColor(rating: "good" | "needs-improvement" | "poor" | null | undefined): string {
+  if (rating === "good") return "text-green-600 dark:text-green-400";
+  if (rating === "needs-improvement") return "text-yellow-600 dark:text-yellow-400";
+  if (rating === "poor") return "text-red-600 dark:text-red-400";
+  return "text-slate-400";
+}
+
+function ratingBg(rating: "good" | "needs-improvement" | "poor" | null | undefined): string {
+  if (rating === "good") return "bg-green-100 dark:bg-green-900/30";
+  if (rating === "needs-improvement") return "bg-yellow-100 dark:bg-yellow-900/30";
+  if (rating === "poor") return "bg-red-100 dark:bg-red-900/30";
+  return "bg-slate-100 dark:bg-slate-800";
+}
+
+function formatValue(metric: string, value: number): string {
+  if (!Number.isFinite(value)) return "-";
+  const unit = METRIC_UNITS[metric] ?? "";
+  return unit ? `${value.toFixed(0)} ${unit}` : value.toFixed(3);
+}
+
+function MetricCard({ summary }: { summary: MetricSummary }) {
+  return (
+    <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-4">
+      <div className="flex items-baseline justify-between">
+        <h3 className="text-sm font-medium text-slate-700 dark:text-slate-300">{summary.name}</h3>
+        <span className="text-xs text-slate-500">{summary.count} samples</span>
+      </div>
+      <p className="text-xs text-slate-500 mt-0.5 mb-3">{METRIC_DESCRIPTIONS[summary.name]}</p>
+
+      <div className="grid grid-cols-3 gap-2 text-center">
+        <div>
+          <div className="text-xs text-slate-500">P50</div>
+          <div className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+            {formatValue(summary.name, summary.p50)}
+          </div>
+        </div>
+        <div>
+          <div className="text-xs text-slate-500">P95</div>
+          <div className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+            {formatValue(summary.name, summary.p95)}
+          </div>
+        </div>
+        <div>
+          <div className="text-xs text-slate-500">avg</div>
+          <div className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+            {formatValue(summary.name, summary.avg)}
+          </div>
+        </div>
+      </div>
+
+      {summary.count > 0 && (
+        <div className="mt-3 h-2 bg-slate-100 dark:bg-slate-800 rounded overflow-hidden flex">
+          <div
+            className="bg-green-500"
+            style={{ width: `${summary.goodPct}%` }}
+            title={`Good: ${summary.goodPct}%`}
+          />
+          <div
+            className="bg-yellow-500"
+            style={{ width: `${100 - summary.goodPct - summary.poorPct}%` }}
+            title="Needs improvement"
+          />
+          <div className="bg-red-500" style={{ width: `${summary.poorPct}%` }} title={`Poor: ${summary.poorPct}%`} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function MetricsDashboard() {
+  const [range, setRange] = useState<RangeFilter>("7d");
+  const [selectedMetric, setSelectedMetric] = useState<string>("LCP");
+
+  const { stats, points, loading, error, refetch } = useMetricsDashboard({ range, selectedMetric });
+
+  return (
+    <div className="max-w-7xl mx-auto p-6">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">性能监控</h1>
+          <p className="text-sm text-slate-500 mt-1">Web Vitals 和导航时序指标</p>
+        </div>
+        <button
+          onClick={refetch}
+          className="px-3 py-1.5 text-sm bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 rounded"
+        >
+          刷新
+        </button>
+      </div>
+
+      {/* Range selector */}
+      <div className="flex gap-2 mb-4">
+        {(["1h", "24h", "7d", "30d"] as RangeFilter[]).map((r) => (
+          <button
+            key={r}
+            onClick={() => setRange(r)}
+            className={`px-3 py-1.5 text-sm rounded ${
+              range === r
+                ? "bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900"
+                : "bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700"
+            }`}
+          >
+            {r}
+          </button>
+        ))}
+      </div>
+
+      {error && (
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-4 rounded-lg mb-4">
+          <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
+        </div>
+      )}
+
+      {/* Core Web Vitals cards */}
+      <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-3">核心指标</h2>
+      {loading && !stats ? (
+        <div className="text-center py-12 text-slate-500">加载中...</div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-4 mb-8">
+          {stats?.metrics.map((m) => <MetricCard key={m.name} summary={m} />) ??
+            CORE_METRICS.map((name) => <MetricCard key={name} summary={{ name, count: 0, p50: 0, p95: 0, avg: 0, goodPct: 0, poorPct: 0 }} />)}
+        </div>
+      )}
+
+      {/* Recent data points */}
+      <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 overflow-hidden">
+        <div className="px-4 py-3 border-b border-slate-200 dark:border-slate-700 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">最近数据</h2>
+          <select
+            value={selectedMetric}
+            onChange={(e) => setSelectedMetric(e.target.value)}
+            className="px-3 py-1 text-sm border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+          >
+            {CORE_METRICS.map((m) => (
+              <option key={m} value={m}>
+                {m}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {points.length === 0 ? (
+          <div className="text-center py-12 text-slate-500">暂无数据</div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="bg-slate-50 dark:bg-slate-800 text-xs uppercase text-slate-500">
+              <tr>
+                <th className="px-4 py-3 text-left">时间</th>
+                <th className="px-4 py-3 text-left">设备</th>
+                <th className="px-4 py-3 text-left">评分</th>
+                <th className="px-4 py-3 text-right">值</th>
+                <th className="px-4 py-3 text-left">URL</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200 dark:divide-slate-700">
+              {points.map((p) => (
+                <tr key={p.id} className="hover:bg-slate-50 dark:hover:bg-slate-800/50">
+                  <td className="px-4 py-3 text-slate-500 text-xs">
+                    {new Date(p.recordedAt).toLocaleString("zh-CN", { month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit" })}
+                  </td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400">{p.deviceType ?? "-"}</td>
+                  <td className="px-4 py-3">
+                    {p.rating ? (
+                      <span className={`px-2 py-0.5 rounded text-xs font-medium ${ratingBg(p.rating)} ${ratingColor(p.rating)}`}>
+                        {p.rating}
+                      </span>
+                    ) : (
+                      <span className="text-slate-400">-</span>
+                    )}
+                  </td>
+                  <td className={`px-4 py-3 text-right font-mono ${ratingColor(p.rating)}`}>
+                    {formatValue(selectedMetric, p.value)}
+                  </td>
+                  <td className="px-4 py-3 text-slate-500 text-xs max-w-md truncate">{p.url ?? "-"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useMetricsDashboard.ts
+++ b/frontend/src/hooks/useMetricsDashboard.ts
@@ -1,0 +1,77 @@
+/**
+ * useMetricsDashboard Hook
+ */
+
+import { useState, useEffect, useCallback } from "react";
+
+export type Rating = "good" | "needs-improvement" | "poor";
+
+export interface MetricSummary {
+  name: string;
+  count: number;
+  p50: number;
+  p95: number;
+  avg: number;
+  goodPct: number;
+  poorPct: number;
+}
+
+export interface MetricPoint {
+  id: string;
+  name: string;
+  value: number;
+  rating: Rating | null;
+  url: string | null;
+  deviceType: "mobile" | "tablet" | "desktop" | null;
+  recordedAt: string;
+}
+
+export interface DashboardStats {
+  range: string;
+  metrics: MetricSummary[];
+}
+
+interface UseMetricsParams {
+  range?: "1h" | "24h" | "7d" | "30d";
+  selectedMetric?: string;
+}
+
+export function useMetricsDashboard(params: UseMetricsParams = {}) {
+  const { range = "7d", selectedMetric = "LCP" } = params;
+
+  const [stats, setStats] = useState<DashboardStats | null>(null);
+  const [points, setPoints] = useState<MetricPoint[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAll = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const [statsRes, seriesRes] = await Promise.all([
+        fetch(`/api/metrics/dashboard?range=${range}`, { credentials: "include" }),
+        fetch(`/api/metrics/${selectedMetric}?range=${range}&limit=50`, { credentials: "include" }),
+      ]);
+
+      if (!statsRes.ok || !seriesRes.ok) {
+        throw new Error("Failed to fetch metrics");
+      }
+
+      const [statsJson, seriesJson] = await Promise.all([statsRes.json(), seriesRes.json()]);
+
+      if (statsJson.success) setStats(statsJson.data);
+      if (seriesJson.success) setPoints(seriesJson.data.points);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load metrics");
+    } finally {
+      setLoading(false);
+    }
+  }, [range, selectedMetric]);
+
+  useEffect(() => {
+    fetchAll();
+  }, [fetchAll]);
+
+  return { stats, points, loading, error, refetch: fetchAll };
+}

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -28,12 +28,13 @@ const {
   <body class="font-sans antialiased min-h-screen bg-white text-slate-900">
     <slot />
     <script>
-      // Install the global error reporter as early as possible on every page.
-      import("/src/lib/errorReporter.ts")
-        .then((m) => m.installErrorReporter())
-        .catch(() => {
-          /* never let the reporter itself block the app */
-        });
+      // Install the global error and metric reporters as early as possible on every page.
+      Promise.all([
+        import("/src/lib/errorReporter.ts").then((m) => m.installErrorReporter()),
+        import("/src/lib/metricReporter.ts").then((m) => m.installMetricReporter()),
+      ]).catch(() => {
+        /* never let the reporters themselves block the app */
+      });
     </script>
   </body>
 </html>

--- a/frontend/src/lib/metricReporter.ts
+++ b/frontend/src/lib/metricReporter.ts
@@ -1,0 +1,145 @@
+/**
+ * Metric Reporter
+ *
+ * Collects Web Vitals (LCP, INP, CLS, FCP, TTFB) and navigation timings,
+ * then batches them to the backend. Batched + send-on-hidden to avoid
+ * noisy network traffic during user interaction.
+ */
+
+import { onLCP, onINP, onCLS, onFCP, onTTFB } from "web-vitals";
+
+type Rating = "good" | "needs-improvement" | "poor";
+type DeviceType = "mobile" | "tablet" | "desktop";
+
+interface MetricPayload {
+  name: string;
+  value: number;
+  rating?: Rating;
+  url?: string;
+  userAgent?: string;
+  deviceType?: DeviceType;
+  connectionType?: string;
+  context?: Record<string, unknown>;
+}
+
+let installed = false;
+const buffered: MetricPayload[] = [];
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+const FLUSH_INTERVAL_MS = 5000;
+const BATCH_SIZE = 20;
+const MAX_BUFFER = 50;
+
+function getDeviceType(): DeviceType {
+  if (typeof window === "undefined") return "desktop";
+  const w = window.innerWidth;
+  if (w < 640) return "mobile";
+  if (w < 1024) return "tablet";
+  return "desktop";
+}
+
+function getConnectionType(): string | undefined {
+  if (typeof navigator === "undefined") return undefined;
+  // navigator.connection is non-standard but supported in Chromium
+  const conn = (navigator as unknown as { connection?: { effectiveType?: string } }).connection;
+  return conn?.effectiveType;
+}
+
+function buildContext(): Omit<MetricPayload, "name" | "value"> {
+  return {
+    url: typeof window !== "undefined" ? window.location.href : undefined,
+    userAgent: typeof navigator !== "undefined" ? navigator.userAgent : undefined,
+    deviceType: getDeviceType(),
+    connectionType: getConnectionType(),
+  };
+}
+
+async function send(payload: MetricPayload): Promise<void> {
+  try {
+    await fetch("/api/metrics", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(payload),
+      keepalive: true,
+    });
+  } catch {
+    /* never let the reporter itself block the app */
+  }
+}
+
+async function flushBatch(): Promise<void> {
+  if (buffered.length === 0) return;
+  const batch = buffered.splice(0, BATCH_SIZE);
+  try {
+    await fetch("/api/metrics/batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ metrics: batch }),
+      keepalive: true,
+    });
+  } catch {
+    /* swallow; metrics are best-effort */
+  }
+}
+
+function enqueue(metric: MetricPayload): void {
+  if (buffered.length >= MAX_BUFFER) {
+    // Drop oldest to prevent unbounded growth if backend is down
+    buffered.shift();
+  }
+  buffered.push(metric);
+
+  if (buffered.length >= BATCH_SIZE) {
+    void flushBatch();
+  } else if (flushTimer === null) {
+    flushTimer = setTimeout(() => {
+      flushTimer = null;
+      void flushBatch();
+    }, FLUSH_INTERVAL_MS);
+  }
+}
+
+function setupVisibilityFlush(): void {
+  if (typeof document === "undefined") return;
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "hidden") {
+      void flushBatch();
+    }
+  });
+  // Also flush on pagehide for browsers that don't fire visibilitychange
+  window.addEventListener("pagehide", () => {
+    void flushBatch();
+  });
+}
+
+/**
+ * Install Web Vitals collection. Idempotent.
+ */
+export function installMetricReporter(): void {
+  if (installed || typeof window === "undefined") return;
+  installed = true;
+
+  setupVisibilityFlush();
+
+  const ctx = buildContext();
+  const baseContext: Record<string, unknown> = { ...ctx };
+
+  onLCP((m) => enqueue({ ...baseContext, name: "LCP", value: m.value, rating: m.rating }));
+  onINP((m) => enqueue({ ...baseContext, name: "INP", value: m.value, rating: m.rating }));
+  onCLS((m) => enqueue({ ...baseContext, name: "CLS", value: m.value, rating: m.rating }));
+  onFCP((m) => enqueue({ ...baseContext, name: "FCP", value: m.value, rating: m.rating }));
+  onTTFB((m) => enqueue({ ...baseContext, name: "TTFB", value: m.value, rating: m.rating }));
+}
+
+/**
+ * Manually report a metric (e.g. for a custom timing)
+ */
+export async function reportMetric(
+  name: string,
+  value: number,
+  extra?: Partial<MetricPayload>
+): Promise<void> {
+  const ctx = buildContext();
+  await send({ ...ctx, name, value, ...extra });
+}

--- a/frontend/src/pages/metrics.astro
+++ b/frontend/src/pages/metrics.astro
@@ -1,0 +1,8 @@
+---
+import Layout from '../layouts/Layout.astro';
+import MetricsDashboard from '../components/metrics/MetricsDashboard';
+---
+
+<Layout title="性能监控">
+  <MetricsDashboard client:load />
+</Layout>

--- a/packages/types/src/schema.ts
+++ b/packages/types/src/schema.ts
@@ -532,3 +532,59 @@ export const errors = sqliteTable("errors", {
   createdAtIdx: index("errors_createdAt_idx").on(table.createdAt),
 }));
 
+/**
+ * 性能指标名枚举（对应 web-vitals）
+ */
+export const MetricName = {
+  // Core Web Vitals
+  LCP: "LCP",         // Largest Contentful Paint
+  INP: "INP",         // Interaction to Next Paint
+  CLS: "CLS",         // Cumulative Layout Shift
+  FCP: "FCP",         // First Contentful Paint
+  TTFB: "TTFB",       // Time to First Byte
+  // Navigation timing
+  NAV_DOM: "navigation.domContentLoaded",
+  NAV_LOAD: "navigation.load",
+} as const;
+
+export type MetricNameType = typeof MetricName[keyof typeof MetricName];
+
+/**
+ * 性能指标表
+ *
+ * 记录前端 Web Vitals 和导航时序指标，用于性能监控
+ */
+export const metrics = sqliteTable("metrics", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  // 指标名
+  name: text("name").notNull(),
+  // 指标值（CLS 等无单位指标保留原始数值；时间类指标为毫秒）
+  value: real("value").notNull(),
+  // 评分（good / needs-improvement / poor），可选
+  rating: text("rating", {
+    enum: ["good", "needs-improvement", "poor"],
+  }),
+  // 当前页面 URL
+  url: text("url"),
+  // 用户代理
+  userAgent: text("userAgent"),
+  // 设备类型（mobile / tablet / desktop），基于 viewport 宽度
+  deviceType: text("deviceType", {
+    enum: ["mobile", "tablet", "desktop"],
+  }),
+  // 网络类型（effectiveType，来自 navigator.connection）
+  connectionType: text("connectionType"),
+  // 附加上下文 JSON
+  context: text("context"),
+  recordedAt: integer("recordedAt", { mode: "timestamp_ms" })
+    .notNull()
+    .default(sql`(strftime('%s', 'now') * 1000)`),
+}, (table) => ({
+  nameIdx: index("metrics_name_idx").on(table.name),
+  ratingIdx: index("metrics_rating_idx").on(table.rating),
+  recordedAtIdx: index("metrics_recordedAt_idx").on(table.recordedAt),
+  nameRecordedAtIdx: index("metrics_name_recordedAt_idx").on(table.name, table.recordedAt),
+}));
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       tailwindcss:
         specifier: ^4.0.0
         version: 4.3.0
+      web-vitals:
+        specifier: ^5.3.0
+        version: 5.3.0
       zustand:
         specifier: ^5.0.0
         version: 5.0.13(@types/react@18.3.28)(react@18.3.1)
@@ -4359,6 +4362,9 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
 
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
@@ -8689,6 +8695,8 @@ snapshots:
       - yaml
 
   web-namespaces@2.0.1: {}
+
+  web-vitals@5.3.0: {}
 
   webidl-conversions@7.0.0: {}
 


### PR DESCRIPTION
## Feature #27: 性能监控 - P0

实现 Web Vitals 收集、上报、聚合 + 后台仪表板。

## 依赖
- 新增 `web-vitals` 5.3.0（项目级 dependency，非全局）

## Database
- 新增 `metrics` 表（name, value, rating, url, userAgent, deviceType, connectionType, context, recordedAt）
- 4 个索引：name / rating / recordedAt / name+recordedAt
- Migration: `drizzle/migrations/0009_add_metrics_table.sql`

## API
- `POST /api/metrics` (public) — 单点上报
- `POST /api/metrics/batch` (public) — 批量上报（最多 50 条/请求）
- `GET /api/metrics/dashboard?range=1h|24h|7d|30d` (auth) — 5 个核心指标聚合
- `GET /api/metrics/:name?range=...&limit=50` (auth) — 最近数据点序列

## 聚合统计
- P50 / P95 / avg（SQLite 无原生 percentile，在 JS 计算）
- good / poor 百分比 + 三色分布条

## Frontend
- `metricReporter` — web-vitals v5（LCP, INP, CLS, FCP, TTFB），5s 批量 flush，send-on-hidden，max 50 buffer
- Layout.astro 自动安装
- `/metrics` 仪表板 — 5 个指标卡 + 分布条 + 数据点表 + 范围/指标选择
- Navbar 集成

## 验证
- ✅ typecheck (api + frontend) 通过
- ✅ lint (api + frontend) 通过
- ✅ frontend build 通过
- ✅ pnpm typegen (api) 通过

## 备注
- P1+ 留到后续：趋势图、P95 告警、RUM 抽样、长期数据聚合
- P50/P95 在 JS 计算适合当前数据量；如量级增长再考虑预聚合表