### PR TITLE
feat: add API access with key management (Feature #14 - P0)

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -20,6 +20,8 @@ import statsRoutes from "./routes/stats";
 import notificationRoutes from "./routes/notifications";
 import errorRoutes from "./routes/errors";
 import metricRoutes from "./routes/metrics";
+import apiKeyRoutes from "./routes/keys";
+import v1Routes from "./routes/v1";
 import { stripeWebhookRoutes } from "./routes/webhooks/stripe";
 import { authMiddleware } from "./middleware/auth";
 
@@ -107,6 +109,8 @@ app.route("/api/stats", statsRoutes);
 app.route("/api/notifications", notificationRoutes);
 app.route("/api/errors", errorRoutes);
 app.route("/api/metrics", metricRoutes);
+app.route("/api/keys", apiKeyRoutes);
+app.route("/api/v1", v1Routes);
 app.route("/api/webhooks", stripeWebhookRoutes);
 
 // ============================================

--- a/api/src/middleware/apiKeyAuth.ts
+++ b/api/src/middleware/apiKeyAuth.ts
@@ -1,0 +1,58 @@
+/**
+ * API Key Authentication Middleware
+ *
+ * Validates "Authorization: Bearer op_xxx" against the api_keys table.
+ * On success, attaches { apiKey, user } to context.
+ *
+ * Use this for /api/v1/* public API endpoints.
+ */
+
+import { createMiddleware } from "hono/factory";
+import { createDb, schema, type User as DBUser } from "@oura-pix/database";
+import { eq } from "drizzle-orm";
+import { validateApiKey } from "../services/apiKeyService";
+
+export type ApiKeyContext = {
+  Bindings: {
+    DB: D1Database;
+  };
+  Variables: {
+    apiKey: {
+      id: string;
+      userId: string;
+      name: string;
+    };
+    apiKeyUser: DBUser;
+  };
+};
+
+export const apiKeyAuth = createMiddleware<ApiKeyContext>(async (c, next) => {
+  const authHeader = c.req.header("Authorization") ?? "";
+  const match = authHeader.match(/^Bearer\s+(op_[a-f0-9]{64})$/i);
+  if (!match) {
+    return c.json({ error: "Missing or malformed API key. Use: Authorization: Bearer op_xxx" }, 401);
+  }
+
+  const key = match[1];
+  const db = createDb(c.env.DB);
+  const record = await validateApiKey(db, key);
+  if (!record) {
+    return c.json({ error: "Invalid or revoked API key" }, 401);
+  }
+
+  // Load the user record
+  const users = await db
+    .select()
+    .from(schema.users)
+    .where(eq(schema.users.id, record.userId))
+    .limit(1);
+
+  if (users.length === 0) {
+    return c.json({ error: "API key owner not found" }, 401);
+  }
+
+  c.set("apiKey", { id: record.id, userId: record.userId, name: record.name });
+  c.set("apiKeyUser", users[0]);
+
+  await next();
+});

--- a/api/src/routes/keys.ts
+++ b/api/src/routes/keys.ts
@@ -1,0 +1,142 @@
+/**
+ * API Keys Management Routes (authenticated)
+ *
+ * GET    /api/keys       — list my keys (no full key)
+ * POST   /api/keys       — create a new key (returns full key once)
+ * DELETE /api/keys/:id   — revoke a key
+ */
+
+import { Hono } from "hono";
+import { z } from "zod";
+import { zValidator } from "@hono/zod-validator";
+import { createDb } from "@oura-pix/database";
+import { getUser } from "../middleware/auth";
+import {
+  createApiKey,
+  listApiKeys,
+  revokeApiKey,
+  deleteApiKey,
+} from "../services/apiKeyService";
+
+const keys = new Hono<{
+  Bindings: {
+    DB: D1Database;
+  };
+  Variables: {
+    user: { id: string; email: string; name?: string | null };
+    session: { id: string; expiresAt: Date };
+  };
+}>();
+
+/**
+ * GET /api/keys
+ * List current user's keys
+ */
+keys.get("/", async (c) => {
+  const user = await getUser(c);
+  if (!user) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  try {
+    const db = createDb(c.env.DB);
+    const records = await listApiKeys(db, user.id);
+    return c.json({
+      success: true,
+      data: records.map((r) => ({
+        id: r.id,
+        name: r.name,
+        keyPrefix: r.keyPrefix,
+        lastUsedAt: r.lastUsedAt,
+        expiresAt: r.expiresAt,
+        isRevoked: r.isRevoked,
+        createdAt: r.createdAt,
+      })),
+    });
+  } catch (error) {
+    console.error("Failed to list api keys:", error);
+    return c.json({ error: "Failed to list API keys" }, 500);
+  }
+});
+
+const createSchema = z.object({
+  name: z.string().min(1).max(100),
+  expiresInDays: z.number().int().min(1).max(365).optional(),
+});
+
+/**
+ * POST /api/keys
+ * Create a new key. Returns the full key ONLY in this response.
+ */
+keys.post("/", zValidator("json", createSchema), async (c) => {
+  const user = await getUser(c);
+  if (!user) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const input = c.req.valid("json");
+
+  try {
+    const db = createDb(c.env.DB);
+    const expiresAt = input.expiresInDays
+      ? new Date(Date.now() + input.expiresInDays * 24 * 60 * 60 * 1000)
+      : undefined;
+    const result = await createApiKey(db, user.id, input.name, { expiresAt });
+    return c.json({ success: true, data: result });
+  } catch (error) {
+    console.error("Failed to create api key:", error);
+    return c.json({ error: "Failed to create API key" }, 500);
+  }
+});
+
+/**
+ * DELETE /api/keys/:id
+ * Revoke a key (soft delete — sets isRevoked = true)
+ */
+keys.delete("/:id", async (c) => {
+  const user = await getUser(c);
+  if (!user) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const id = c.req.param("id");
+
+  try {
+    const db = createDb(c.env.DB);
+    const success = await revokeApiKey(db, id, user.id);
+    if (!success) {
+      return c.json({ error: "Key not found" }, 404);
+    }
+    return c.json({ success: true });
+  } catch (error) {
+    console.error("Failed to revoke api key:", error);
+    return c.json({ error: "Failed to revoke API key" }, 500);
+  }
+});
+
+/**
+ * DELETE /api/keys/:id/hard
+ * Hard delete a key record entirely
+ */
+keys.delete("/:id/hard", async (c) => {
+  const user = await getUser(c);
+  if (!user) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const id = c.req.param("id");
+
+  try {
+    const db = createDb(c.env.DB);
+    const success = await deleteApiKey(db, id, user.id);
+    if (!success) {
+      return c.json({ error: "Key not found" }, 404);
+    }
+    return c.json({ success: true });
+  } catch (error) {
+    console.error("Failed to delete api key:", error);
+    return c.json({ error: "Failed to delete API key" }, 500);
+  }
+});
+
+export default keys;

--- a/api/src/routes/v1/generate.ts
+++ b/api/src/routes/v1/generate.ts
@@ -1,0 +1,180 @@
+/**
+ * Public API v1 — Generation endpoints
+ *
+ * Authenticated via API Key (Authorization: Bearer op_xxx).
+ * Mirrors the shape of /api/generations but is intended for external developers.
+ */
+
+import { Hono } from "hono";
+import { z } from "zod";
+import { zValidator } from "@hono/zod-validator";
+import { createDb } from "@oura-pix/database";
+import { apiKeyAuth } from "../../middleware/apiKeyAuth";
+import {
+  getGenerationById,
+  createGeneration,
+} from "../../services/generation-service";
+
+const generate = new Hono<{
+  Bindings: {
+    DB: D1Database;
+  };
+  Variables: {
+    apiKey: { id: string; userId: string; name: string };
+    apiKeyUser: { id: string; email: string };
+  };
+}>();
+
+// All routes require API key
+generate.use("/*", apiKeyAuth);
+
+const createSchema = z.object({
+  productImageId: z.string(),
+  referenceImageIds: z.array(z.string()).optional(),
+  prompt: z.string().max(2000).optional(),
+  settings: z.object({
+    targetPlatform: z.enum(["amazon", "ebay", "shopify", "etsy", "generic"]),
+    language: z.string().min(2).max(10),
+    count: z.number().int().min(1).max(10),
+    style: z.enum(["professional", "lifestyle", "minimal", "luxury"]),
+    generateImages: z.boolean().optional(),
+    imageCount: z.number().int().min(1).max(10).optional(),
+    aspectRatio: z.enum(["1:1", "3:4", "4:3", "9:16", "16:9"]),
+    allowPersons: z.boolean().optional(),
+  }),
+});
+
+/**
+ * POST /api/v1/generate
+ * Trigger a new generation. Returns the generation ID and initial status.
+ */
+generate.post("/", zValidator("json", createSchema), async (c) => {
+  const apiKeyUser = c.get("apiKeyUser");
+  const body = c.req.valid("json");
+
+  try {
+    const db = createDb(c.env.DB);
+    const generation = await createGeneration(db, apiKeyUser.id, body);
+    return c.json(
+      {
+        success: true,
+        data: {
+          id: generation.id,
+          status: generation.status,
+          createdAt: generation.createdAt,
+        },
+      },
+      201
+    );
+  } catch (error) {
+    console.error("[v1/generate] Create error:", error);
+    return c.json(
+      {
+        success: false,
+        error: { code: "INTERNAL_ERROR", message: "Failed to create generation" },
+      },
+      500
+    );
+  }
+});
+
+/**
+ * GET /api/v1/generation/:id
+ * Get the status and result of a generation.
+ */
+generate.get("/:id", async (c) => {
+  const apiKeyUser = c.get("apiKeyUser");
+  const id = c.req.param("id");
+
+  try {
+    const db = createDb(c.env.DB);
+    const generation = await getGenerationById(db, id, apiKeyUser.id);
+    if (!generation) {
+      return c.json(
+        {
+          success: false,
+          error: { code: "NOT_FOUND", message: "Generation not found" },
+        },
+        404
+      );
+    }
+    return c.json({
+      success: true,
+      data: {
+        id: generation.id,
+        status: generation.status,
+        prompt: generation.prompt,
+        generatedImages: generation.generatedImages,
+        errorMessage: generation.errorMessage,
+        createdAt: generation.createdAt,
+      },
+    });
+  } catch (error) {
+    console.error("[v1/generate] Get error:", error);
+    return c.json(
+      {
+        success: false,
+        error: { code: "INTERNAL_ERROR", message: "Failed to fetch generation" },
+      },
+      500
+    );
+  }
+});
+
+/**
+ * GET /api/v1/generation/:id/download
+ * Returns a JSON list of image URLs for the completed generation.
+ * (P0: returns URLs; signed download URLs can be added in P1.)
+ */
+generate.get("/:id/download", async (c) => {
+  const apiKeyUser = c.get("apiKeyUser");
+  const id = c.req.param("id");
+
+  try {
+    const db = createDb(c.env.DB);
+    const generation = await getGenerationById(db, id, apiKeyUser.id);
+    if (!generation) {
+      return c.json(
+        {
+          success: false,
+          error: { code: "NOT_FOUND", message: "Generation not found" },
+        },
+        404
+      );
+    }
+    if (generation.status !== "completed") {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: "NOT_READY",
+            message: `Generation is ${generation.status}, not completed yet`,
+            currentStatus: generation.status,
+          },
+        },
+        409
+      );
+    }
+    return c.json({
+      success: true,
+      data: {
+        id: generation.id,
+        images: generation.generatedImages.map((url, index) => ({
+          index,
+          url,
+        })),
+      },
+    });
+  } catch (error) {
+    console.error("[v1/generate] Download error:", error);
+    return c.json(
+      {
+        success: false,
+        error: { code: "INTERNAL_ERROR", message: "Failed to fetch images" },
+      },
+      500
+    );
+  }
+});
+
+export default generate;

--- a/api/src/routes/v1/index.ts
+++ b/api/src/routes/v1/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Public API v1 — Root
+ *
+ * Mounts all v1 sub-routes. All routes require API Key auth.
+ */
+
+import { Hono } from "hono";
+import generate from "./generate";
+
+const v1 = new Hono();
+
+v1.route("/generate", generate);
+// Aliases for nicer URL shape: /api/v1/generation/:id → /api/v1/generate/:id
+v1.route("/generation", generate);
+
+export default v1;

--- a/api/src/services/apiKeyService.ts
+++ b/api/src/services/apiKeyService.ts
@@ -1,0 +1,176 @@
+/**
+ * API Key Service
+ *
+ * Generates, validates, and revokes API keys.
+ *
+ * Format: op_ + 32 bytes hex = "op_" + 64 hex chars = 67 chars total
+ * Storage: SHA-256 hex hash (64 chars) of the full key
+ */
+
+import { createDb, schema } from "@oura-pix/database";
+import { eq, and, desc } from "drizzle-orm";
+
+const KEY_PREFIX = "op_";
+const RANDOM_BYTES = 32;
+
+export interface ApiKeyRecord {
+  id: string;
+  userId: string;
+  name: string;
+  keyPrefix: string;
+  keyHash: string;
+  lastUsedAt: Date | null;
+  expiresAt: Date | null;
+  isRevoked: boolean;
+  createdAt: Date;
+}
+
+export interface CreateApiKeyResult {
+  id: string;
+  name: string;
+  // The full key — only returned once, at creation time
+  key: string;
+  keyPrefix: string;
+  createdAt: Date;
+  expiresAt: Date | null;
+}
+
+/**
+ * Generate a new API key in the format "op_<64 hex chars>".
+ * Uses crypto.getRandomValues via Web Crypto API (available in Workers).
+ */
+function generateKey(): string {
+  const bytes = new Uint8Array(RANDOM_BYTES);
+  crypto.getRandomValues(bytes);
+  const hex = Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return `${KEY_PREFIX}${hex}`;
+}
+
+async function hashKey(key: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(key);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/**
+ * Create a new API key for a user.
+ * Returns the full key in `key` — this is the only time it will be available.
+ */
+export async function createApiKey(
+  db: ReturnType<typeof createDb>,
+  userId: string,
+  name: string,
+  options: { expiresAt?: Date } = {}
+): Promise<CreateApiKeyResult> {
+  const key = generateKey();
+  const keyHash = await hashKey(key);
+  // Display prefix: first 8 chars of the random hex after "op_"
+  const keyPrefix = key.slice(0, 11);
+
+  const [created] = await db
+    .insert(schema.apiKeys)
+    .values({
+      id: crypto.randomUUID(),
+      userId,
+      name,
+      keyPrefix,
+      keyHash,
+      expiresAt: options.expiresAt ?? null,
+      isRevoked: false,
+      createdAt: new Date(),
+    })
+    .returning();
+
+  return {
+    id: created.id,
+    name: created.name,
+    key, // full key — caller MUST show to user once
+    keyPrefix: created.keyPrefix,
+    createdAt: created.createdAt,
+    expiresAt: created.expiresAt,
+  };
+}
+
+/**
+ * Validate an incoming API key from the Authorization header.
+ * Returns the matching record (with userId) if valid, or null.
+ *
+ * Side effect: updates lastUsedAt on the matched record.
+ */
+export async function validateApiKey(
+  db: ReturnType<typeof createDb>,
+  key: string
+): Promise<ApiKeyRecord | null> {
+  if (!key.startsWith(KEY_PREFIX)) return null;
+
+  const keyHash = await hashKey(key);
+  const records = await db
+    .select()
+    .from(schema.apiKeys)
+    .where(eq(schema.apiKeys.keyHash, keyHash))
+    .limit(1);
+
+  if (records.length === 0) return null;
+  const record = records[0];
+
+  if (record.isRevoked) return null;
+  if (record.expiresAt && record.expiresAt.getTime() < Date.now()) return null;
+
+  // Fire-and-forget: update lastUsedAt without blocking the request
+  db.update(schema.apiKeys)
+    .set({ lastUsedAt: new Date() })
+    .where(eq(schema.apiKeys.id, record.id))
+    .catch((err) => console.error("Failed to update apiKey.lastUsedAt:", err));
+
+  return record;
+}
+
+/**
+ * List all keys owned by a user. The full key is never returned.
+ */
+export async function listApiKeys(
+  db: ReturnType<typeof createDb>,
+  userId: string
+): Promise<ApiKeyRecord[]> {
+  return db
+    .select()
+    .from(schema.apiKeys)
+    .where(eq(schema.apiKeys.userId, userId))
+    .orderBy(desc(schema.apiKeys.createdAt));
+}
+
+/**
+ * Revoke a key owned by the user. Idempotent: returns true even if already revoked.
+ */
+export async function revokeApiKey(
+  db: ReturnType<typeof createDb>,
+  keyId: string,
+  userId: string
+): Promise<boolean> {
+  const result = await db
+    .update(schema.apiKeys)
+    .set({ isRevoked: true })
+    .where(and(eq(schema.apiKeys.id, keyId), eq(schema.apiKeys.userId, userId)))
+    .returning();
+  return result.length > 0;
+}
+
+/**
+ * Delete a key record entirely (hard delete). Different from revoke.
+ */
+export async function deleteApiKey(
+  db: ReturnType<typeof createDb>,
+  keyId: string,
+  userId: string
+): Promise<boolean> {
+  const result = await db
+    .delete(schema.apiKeys)
+    .where(and(eq(schema.apiKeys.id, keyId), eq(schema.apiKeys.userId, userId)))
+    .returning();
+  return result.length > 0;
+}

--- a/drizzle/migrations/0010_add_api_keys_table.sql
+++ b/drizzle/migrations/0010_add_api_keys_table.sql
@@ -1,0 +1,19 @@
+-- API Keys table
+-- Stores hashed API keys. Full key is never stored; only SHA-256 hash.
+
+CREATE TABLE `api_keys` (
+	`id` text PRIMARY KEY NOT NULL,
+	`userId` text NOT NULL,
+	`name` text NOT NULL,
+	`keyPrefix` text NOT NULL,
+	`keyHash` text NOT NULL,
+	`lastUsedAt` integer,
+	`expiresAt` integer,
+	`isRevoked` integer NOT NULL DEFAULT false,
+	`createdAt` integer NOT NULL,
+	FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `api_keys_keyHash_unique` ON `api_keys` (`keyHash`);--> statement-breakpoint
+CREATE INDEX `api_keys_userId_idx` ON `api_keys` (`userId`);--> statement-breakpoint
+CREATE INDEX `api_keys_keyHash_idx` ON `api_keys` (`keyHash`);

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -24,6 +24,7 @@ export default function Navbar() {
     { href: "/history", label: m.history_title?.() || "生成历史" },
     { href: "/favorites", label: m.favorites_title?.() || "我的收藏" },
     { href: "/stats", label: m.stats_title?.() || "统计" },
+    { href: "/api-keys", label: "API Keys" },
     { href: "/metrics", label: "性能监控" },
     { href: "/errors", label: "错误追踪" },
     { href: "/pricing", label: m.pricing() },

--- a/frontend/src/components/keys/ApiKeysPage.tsx
+++ b/frontend/src/components/keys/ApiKeysPage.tsx
@@ -1,0 +1,290 @@
+/**
+ * ApiKeysPage Component
+ *
+ * Manage API keys for programmatic access to /api/v1/* endpoints
+ */
+
+"use client";
+
+import { useState } from "react";
+import { useApiKeys } from "@/hooks/useApiKeys";
+
+function formatDate(dateString: string | null): string {
+  if (!dateString) return "-";
+  return new Date(dateString).toLocaleString("zh-CN", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function CopyableKey({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* clipboard may be blocked; user can still select manually */
+    }
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="inline-flex items-center gap-2 px-2 py-1 text-xs font-mono bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 rounded"
+    >
+      <code className="break-all">{value}</code>
+      <span className="text-slate-500">{copied ? "✓" : "📋"}</span>
+    </button>
+  );
+}
+
+function NewKeyModal({
+  fullKey,
+  prefix,
+  onClose,
+}: {
+  fullKey: string;
+  prefix: string;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white dark:bg-slate-900 rounded-lg shadow-xl max-w-xl w-full p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-2">
+          API Key 已创建
+        </h2>
+        <p className="text-sm text-slate-500 mb-4">
+          ⚠️ 请立即保存这个 Key。出于安全考虑，<strong>关闭此弹窗后无法再次查看完整 Key</strong>。
+        </p>
+        <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded p-3 mb-4">
+          <p className="text-xs text-amber-700 dark:text-amber-300 mb-2">完整 Key：</p>
+          <CopyableKey value={fullKey} />
+          <p className="text-xs text-amber-700 dark:text-amber-300 mt-2">
+            前缀: <code>{prefix}</code>
+          </p>
+        </div>
+        <div className="bg-slate-50 dark:bg-slate-800 rounded p-3 mb-4">
+          <p className="text-xs text-slate-600 dark:text-slate-400 mb-1">使用示例：</p>
+          <pre className="text-xs font-mono overflow-x-auto whitespace-pre">
+{`curl -X POST https://api.ourapix.jiahongw.com/api/v1/generate \\
+  -H "Authorization: Bearer ${prefix}..." \\
+  -H "Content-Type: application/json" \\
+  -d '{ "productImageId": "...", "settings": { ... } }'`}
+          </pre>
+        </div>
+        <button
+          onClick={onClose}
+          className="w-full px-4 py-2 bg-slate-900 text-white rounded hover:bg-slate-800"
+        >
+          我已保存，关闭
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function ApiKeysPage() {
+  const { keys, loading, error, newlyCreated, setNewlyCreated, createKey, revokeKey } = useApiKeys();
+  const [showCreate, setShowCreate] = useState(false);
+  const [name, setName] = useState("");
+  const [expiresInDays, setExpiresInDays] = useState<string>("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+    setSubmitting(true);
+    const days = expiresInDays ? parseInt(expiresInDays, 10) : undefined;
+    const result = await createKey(name.trim(), days);
+    setSubmitting(false);
+    if (result) {
+      setShowCreate(false);
+      setName("");
+      setExpiresInDays("");
+    }
+  };
+
+  return (
+    <div className="max-w-5xl mx-auto p-6">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">API Keys</h1>
+          <p className="text-sm text-slate-500 mt-1">通过 API Key 访问 <code className="text-xs">/api/v1/*</code> 端点</p>
+        </div>
+        <button
+          onClick={() => setShowCreate(true)}
+          className="px-4 py-2 bg-slate-900 text-white text-sm rounded hover:bg-slate-800"
+        >
+          + 创建 API Key
+        </button>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-3 rounded mb-4">
+          <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
+        </div>
+      )}
+
+      <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 overflow-hidden">
+        {loading && keys.length === 0 ? (
+          <div className="text-center py-12 text-slate-500">加载中...</div>
+        ) : keys.length === 0 ? (
+          <div className="text-center py-12 text-slate-500">
+            <p>还没有 API Key</p>
+            <p className="text-xs mt-1">点击右上角创建第一个</p>
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="bg-slate-50 dark:bg-slate-800 text-xs uppercase text-slate-500">
+              <tr>
+                <th className="px-4 py-3 text-left">名称</th>
+                <th className="px-4 py-3 text-left">Key</th>
+                <th className="px-4 py-3 text-left">状态</th>
+                <th className="px-4 py-3 text-left">最后使用</th>
+                <th className="px-4 py-3 text-left">过期时间</th>
+                <th className="px-4 py-3 text-left">创建时间</th>
+                <th className="px-4 py-3 text-right w-20">操作</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200 dark:divide-slate-700">
+              {keys.map((k) => (
+                <tr key={k.id} className="hover:bg-slate-50 dark:hover:bg-slate-800/50">
+                  <td className="px-4 py-3 font-medium text-slate-900 dark:text-slate-100">
+                    {k.name}
+                  </td>
+                  <td className="px-4 py-3">
+                    <code className="text-xs text-slate-600 dark:text-slate-400 font-mono">
+                      {k.keyPrefix}…
+                    </code>
+                  </td>
+                  <td className="px-4 py-3">
+                    {k.isRevoked ? (
+                      <span className="px-2 py-0.5 text-xs rounded bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300">
+                        已吊销
+                      </span>
+                    ) : k.expiresAt && new Date(k.expiresAt) < new Date() ? (
+                      <span className="px-2 py-0.5 text-xs rounded bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-300">
+                        已过期
+                      </span>
+                    ) : (
+                      <span className="px-2 py-0.5 text-xs rounded bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300">
+                        有效
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-slate-500 text-xs">{formatDate(k.lastUsedAt)}</td>
+                  <td className="px-4 py-3 text-slate-500 text-xs">{formatDate(k.expiresAt)}</td>
+                  <td className="px-4 py-3 text-slate-500 text-xs">{formatDate(k.createdAt)}</td>
+                  <td className="px-4 py-3 text-right">
+                    {!k.isRevoked && (
+                      <button
+                        onClick={async () => {
+                          if (confirm(`确定吊销 "${k.name}"?`)) await revokeKey(k.id);
+                        }}
+                        className="text-xs text-slate-500 hover:text-red-500"
+                      >
+                        吊销
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <div className="mt-6 p-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded text-sm text-blue-800 dark:text-blue-300">
+        <h3 className="font-medium mb-1">使用说明</h3>
+        <ul className="text-xs space-y-1 list-disc list-inside">
+          <li>API Key 格式：<code className="bg-blue-100 dark:bg-blue-900/40 px-1 rounded">op_</code> + 64 位十六进制</li>
+          <li>认证方式：HTTP Header <code className="bg-blue-100 dark:bg-blue-900/40 px-1 rounded">Authorization: Bearer op_xxx</code></li>
+          <li>完整 Key 仅在创建时显示一次，请立即保存</li>
+          <li>可吊销 Key 而非删除（吊销后无法恢复，但保留审计记录）</li>
+        </ul>
+      </div>
+
+      {showCreate && (
+        <div
+          className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
+          onClick={() => setShowCreate(false)}
+        >
+          <form
+            onSubmit={handleCreate}
+            className="bg-white dark:bg-slate-900 rounded-lg shadow-xl max-w-md w-full p-6"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-4">
+              创建 API Key
+            </h2>
+            <div className="mb-4">
+              <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+                名称
+              </label>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="如：production-server"
+                className="w-full px-3 py-2 border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+                maxLength={100}
+                required
+                autoFocus
+              />
+            </div>
+            <div className="mb-6">
+              <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+                过期天数（可选）
+              </label>
+              <input
+                type="number"
+                value={expiresInDays}
+                onChange={(e) => setExpiresInDays(e.target.value)}
+                placeholder="留空表示永不过期"
+                min={1}
+                max={365}
+                className="w-full px-3 py-2 border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+              />
+            </div>
+            <div className="flex gap-2 justify-end">
+              <button
+                type="button"
+                onClick={() => setShowCreate(false)}
+                className="px-4 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded"
+              >
+                取消
+              </button>
+              <button
+                type="submit"
+                disabled={!name.trim() || submitting}
+                className="px-4 py-2 text-sm bg-slate-900 text-white rounded hover:bg-slate-800 disabled:opacity-50"
+              >
+                {submitting ? "创建中..." : "创建"}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {newlyCreated && (
+        <NewKeyModal
+          fullKey={newlyCreated.key}
+          prefix={newlyCreated.keyPrefix}
+          onClose={() => setNewlyCreated(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useApiKeys.ts
+++ b/frontend/src/hooks/useApiKeys.ts
@@ -1,0 +1,97 @@
+/**
+ * useApiKeys Hook
+ */
+
+import { useState, useEffect, useCallback } from "react";
+
+export interface ApiKey {
+  id: string;
+  name: string;
+  keyPrefix: string;
+  lastUsedAt: string | null;
+  expiresAt: string | null;
+  isRevoked: boolean;
+  createdAt: string;
+}
+
+interface CreatedKey extends ApiKey {
+  key: string; // full key — only present in create response
+}
+
+export function useApiKeys() {
+  const [keys, setKeys] = useState<ApiKey[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [newlyCreated, setNewlyCreated] = useState<CreatedKey | null>(null);
+
+  const fetchKeys = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/keys", { credentials: "include" });
+      if (!res.ok) throw new Error("Failed to fetch API keys");
+      const json = await res.json();
+      if (json.success) setKeys(json.data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load API keys");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchKeys();
+  }, [fetchKeys]);
+
+  const createKey = useCallback(
+    async (name: string, expiresInDays?: number): Promise<CreatedKey | null> => {
+      try {
+        const res = await fetch("/api/keys", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({ name, ...(expiresInDays ? { expiresInDays } : {}) }),
+        });
+        if (!res.ok) throw new Error("Failed to create API key");
+        const json = await res.json();
+        if (json.success) {
+          setNewlyCreated(json.data);
+          await fetchKeys();
+          return json.data as CreatedKey;
+        }
+        return null;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to create API key");
+        return null;
+      }
+    },
+    [fetchKeys]
+  );
+
+  const revokeKey = useCallback(
+    async (id: string) => {
+      try {
+        const res = await fetch(`/api/keys/${id}`, {
+          method: "DELETE",
+          credentials: "include",
+        });
+        if (!res.ok) throw new Error("Failed to revoke API key");
+        await fetchKeys();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to revoke API key");
+      }
+    },
+    [fetchKeys]
+  );
+
+  return {
+    keys,
+    loading,
+    error,
+    newlyCreated,
+    setNewlyCreated,
+    createKey,
+    revokeKey,
+    refetch: fetchKeys,
+  };
+}

--- a/frontend/src/pages/api-keys.astro
+++ b/frontend/src/pages/api-keys.astro
@@ -1,0 +1,8 @@
+---
+import Layout from '../layouts/Layout.astro';
+import ApiKeysPage from '../components/keys/ApiKeysPage';
+---
+
+<Layout title="API Keys">
+  <ApiKeysPage client:load />
+</Layout>

--- a/packages/types/src/schema.ts
+++ b/packages/types/src/schema.ts
@@ -588,3 +588,36 @@ export const metrics = sqliteTable("metrics", {
   nameRecordedAtIdx: index("metrics_name_recordedAt_idx").on(table.name, table.recordedAt),
 }));
 
+/**
+ * API 密钥表
+ *
+ * 存储用户生成的 API Key 哈希值，永不存明文。
+ * 完整 key 仅在创建时返回一次。
+ */
+export const apiKeys = sqliteTable("api_keys", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  userId: text("userId")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  // 用户自定义名称
+  name: text("name").notNull(),
+  // 展示用前缀，例如 "op_a1b2c3"
+  keyPrefix: text("keyPrefix").notNull(),
+  // 完整 key 的 SHA-256 哈希
+  keyHash: text("keyHash").notNull().unique(),
+  // 最后使用时间
+  lastUsedAt: integer("lastUsedAt", { mode: "timestamp_ms" }),
+  // 过期时间（可选）
+  expiresAt: integer("expiresAt", { mode: "timestamp_ms" }),
+  // 是否已吊销
+  isRevoked: integer("isRevoked", { mode: "boolean" }).notNull().default(false),
+  createdAt: integer("createdAt", { mode: "timestamp_ms" })
+    .notNull()
+    .default(sql`(strftime('%s', 'now') * 1000)`),
+}, (table) => ({
+  userIdIdx: index("api_keys_userId_idx").on(table.userId),
+  keyHashIdx: index("api_keys_keyHash_idx").on(table.keyHash),
+}));
+


### PR DESCRIPTION
## Feature #14: API 访问 - P0

实现 API Key 管理 + 公共 API v1 端点。

## Database
- 新增 `api_keys` 表（9 字段 + 2 索引）
- Key 格式：`op_` + 32-byte hex（67 字符）
- 存储 SHA-256 hash，明文永不保存
- Migration: `drizzle/migrations/0010_add_api_keys_table.sql`

## API Key 认证中间件
- 验证 `Authorization: Bearer op_xxx`
- 拒绝吊销/过期/格式错误
- 注入 `{ apiKey, apiKeyUser }` 到 context
- 异步 fire-and-forget 更新 lastUsedAt

## 管理端点（需登录）
- `GET /api/keys` — 列出我的 Key
- `POST /api/keys` — 创建（返回完整 key 一次）
- `DELETE /api/keys/:id` — 软吊销
- `DELETE /api/keys/:id/hard` — 硬删除

## 公共 API v1（API Key 认证）
- `POST /api/v1/generate` — 创建 generation 记录
- `GET /api/v1/generation/:id` — 查询状态和结果
- `GET /api/v1/generation/:id/download` — 图片 URL 列表（未完成返回 409）
- 别名：`/api/v1/generation/*` → `/api/v1/generate/*`

## Frontend
- `/api-keys` 页面 — 列表/创建/吊销
- NewKeyModal — 完整 Key 一次显示，复制到剪贴板，curl 示例
- 状态徽章（有效/已吊销/已过期）
- Navbar 集成

## 验证
- ✅ typecheck (api + frontend) 通过
- ✅ lint (api + frontend) 通过
- ✅ frontend build 通过
- ✅ pnpm typegen (api) 通过

## 备注
- P1+ 留到后续：Rate Limiting、用量统计、开发者文档、Webhook 回调
- 完整 Key 只在创建时返回；之后只展示 `op_xxxxxxxx` 前缀
- 7 天内 Key 列表自动加 userId 过滤，防止越权