### PR TITLE
feat: add team collaboration (Feature #15 - P0)

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -21,6 +21,7 @@ import notificationRoutes from "./routes/notifications";
 import errorRoutes from "./routes/errors";
 import metricRoutes from "./routes/metrics";
 import apiKeyRoutes from "./routes/keys";
+import teamRoutes from "./routes/teams";
 import v1Routes from "./routes/v1";
 import { stripeWebhookRoutes } from "./routes/webhooks/stripe";
 import { authMiddleware } from "./middleware/auth";
@@ -110,6 +111,7 @@ app.route("/api/notifications", notificationRoutes);
 app.route("/api/errors", errorRoutes);
 app.route("/api/metrics", metricRoutes);
 app.route("/api/keys", apiKeyRoutes);
+app.route("/api/teams", teamRoutes);
 app.route("/api/v1", v1Routes);
 app.route("/api/webhooks", stripeWebhookRoutes);
 

--- a/api/src/routes/teams.ts
+++ b/api/src/routes/teams.ts
@@ -1,0 +1,325 @@
+/**
+ * Teams Routes
+ *
+ * Team management: create, list, detail, members, generations
+ */
+
+import { Hono } from "hono";
+import { z } from "zod";
+import { zValidator } from "@hono/zod-validator";
+import { createDb, schema } from "@oura-pix/database";
+import { inArray, desc, sql } from "drizzle-orm";
+import { getUser } from "../middleware/auth";
+import {
+  createTeam,
+  listUserTeams,
+  getTeamForUser,
+  updateTeam,
+  deleteTeam,
+  joinTeamByInviteCode,
+  listTeamMembers,
+  updateMemberRole,
+  removeMember,
+  leaveTeam,
+  getTeamMemberIds,
+  isRoleAtLeast,
+} from "../services/teamService";
+
+const teams = new Hono<{
+  Bindings: {
+    DB: D1Database;
+  };
+  Variables: {
+    user: { id: string; email: string; name?: string | null };
+    session: { id: string; expiresAt: Date };
+  };
+}>();
+
+const createSchema = z.object({
+  name: z.string().min(1).max(100),
+});
+
+const updateSchema = z.object({
+  name: z.string().min(1).max(100),
+});
+
+const joinSchema = z.object({
+  inviteCode: z.string().min(4).max(50),
+});
+
+const roleSchema = z.object({
+  role: z.enum(["admin", "member"]),
+});
+
+/**
+ * POST /api/teams — Create a new team
+ */
+teams.post("/", zValidator("json", createSchema), async (c) => {
+  const user = await getUser(c);
+  if (!user) return c.json({ error: "Unauthorized" }, 401);
+
+  const { name } = c.req.valid("json");
+
+  try {
+    const db = createDb(c.env.DB);
+    const team = await createTeam(db, user.id, name);
+    return c.json({ success: true, data: team }, 201);
+  } catch (error) {
+    console.error("Failed to create team:", error);
+    return c.json({ error: "Failed to create team" }, 500);
+  }
+});
+
+/**
+ * GET /api/teams — List user's teams
+ */
+teams.get("/", async (c) => {
+  const user = await getUser(c);
+  if (!user) return c.json({ error: "Unauthorized" }, 401);
+
+  try {
+    const db = createDb(c.env.DB);
+    const teams = await listUserTeams(db, user.id);
+    return c.json({ success: true, data: teams });
+  } catch (error) {
+    console.error("Failed to list teams:", error);
+    return c.json({ error: "Failed to list teams" }, 500);
+  }
+});
+
+/**
+ * GET /api/teams/:id — Get team details with members
+ */
+teams.get("/:id", async (c) => {
+  const user = await getUser(c);
+  if (!user) return c.json({ error: "Unauthorized" }, 401);
+
+  const teamId = c.req.param("id");
+
+  try {
+    const db = createDb(c.env.DB);
+    const team = await getTeamForUser(db, teamId, user.id);
+    if (!team) return c.json({ error: "Team not found" }, 404);
+
+    const members = await listTeamMembers(db, teamId);
+    return c.json({
+      success: true,
+      data: { ...team, members },
+    });
+  } catch (error) {
+    console.error("Failed to get team:", error);
+    return c.json({ error: "Failed to get team" }, 500);
+  }
+});
+
+/**
+ * PUT /api/teams/:id — Update team name (owner only)
+ */
+teams.put("/:id", zValidator("json", updateSchema), async (c) => {
+  const user = await getUser(c);
+  if (!user) return c.json({ error: "Unauthorized" }, 401);
+
+  const teamId = c.req.param("id");
+  const { name } = c.req.valid("json");
+
+  try {
+    const db = createDb(c.env.DB);
+    const team = await getTeamForUser(db, teamId, user.id);
+    if (!team) return c.json({ error: "Team not found" }, 404);
+    if (team.role !== "owner") return c.json({ error: "Only owner can update" }, 403);
+
+    const updated = await updateTeam(db, teamId, name);
+    return c.json({ success: true, data: updated });
+  } catch (error) {
+    console.error("Failed to update team:", error);
+    return c.json({ error: "Failed to update team" }, 500);
+  }
+});
+
+/**
+ * DELETE /api/teams/:id — Delete team (owner only)
+ */
+teams.delete("/:id", async (c) => {
+  const user = await getUser(c);
+  if (!user) return c.json({ error: "Unauthorized" }, 401);
+
+  const teamId = c.req.param("id");
+
+  try {
+    const db = createDb(c.env.DB);
+    const team = await getTeamForUser(db, teamId, user.id);
+    if (!team) return c.json({ error: "Team not found" }, 404);
+    if (team.role !== "owner") return c.json({ error: "Only owner can delete" }, 403);
+
+    await deleteTeam(db, teamId);
+    return c.json({ success: true });
+  } catch (error) {
+    console.error("Failed to delete team:", error);
+    return c.json({ error: "Failed to delete team" }, 500);
+  }
+});
+
+/**
+ * POST /api/teams/:id/join — Join a team via invite code
+ */
+teams.post("/:id/join", zValidator("json", joinSchema), async (c) => {
+  const user = await getUser(c);
+  if (!user) return c.json({ error: "Unauthorized" }, 401);
+
+  const { inviteCode } = c.req.valid("json");
+
+  try {
+    const db = createDb(c.env.DB);
+    const member = await joinTeamByInviteCode(db, user.id, inviteCode);
+    if (!member) return c.json({ error: "Invalid invite code or already a member" }, 400);
+    return c.json({ success: true, data: member });
+  } catch (error) {
+    console.error("Failed to join team:", error);
+    return c.json({ error: "Failed to join team" }, 500);
+  }
+});
+
+/**
+ * POST /api/teams/:id/leave — Leave a team
+ */
+teams.post("/:id/leave", async (c) => {
+  const user = await getUser(c);
+  if (!user) return c.json({ error: "Unauthorized" }, 401);
+
+  const teamId = c.req.param("id");
+
+  try {
+    const db = createDb(c.env.DB);
+    const success = await leaveTeam(db, teamId, user.id);
+    if (!success) return c.json({ error: "Cannot leave (owner or not a member)" }, 400);
+    return c.json({ success: true });
+  } catch (error) {
+    console.error("Failed to leave team:", error);
+    return c.json({ error: "Failed to leave team" }, 500);
+  }
+});
+
+/**
+ * PUT /api/teams/:id/members/:userId/role — Update member role
+ *  - owner can promote/demote anyone
+ *  - admin can promote/demote members
+ */
+teams.put(
+  "/:id/members/:userId/role",
+  zValidator("json", roleSchema),
+  async (c) => {
+    const user = await getUser(c);
+    if (!user) return c.json({ error: "Unauthorized" }, 401);
+
+    const teamId = c.req.param("id");
+    const targetUserId = c.req.param("userId");
+    const { role } = c.req.valid("json");
+
+    try {
+      const db = createDb(c.env.DB);
+      const team = await getTeamForUser(db, teamId, user.id);
+      if (!team) return c.json({ error: "Team not found" }, 404);
+
+      // Authorization: owner can do anything; admin can only set role to 'member'
+      if (team.role === "owner") {
+        // OK
+      } else if (team.role === "admin" && role === "member") {
+        // OK
+      } else {
+        return c.json({ error: "Insufficient permissions" }, 403);
+      }
+
+      const updated = await updateMemberRole(db, teamId, targetUserId, role);
+      if (!updated) return c.json({ error: "Cannot change role (owner or not found)" }, 400);
+      return c.json({ success: true, data: updated });
+    } catch (error) {
+      console.error("Failed to update role:", error);
+      return c.json({ error: "Failed to update role" }, 500);
+    }
+  }
+);
+
+/**
+ * DELETE /api/teams/:id/members/:userId — Remove a member
+ *  - owner can remove anyone (except self/owner)
+ *  - admin can remove members only
+ */
+teams.delete("/:id/members/:userId", async (c) => {
+  const user = await getUser(c);
+  if (!user) return c.json({ error: "Unauthorized" }, 401);
+
+  const teamId = c.req.param("id");
+  const targetUserId = c.req.param("userId");
+
+  try {
+    const db = createDb(c.env.DB);
+    const team = await getTeamForUser(db, teamId, user.id);
+    if (!team) return c.json({ error: "Team not found" }, 404);
+
+    if (!isRoleAtLeast(team.role, "admin")) {
+      return c.json({ error: "Insufficient permissions" }, 403);
+    }
+
+    const success = await removeMember(db, teamId, targetUserId);
+    if (!success) return c.json({ error: "Cannot remove (owner or not found)" }, 400);
+    return c.json({ success: true });
+  } catch (error) {
+    console.error("Failed to remove member:", error);
+    return c.json({ error: "Failed to remove member" }, 500);
+  }
+});
+
+/**
+ * GET /api/teams/:id/generations — List team's generations
+ */
+teams.get("/:id/generations", async (c) => {
+  const user = await getUser(c);
+  if (!user) return c.json({ error: "Unauthorized" }, 401);
+
+  const teamId = c.req.param("id");
+  const page = Math.max(1, Number(c.req.query("page")) || 1);
+  const pageSize = Math.min(100, Math.max(1, Number(c.req.query("pageSize")) || 20));
+
+  try {
+    const db = createDb(c.env.DB);
+    const team = await getTeamForUser(db, teamId, user.id);
+    if (!team) return c.json({ error: "Team not found" }, 404);
+
+    const memberIds = await getTeamMemberIds(db, teamId);
+    if (memberIds.length === 0) {
+      return c.json({ success: true, data: { data: [], pagination: { page, pageSize, total: 0, totalPages: 0 } } });
+    }
+
+    const totalResult = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(schema.generations)
+      .where(inArray(schema.generations.userId, memberIds));
+    const total = totalResult[0]?.count ?? 0;
+
+    const data = await db
+      .select()
+      .from(schema.generations)
+      .where(inArray(schema.generations.userId, memberIds))
+      .orderBy(desc(schema.generations.createdAt))
+      .limit(pageSize)
+      .offset((page - 1) * pageSize);
+
+    return c.json({
+      success: true,
+      data: {
+        data,
+        pagination: {
+          page,
+          pageSize,
+          total,
+          totalPages: Math.ceil(total / pageSize),
+        },
+      },
+    });
+  } catch (error) {
+    console.error("Failed to list team generations:", error);
+    return c.json({ error: "Failed to list generations" }, 500);
+  }
+});
+
+export default teams;

--- a/api/src/services/teamService.ts
+++ b/api/src/services/teamService.ts
@@ -1,0 +1,347 @@
+/**
+ * Team Service
+ *
+ * Handles team CRUD, membership management, and role-based access control
+ */
+
+import { createDb, schema } from "@oura-pix/database";
+import { eq, and, desc, sql, inArray, ne } from "drizzle-orm";
+import type { TeamRoleType } from "@oura-pix/database";
+
+export interface TeamRecord {
+  id: string;
+  name: string;
+  ownerId: string;
+  inviteCode: string;
+  createdAt: Date;
+}
+
+export interface TeamMemberRecord {
+  id: string;
+  teamId: string;
+  userId: string;
+  role: TeamRoleType;
+  joinedAt: Date;
+  user?: {
+    id: string;
+    name: string | null;
+    email: string;
+  };
+}
+
+export interface TeamWithRole extends TeamRecord {
+  role: TeamRoleType;
+  memberCount: number;
+}
+
+const ROLE_PRIORITY: Record<TeamRoleType, number> = {
+  owner: 3,
+  admin: 2,
+  member: 1,
+};
+
+export function isRoleAtLeast(actual: TeamRoleType, required: TeamRoleType): boolean {
+  return ROLE_PRIORITY[actual] >= ROLE_PRIORITY[required];
+}
+
+function generateInviteCode(): string {
+  const bytes = new Uint8Array(4);
+  crypto.getRandomValues(bytes);
+  const hex = Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0").toUpperCase())
+    .join("");
+  return `TEAM-${hex}`;
+}
+
+export async function createTeam(
+  db: ReturnType<typeof createDb>,
+  ownerId: string,
+  name: string
+): Promise<TeamRecord> {
+  let team: TeamRecord | undefined;
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const inviteCode = generateInviteCode();
+    try {
+      const [created] = await db
+        .insert(schema.teams)
+        .values({
+          id: crypto.randomUUID(),
+          name,
+          ownerId,
+          inviteCode,
+          createdAt: new Date(),
+        })
+        .returning();
+      team = created;
+      break;
+    } catch (err) {
+      if (attempt === 4) throw err;
+    }
+  }
+
+  if (!team) throw new Error("Failed to create team");
+
+  await db.insert(schema.teamMembers).values({
+    id: crypto.randomUUID(),
+    teamId: team.id,
+    userId: ownerId,
+    role: "owner",
+    joinedAt: new Date(),
+  });
+
+  return team;
+}
+
+export async function listUserTeams(
+  db: ReturnType<typeof createDb>,
+  userId: string
+): Promise<TeamWithRole[]> {
+  const rows = await db
+    .select({
+      id: schema.teams.id,
+      name: schema.teams.name,
+      ownerId: schema.teams.ownerId,
+      inviteCode: schema.teams.inviteCode,
+      createdAt: schema.teams.createdAt,
+      role: schema.teamMembers.role,
+    })
+    .from(schema.teamMembers)
+    .innerJoin(schema.teams, eq(schema.teams.id, schema.teamMembers.teamId))
+    .where(eq(schema.teamMembers.userId, userId))
+    .orderBy(desc(schema.teams.createdAt));
+
+  const teamIds = rows.map((r) => r.id);
+  const counts = teamIds.length
+    ? await db
+        .select({
+          teamId: schema.teamMembers.teamId,
+          count: sql<number>`count(*)`,
+        })
+        .from(schema.teamMembers)
+        .where(inArray(schema.teamMembers.teamId, teamIds))
+        .groupBy(schema.teamMembers.teamId)
+    : [];
+
+  const countMap = new Map(counts.map((c) => [c.teamId, c.count]));
+
+  return rows.map((r) => ({
+    id: r.id,
+    name: r.name,
+    ownerId: r.ownerId,
+    inviteCode: r.inviteCode,
+    createdAt: r.createdAt,
+    role: r.role,
+    memberCount: countMap.get(r.id) ?? 0,
+  }));
+}
+
+export async function getTeamForUser(
+  db: ReturnType<typeof createDb>,
+  teamId: string,
+  userId: string
+): Promise<TeamWithRole | null> {
+  const rows = await db
+    .select({
+      id: schema.teams.id,
+      name: schema.teams.name,
+      ownerId: schema.teams.ownerId,
+      inviteCode: schema.teams.inviteCode,
+      createdAt: schema.teams.createdAt,
+      role: schema.teamMembers.role,
+    })
+    .from(schema.teamMembers)
+    .innerJoin(schema.teams, eq(schema.teams.id, schema.teamMembers.teamId))
+    .where(and(eq(schema.teamMembers.teamId, teamId), eq(schema.teamMembers.userId, userId)))
+    .limit(1);
+
+  if (rows.length === 0) return null;
+
+  const [count] = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(schema.teamMembers)
+    .where(eq(schema.teamMembers.teamId, teamId));
+
+  return {
+    ...rows[0],
+    memberCount: count?.count ?? 0,
+  };
+}
+
+export async function updateTeam(
+  db: ReturnType<typeof createDb>,
+  teamId: string,
+  name: string
+): Promise<TeamRecord | null> {
+  const [updated] = await db
+    .update(schema.teams)
+    .set({ name })
+    .where(eq(schema.teams.id, teamId))
+    .returning();
+  return updated ?? null;
+}
+
+export async function deleteTeam(
+  db: ReturnType<typeof createDb>,
+  teamId: string
+): Promise<boolean> {
+  const result = await db
+    .delete(schema.teams)
+    .where(eq(schema.teams.id, teamId))
+    .returning();
+  return result.length > 0;
+}
+
+export async function joinTeamByInviteCode(
+  db: ReturnType<typeof createDb>,
+  userId: string,
+  inviteCode: string
+): Promise<TeamMemberRecord | null> {
+  const teams = await db
+    .select()
+    .from(schema.teams)
+    .where(eq(schema.teams.inviteCode, inviteCode.toUpperCase()))
+    .limit(1);
+
+  if (teams.length === 0) return null;
+  const team = teams[0];
+
+  const existing = await db
+    .select()
+    .from(schema.teamMembers)
+    .where(and(eq(schema.teamMembers.teamId, team.id), eq(schema.teamMembers.userId, userId)))
+    .limit(1);
+
+  if (existing.length > 0) return null;
+
+  const [created] = await db
+    .insert(schema.teamMembers)
+    .values({
+      id: crypto.randomUUID(),
+      teamId: team.id,
+      userId,
+      role: "member",
+      joinedAt: new Date(),
+    })
+    .returning();
+  return created;
+}
+
+export async function listTeamMembers(
+  db: ReturnType<typeof createDb>,
+  teamId: string
+): Promise<TeamMemberRecord[]> {
+  const rows = await db
+    .select({
+      id: schema.teamMembers.id,
+      teamId: schema.teamMembers.teamId,
+      userId: schema.teamMembers.userId,
+      role: schema.teamMembers.role,
+      joinedAt: schema.teamMembers.joinedAt,
+      userName: schema.users.name,
+      userEmail: schema.users.email,
+    })
+    .from(schema.teamMembers)
+    .innerJoin(schema.users, eq(schema.users.id, schema.teamMembers.userId))
+    .where(eq(schema.teamMembers.teamId, teamId))
+    .orderBy(desc(schema.teamMembers.joinedAt));
+
+  return rows.map((r) => ({
+    id: r.id,
+    teamId: r.teamId,
+    userId: r.userId,
+    role: r.role,
+    joinedAt: r.joinedAt,
+    user: {
+      id: r.userId,
+      name: r.userName,
+      email: r.userEmail,
+    },
+  }));
+}
+
+export async function updateMemberRole(
+  db: ReturnType<typeof createDb>,
+  teamId: string,
+  targetUserId: string,
+  role: TeamRoleType
+): Promise<TeamMemberRecord | null> {
+  if (role !== "owner") {
+    const target = await db
+      .select()
+      .from(schema.teamMembers)
+      .where(
+        and(eq(schema.teamMembers.teamId, teamId), eq(schema.teamMembers.userId, targetUserId))
+      )
+      .limit(1);
+    if (target.length > 0 && target[0].role === "owner") {
+      return null;
+    }
+  }
+
+  const [updated] = await db
+    .update(schema.teamMembers)
+    .set({ role })
+    .where(
+      and(eq(schema.teamMembers.teamId, teamId), eq(schema.teamMembers.userId, targetUserId))
+    )
+    .returning();
+  return updated ?? null;
+}
+
+export async function removeMember(
+  db: ReturnType<typeof createDb>,
+  teamId: string,
+  targetUserId: string
+): Promise<boolean> {
+  const target = await db
+    .select()
+    .from(schema.teamMembers)
+    .where(
+      and(eq(schema.teamMembers.teamId, teamId), eq(schema.teamMembers.userId, targetUserId))
+    )
+    .limit(1);
+  if (target.length === 0) return false;
+  if (target[0].role === "owner") return false;
+
+  const result = await db
+    .delete(schema.teamMembers)
+    .where(
+      and(
+        eq(schema.teamMembers.teamId, teamId),
+        eq(schema.teamMembers.userId, targetUserId),
+        ne(schema.teamMembers.role, "owner")
+      )
+    )
+    .returning();
+  return result.length > 0;
+}
+
+export async function leaveTeam(
+  db: ReturnType<typeof createDb>,
+  teamId: string,
+  userId: string
+): Promise<boolean> {
+  const member = await db
+    .select()
+    .from(schema.teamMembers)
+    .where(and(eq(schema.teamMembers.teamId, teamId), eq(schema.teamMembers.userId, userId)))
+    .limit(1);
+  if (member.length === 0) return false;
+  if (member[0].role === "owner") return false;
+
+  await db
+    .delete(schema.teamMembers)
+    .where(and(eq(schema.teamMembers.teamId, teamId), eq(schema.teamMembers.userId, userId)));
+  return true;
+}
+
+export async function getTeamMemberIds(
+  db: ReturnType<typeof createDb>,
+  teamId: string
+): Promise<string[]> {
+  const rows = await db
+    .select({ userId: schema.teamMembers.userId })
+    .from(schema.teamMembers)
+    .where(eq(schema.teamMembers.teamId, teamId));
+  return rows.map((r) => r.userId);
+}

--- a/drizzle/migrations/0011_add_teams_tables.sql
+++ b/drizzle/migrations/0011_add_teams_tables.sql
@@ -1,0 +1,28 @@
+-- Teams and team members tables
+-- Teams have an owner; members join via invite code
+
+CREATE TABLE `teams` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`ownerId` text NOT NULL,
+	`inviteCode` text NOT NULL,
+	`createdAt` integer NOT NULL,
+	FOREIGN KEY (`ownerId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `teams_inviteCode_unique` ON `teams` (`inviteCode`);--> statement-breakpoint
+CREATE INDEX `teams_ownerId_idx` ON `teams` (`ownerId`);--> statement-breakpoint
+CREATE INDEX `teams_inviteCode_idx` ON `teams` (`inviteCode`);--> statement-breakpoint
+CREATE TABLE `team_members` (
+	`id` text PRIMARY KEY NOT NULL,
+	`teamId` text NOT NULL,
+	`userId` text NOT NULL,
+	`role` text NOT NULL DEFAULT 'member',
+	`joinedAt` integer NOT NULL,
+	FOREIGN KEY (`teamId`) REFERENCES `teams`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `team_members_teamId_idx` ON `team_members` (`teamId`);--> statement-breakpoint
+CREATE INDEX `team_members_userId_idx` ON `team_members` (`userId`);--> statement-breakpoint
+CREATE UNIQUE INDEX `team_members_teamId_userId_unique_idx` ON `team_members` (`teamId`,`userId`);

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -23,6 +23,7 @@ export default function Navbar() {
     { href: "/generate", label: m.generate() },
     { href: "/history", label: m.history_title?.() || "生成历史" },
     { href: "/favorites", label: m.favorites_title?.() || "我的收藏" },
+    { href: "/teams", label: "团队" },
     { href: "/stats", label: m.stats_title?.() || "统计" },
     { href: "/api-keys", label: "API Keys" },
     { href: "/metrics", label: "性能监控" },

--- a/frontend/src/components/teams/TeamDetailPage.tsx
+++ b/frontend/src/components/teams/TeamDetailPage.tsx
@@ -1,0 +1,282 @@
+/**
+ * TeamDetailPage Component
+ *
+ * Team detail with member management
+ */
+
+"use client";
+
+import { useState } from "react";
+import { useTeam, type TeamMember, type TeamRole } from "@/hooks/useTeams";
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleString("zh-CN", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+}
+
+const ROLE_LABELS: Record<TeamRole, string> = {
+  owner: "所有者",
+  admin: "管理员",
+  member: "成员",
+};
+
+const ROLE_COLORS: Record<TeamRole, string> = {
+  owner: "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300",
+  admin: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
+  member: "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300",
+};
+
+export default function TeamDetailPage({ teamId }: { teamId: string }) {
+  const { team, loading, error, updateName, updateMemberRole, removeMember, leaveTeam, deleteTeam } =
+    useTeam(teamId);
+  const [editingName, setEditingName] = useState(false);
+  const [nameInput, setNameInput] = useState("");
+  const [confirmAction, setConfirmAction] = useState<"leave" | "delete" | null>(null);
+
+  if (loading && !team) {
+    return <div className="text-center py-12 text-slate-500">加载中...</div>;
+  }
+
+  if (error && !team) {
+    return (
+      <div className="max-w-3xl mx-auto p-6">
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-4 rounded">
+          <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!team) return null;
+
+  const isOwner = team.role === "owner";
+  const isAdmin = team.role === "admin" || isOwner;
+  const canManageMember = (m: TeamMember) => {
+    if (m.role === "owner") return false;
+    if (isOwner) return true;
+    if (isAdmin && m.role === "member") return true;
+    return false;
+  };
+
+  const handleSaveName = async () => {
+    if (!nameInput.trim() || nameInput === team.name) {
+      setEditingName(false);
+      return;
+    }
+    const ok = await updateName(nameInput.trim());
+    if (ok) setEditingName(false);
+  };
+
+  const handleDelete = async () => {
+    const ok = await deleteTeam();
+    if (ok) window.location.href = "/teams";
+  };
+
+  const handleLeave = async () => {
+    const ok = await leaveTeam();
+    if (ok) window.location.href = "/teams";
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto p-6">
+      <div className="mb-6">
+        <a href="/teams" className="text-sm text-slate-500 hover:text-slate-700 dark:hover:text-slate-300">
+          ← 返回团队列表
+        </a>
+      </div>
+
+      <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-6 mb-4">
+        <div className="flex items-start justify-between mb-4">
+          <div className="flex-1">
+            {editingName ? (
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={nameInput}
+                  onChange={(e) => setNameInput(e.target.value)}
+                  className="flex-1 px-3 py-1.5 text-lg font-semibold border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+                  autoFocus
+                />
+                <button
+                  onClick={handleSaveName}
+                  className="px-3 py-1.5 text-sm bg-slate-900 text-white rounded"
+                >
+                  保存
+                </button>
+                <button
+                  onClick={() => setEditingName(false)}
+                  className="px-3 py-1.5 text-sm border border-slate-200 dark:border-slate-700 rounded"
+                >
+                  取消
+                </button>
+              </div>
+            ) : (
+              <div className="flex items-center gap-2">
+                <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">{team.name}</h1>
+                {isOwner && (
+                  <button
+                    onClick={() => {
+                      setNameInput(team.name);
+                      setEditingName(true);
+                    }}
+                    className="text-sm text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
+                  >
+                    编辑
+                  </button>
+                )}
+              </div>
+            )}
+            <p className="text-sm text-slate-500 mt-1">
+              {team.memberCount} 成员 · 创建于 {formatDate(team.createdAt)}
+            </p>
+          </div>
+          <span className={`px-3 py-1 text-sm rounded ${ROLE_COLORS[team.role]}`}>
+            你是 {ROLE_LABELS[team.role]}
+          </span>
+        </div>
+
+        <div className="flex items-center gap-2 text-sm bg-slate-50 dark:bg-slate-800 p-3 rounded">
+          <span className="text-slate-500">邀请码:</span>
+          <code className="font-mono text-slate-900 dark:text-slate-100">{team.inviteCode}</code>
+          <button
+            onClick={async () => {
+              try {
+                await navigator.clipboard.writeText(team.inviteCode);
+              } catch {
+                /* ignore */
+              }
+            }}
+            className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            复制
+          </button>
+        </div>
+
+        <div className="flex gap-2 mt-4">
+          {!isOwner && (
+            <button
+              onClick={() => setConfirmAction("leave")}
+              className="px-3 py-1.5 text-sm border border-slate-200 dark:border-slate-700 rounded hover:bg-slate-50 dark:hover:bg-slate-800"
+            >
+              退出团队
+            </button>
+          )}
+          {isOwner && (
+            <button
+              onClick={() => setConfirmAction("delete")}
+              className="px-3 py-1.5 text-sm text-red-600 dark:text-red-400 border border-red-200 dark:border-red-800 rounded hover:bg-red-50 dark:hover:bg-red-900/20"
+            >
+              解散团队
+            </button>
+          )}
+        </div>
+      </div>
+
+      <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-3">成员</h2>
+      <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-50 dark:bg-slate-800 text-xs uppercase text-slate-500">
+            <tr>
+              <th className="px-4 py-3 text-left">用户</th>
+              <th className="px-4 py-3 text-left">角色</th>
+              <th className="px-4 py-3 text-left">加入时间</th>
+              <th className="px-4 py-3 text-right w-32">操作</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-200 dark:divide-slate-700">
+            {team.members.map((m) => (
+              <tr key={m.id} className="hover:bg-slate-50 dark:hover:bg-slate-800/50">
+                <td className="px-4 py-3">
+                  <div className="text-slate-900 dark:text-slate-100">
+                    {m.user?.name ?? "(未命名)"}
+                  </div>
+                  <div className="text-xs text-slate-500">{m.user?.email}</div>
+                </td>
+                <td className="px-4 py-3">
+                  {isOwner && m.role !== "owner" ? (
+                    <select
+                      value={m.role}
+                      onChange={async (e) => {
+                        await updateMemberRole(m.userId, e.target.value as "admin" | "member");
+                      }}
+                      className={`px-2 py-0.5 text-xs rounded ${ROLE_COLORS[m.role]}`}
+                    >
+                      <option value="admin">admin</option>
+                      <option value="member">member</option>
+                    </select>
+                  ) : (
+                    <span className={`px-2 py-0.5 text-xs rounded ${ROLE_COLORS[m.role]}`}>
+                      {ROLE_LABELS[m.role]}
+                    </span>
+                  )}
+                </td>
+                <td className="px-4 py-3 text-slate-500 text-xs">{formatDate(m.joinedAt)}</td>
+                <td className="px-4 py-3 text-right">
+                  {canManageMember(m) && (
+                    <button
+                      onClick={async () => {
+                        if (confirm(`确定移除 ${m.user?.name ?? m.user?.email}?`)) {
+                          await removeMember(m.userId);
+                        }
+                      }}
+                      className="text-xs text-slate-500 hover:text-red-500"
+                    >
+                      移除
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-4">
+        <a
+          href={`/teams/${teamId}/generations`}
+          className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          查看团队生成历史 →
+        </a>
+      </div>
+
+      {confirmAction && (
+        <div
+          className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
+          onClick={() => setConfirmAction(null)}
+        >
+          <div
+            className="bg-white dark:bg-slate-900 rounded-lg shadow-xl max-w-sm w-full p-6"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-2">
+              {confirmAction === "delete" ? "解散团队" : "退出团队"}
+            </h2>
+            <p className="text-sm text-slate-500 mb-4">
+              {confirmAction === "delete"
+                ? "解散后所有成员将失去访问权限，且无法恢复。确定继续？"
+                : "退出后将无法访问该团队的生成历史。确定继续？"}
+            </p>
+            <div className="flex gap-2 justify-end">
+              <button
+                onClick={() => setConfirmAction(null)}
+                className="px-4 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded"
+              >
+                取消
+              </button>
+              <button
+                onClick={confirmAction === "delete" ? handleDelete : handleLeave}
+                className="px-4 py-2 text-sm bg-red-600 text-white rounded hover:bg-red-700"
+              >
+                确认
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/teams/TeamsPage.tsx
+++ b/frontend/src/components/teams/TeamsPage.tsx
@@ -1,0 +1,240 @@
+/**
+ * TeamsPage Component
+ *
+ * List user's teams and create / join new ones
+ */
+
+"use client";
+
+import { useState } from "react";
+import { useTeams, type Team } from "@/hooks/useTeams";
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleDateString("zh-CN", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+}
+
+const ROLE_LABELS: Record<Team["role"], string> = {
+  owner: "所有者",
+  admin: "管理员",
+  member: "成员",
+};
+
+const ROLE_COLORS: Record<Team["role"], string> = {
+  owner: "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300",
+  admin: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
+  member: "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300",
+};
+
+function CopyableCode({ code }: { code: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      onClick={async () => {
+        try {
+          await navigator.clipboard.writeText(code);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        } catch {
+          /* ignore */
+        }
+      }}
+      className="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-mono bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 rounded"
+    >
+      <code>{code}</code>
+      <span className="text-slate-500">{copied ? "✓" : "📋"}</span>
+    </button>
+  );
+}
+
+export default function TeamsPage() {
+  const { teams, loading, error, createTeam, joinTeam } = useTeams();
+  const [showCreate, setShowCreate] = useState(false);
+  const [showJoin, setShowJoin] = useState(false);
+  const [name, setName] = useState("");
+  const [inviteCode, setInviteCode] = useState("");
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+    const team = await createTeam(name.trim());
+    if (team) {
+      setShowCreate(false);
+      setName("");
+    }
+  };
+
+  const handleJoin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!inviteCode.trim()) return;
+    const ok = await joinTeam(inviteCode.trim());
+    if (ok) {
+      setShowJoin(false);
+      setInviteCode("");
+    }
+  };
+
+  return (
+    <div className="max-w-5xl mx-auto p-6">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">团队</h1>
+          <p className="text-sm text-slate-500 mt-1">协作共享生成历史</p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={() => setShowJoin(true)}
+            className="px-3 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded hover:bg-slate-50 dark:hover:bg-slate-800"
+          >
+            加入团队
+          </button>
+          <button
+            onClick={() => setShowCreate(true)}
+            className="px-3 py-2 text-sm bg-slate-900 text-white rounded hover:bg-slate-800"
+          >
+            + 创建团队
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-3 rounded mb-4">
+          <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
+        </div>
+      )}
+
+      {loading && teams.length === 0 ? (
+        <div className="text-center py-12 text-slate-500">加载中...</div>
+      ) : teams.length === 0 ? (
+        <div className="text-center py-12 text-slate-500">
+          <p>还没有加入任何团队</p>
+          <p className="text-xs mt-1">创建或加入团队开始协作</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {teams.map((team) => (
+            <a
+              key={team.id}
+              href={`/teams/${team.id}`}
+              className="block bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-4 hover:border-slate-400 dark:hover:border-slate-500 transition-colors"
+            >
+              <div className="flex items-start justify-between mb-2">
+                <h3 className="font-semibold text-slate-900 dark:text-slate-100">
+                  {team.name}
+                </h3>
+                <span className={`px-2 py-0.5 text-xs rounded ${ROLE_COLORS[team.role]}`}>
+                  {ROLE_LABELS[team.role]}
+                </span>
+              </div>
+              <p className="text-xs text-slate-500 mb-2">
+                {team.memberCount} 成员 · 创建于 {formatDate(team.createdAt)}
+              </p>
+              <div className="flex items-center gap-2 text-xs">
+                <span className="text-slate-500">邀请码:</span>
+                <CopyableCode code={team.inviteCode} />
+              </div>
+            </a>
+          ))}
+        </div>
+      )}
+
+      {showCreate && (
+        <div
+          className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
+          onClick={() => setShowCreate(false)}
+        >
+          <form
+            onSubmit={handleCreate}
+            className="bg-white dark:bg-slate-900 rounded-lg shadow-xl max-w-md w-full p-6"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-4">
+              创建团队
+            </h2>
+            <div className="mb-4">
+              <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+                团队名称
+              </label>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="如：电商产品组"
+                className="w-full px-3 py-2 border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+                maxLength={100}
+                required
+                autoFocus
+              />
+            </div>
+            <div className="flex gap-2 justify-end">
+              <button
+                type="button"
+                onClick={() => setShowCreate(false)}
+                className="px-4 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded"
+              >
+                取消
+              </button>
+              <button
+                type="submit"
+                disabled={!name.trim()}
+                className="px-4 py-2 text-sm bg-slate-900 text-white rounded hover:bg-slate-800 disabled:opacity-50"
+              >
+                创建
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {showJoin && (
+        <div
+          className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
+          onClick={() => setShowJoin(false)}
+        >
+          <form
+            onSubmit={handleJoin}
+            className="bg-white dark:bg-slate-900 rounded-lg shadow-xl max-w-md w-full p-6"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-4">
+              加入团队
+            </h2>
+            <div className="mb-4">
+              <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+                邀请码
+              </label>
+              <input
+                type="text"
+                value={inviteCode}
+                onChange={(e) => setInviteCode(e.target.value.toUpperCase())}
+                placeholder="TEAM-XXXXXXXX"
+                className="w-full px-3 py-2 border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800 font-mono"
+                required
+                autoFocus
+              />
+            </div>
+            <div className="flex gap-2 justify-end">
+              <button
+                type="button"
+                onClick={() => setShowJoin(false)}
+                className="px-4 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded"
+              >
+                取消
+              </button>
+              <button
+                type="submit"
+                disabled={!inviteCode.trim()}
+                className="px-4 py-2 text-sm bg-slate-900 text-white rounded hover:bg-slate-800 disabled:opacity-50"
+              >
+                加入
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useTeams.ts
+++ b/frontend/src/hooks/useTeams.ts
@@ -1,0 +1,207 @@
+/**
+ * useTeams Hook
+ */
+
+import { useState, useEffect, useCallback } from "react";
+
+export type TeamRole = "owner" | "admin" | "member";
+
+export interface Team {
+  id: string;
+  name: string;
+  ownerId: string;
+  inviteCode: string;
+  createdAt: string;
+  role: TeamRole;
+  memberCount: number;
+}
+
+export interface TeamMember {
+  id: string;
+  teamId: string;
+  userId: string;
+  role: TeamRole;
+  joinedAt: string;
+  user?: {
+    id: string;
+    name: string | null;
+    email: string;
+  };
+}
+
+export interface TeamDetail extends Team {
+  members: TeamMember[];
+}
+
+async function api<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, { credentials: "include", ...init });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data.error ?? `Request failed: ${res.status}`);
+  }
+  const json = await res.json();
+  if (!json.success) throw new Error(json.error ?? "Request failed");
+  return json.data as T;
+}
+
+export function useTeams() {
+  const [teams, setTeams] = useState<Team[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchTeams = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await api<Team[]>("/api/teams");
+      setTeams(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load teams");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchTeams();
+  }, [fetchTeams]);
+
+  const createTeam = useCallback(
+    async (name: string): Promise<Team | null> => {
+      try {
+        const team = await api<Team>("/api/teams", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name }),
+        });
+        await fetchTeams();
+        return team;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to create team");
+        return null;
+      }
+    },
+    [fetchTeams]
+  );
+
+  const joinTeam = useCallback(
+    async (inviteCode: string): Promise<boolean> => {
+      try {
+        await api(`/api/teams/any/join`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ inviteCode }),
+        });
+        await fetchTeams();
+        return true;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to join team");
+        return false;
+      }
+    },
+    [fetchTeams]
+  );
+
+  return { teams, loading, error, refetch: fetchTeams, createTeam, joinTeam };
+}
+
+export function useTeam(teamId: string | null) {
+  const [team, setTeam] = useState<TeamDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchTeam = useCallback(async () => {
+    if (!teamId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await api<TeamDetail>(`/api/teams/${teamId}`);
+      setTeam(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load team");
+    } finally {
+      setLoading(false);
+    }
+  }, [teamId]);
+
+  useEffect(() => {
+    fetchTeam();
+  }, [fetchTeam]);
+
+  const updateName = useCallback(
+    async (name: string): Promise<boolean> => {
+      if (!teamId) return false;
+      try {
+        await api(`/api/teams/${teamId}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name }),
+        });
+        await fetchTeam();
+        return true;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to update");
+        return false;
+      }
+    },
+    [teamId, fetchTeam]
+  );
+
+  const updateMemberRole = useCallback(
+    async (userId: string, role: "admin" | "member"): Promise<boolean> => {
+      if (!teamId) return false;
+      try {
+        await api(`/api/teams/${teamId}/members/${userId}/role`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ role }),
+        });
+        await fetchTeam();
+        return true;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to update role");
+        return false;
+      }
+    },
+    [teamId, fetchTeam]
+  );
+
+  const removeMember = useCallback(
+    async (userId: string): Promise<boolean> => {
+      if (!teamId) return false;
+      try {
+        await api(`/api/teams/${teamId}/members/${userId}`, { method: "DELETE" });
+        await fetchTeam();
+        return true;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to remove");
+        return false;
+      }
+    },
+    [teamId, fetchTeam]
+  );
+
+  const leaveTeam = useCallback(async (): Promise<boolean> => {
+    if (!teamId) return false;
+    try {
+      await api(`/api/teams/${teamId}/leave`, { method: "POST" });
+      return true;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to leave");
+      return false;
+    }
+  }, [teamId]);
+
+  const deleteTeam = useCallback(async (): Promise<boolean> => {
+    if (!teamId) return false;
+    try {
+      await api(`/api/teams/${teamId}`, { method: "DELETE" });
+      return true;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete");
+      return false;
+    }
+  }, [teamId]);
+
+  return { team, loading, error, refetch: fetchTeam, updateName, updateMemberRole, removeMember, leaveTeam, deleteTeam };
+}

--- a/frontend/src/pages/teams.astro
+++ b/frontend/src/pages/teams.astro
@@ -1,0 +1,8 @@
+---
+import Layout from '../layouts/Layout.astro';
+import TeamsPage from '../components/teams/TeamsPage';
+---
+
+<Layout title="团队">
+  <TeamsPage client:load />
+</Layout>

--- a/frontend/src/pages/teams/[id].astro
+++ b/frontend/src/pages/teams/[id].astro
@@ -1,0 +1,12 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import TeamDetailPage from '../../components/teams/TeamDetailPage';
+
+export const prerender = false;
+
+const { id } = Astro.params;
+---
+
+<Layout title="团队详情">
+  <TeamDetailPage teamId={id ?? ''} client:load />
+</Layout>

--- a/packages/types/src/schema.ts
+++ b/packages/types/src/schema.ts
@@ -621,3 +621,65 @@ export const apiKeys = sqliteTable("api_keys", {
   keyHashIdx: index("api_keys_keyHash_idx").on(table.keyHash),
 }));
 
+/**
+ * 团队角色枚举
+ */
+export const TeamRole = {
+  OWNER: "owner",
+  ADMIN: "admin",
+  MEMBER: "member",
+} as const;
+
+export type TeamRoleType = typeof TeamRole[keyof typeof TeamRole];
+
+/**
+ * 团队表
+ */
+export const teams = sqliteTable("teams", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  // 团队名称
+  name: text("name").notNull(),
+  // 团队所有者（创建者）
+  ownerId: text("ownerId")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  // 邀请码（如 "TEAM-A1B2C3"）
+  inviteCode: text("inviteCode").notNull().unique(),
+  createdAt: integer("createdAt", { mode: "timestamp_ms" })
+    .notNull()
+    .default(sql`(strftime('%s', 'now') * 1000)`),
+}, (table) => ({
+  ownerIdIdx: index("teams_ownerId_idx").on(table.ownerId),
+  inviteCodeIdx: index("teams_inviteCode_idx").on(table.inviteCode),
+}));
+
+/**
+ * 团队成员表
+ */
+export const teamMembers = sqliteTable("team_members", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  teamId: text("teamId")
+    .notNull()
+    .references(() => teams.id, { onDelete: "cascade" }),
+  userId: text("userId")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  role: text("role", {
+    enum: ["owner", "admin", "member"],
+  })
+    .notNull()
+    .default("member"),
+  joinedAt: integer("joinedAt", { mode: "timestamp_ms" })
+    .notNull()
+    .default(sql`(strftime('%s', 'now') * 1000)`),
+}, (table) => ({
+  teamIdIdx: index("team_members_teamId_idx").on(table.teamId),
+  userIdIdx: index("team_members_userId_idx").on(table.userId),
+  // Unique constraint on (teamId, userId) is implicit via primary keys? No — must add explicit unique index
+  teamUserUniqueIdx: index("team_members_teamId_userId_unique_idx").on(table.teamId, table.userId),
+}));
+


### PR DESCRIPTION
## Feature #15: 团队协作 - P0

实现团队创建 + 成员管理 + 团队生成历史共享。

## Database
- `teams` 表（5 字段 + 3 索引）
- `team_members` 表（5 字段 + 3 索引，含 unique teamId+userId）
- 3 个角色：owner / admin / member
- inviteCode 格式：`TEAM-XXXXXXXX`（5 次重试防冲突）
- Migration: `drizzle/migrations/0011_add_teams_tables.sql`

## 权限模型
- **owner**：解散团队、改名、管理所有成员
- **admin**：管理 member、移除 member
- **member**：查看历史、退出
- 关键不变量：owner 角色和成员关系不可被非 owner 修改

## API（10 个端点）
- `POST /api/teams` — 创建
- `GET /api/teams` — 列出我的团队（含 role 和 memberCount）
- `GET /api/teams/:id` — 详情 + 成员列表
- `PUT /api/teams/:id` — 改名（owner）
- `DELETE /api/teams/:id` — 解散（owner）
- `POST /api/teams/:id/join` — 通过邀请码加入
- `POST /api/teams/:id/leave` — 退出（非 owner）
- `PUT /api/teams/:id/members/:userId/role` — 改角色（owner 可改任何人，admin 只能改 member）
- `DELETE /api/teams/:id/members/:userId` — 移除成员（admin+）
- `GET /api/teams/:id/generations` — 团队生成历史（所有成员可见，分页）

## Frontend
- `/teams` — 团队列表 + 创建/加入弹窗
- `/teams/[id]` — 详情 + 成员管理 + 改名 + 退出/解散
- 角色徽章、邀请码复制、危险操作二次确认
- Navbar 集成

## 验证
- ✅ typecheck (api + frontend) 通过
- ✅ lint (api + frontend) 通过
- ✅ frontend build 通过
- ✅ pnpm typegen (api) 通过

## 备注
- P1+ 留到后续：邮件邀请、审批流程、评论、模板共享、活动日志