### PR TITLE
feat: add competitor tracking (Feature #19 - P0)

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -22,6 +22,7 @@ import errorRoutes from "./routes/errors";
 import metricRoutes from "./routes/metrics";
 import apiKeyRoutes from "./routes/keys";
 import teamRoutes from "./routes/teams";
+import competitorRoutes from "./routes/competitors";
 import v1Routes from "./routes/v1";
 import { stripeWebhookRoutes } from "./routes/webhooks/stripe";
 import { authMiddleware } from "./middleware/auth";
@@ -112,6 +113,7 @@ app.route("/api/errors", errorRoutes);
 app.route("/api/metrics", metricRoutes);
 app.route("/api/keys", apiKeyRoutes);
 app.route("/api/teams", teamRoutes);
+app.route("/api/competitors", competitorRoutes);
 app.route("/api/v1", v1Routes);
 app.route("/api/webhooks", stripeWebhookRoutes);
 

--- a/api/src/routes/competitors.ts
+++ b/api/src/routes/competitors.ts
@@ -1,0 +1,166 @@
+/**
+ * Competitors Routes
+ *
+ * Manual tracking of competitor products. P0: CRUD only.
+ */
+
+import { Hono } from "hono";
+import { z } from "zod";
+import { zValidator } from "@hono/zod-validator";
+import { createDb, schema } from "@oura-pix/database";
+import { eq, and, desc } from "drizzle-orm";
+import { getUser } from "../middleware/auth";
+
+const competitors = new Hono<{
+  Bindings: {
+    DB: D1Database;
+  };
+  Variables: {
+    user: { id: string; email: string; name?: string | null };
+    session: { id: string; expiresAt: Date };
+  };
+}>();
+
+const PLATFORMS = ["amazon", "shopify", "etsy", "ebay", "taobao", "jd", "tmall", "self", "other"] as const;
+
+const createSchema = z.object({
+  name: z.string().min(1).max(200),
+  url: z.string().url().max(2000),
+  platform: z.enum(PLATFORMS).default("other"),
+  notes: z.string().max(2000).optional(),
+  screenshots: z.array(z.string().url()).max(20).optional(),
+});
+
+const updateSchema = createSchema.partial();
+
+function parseScreenshots(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((x) => typeof x === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function toResponse(row: typeof schema.competitors.$inferSelect) {
+  return {
+    id: row.id,
+    name: row.name,
+    url: row.url,
+    platform: row.platform,
+    notes: row.notes,
+    screenshots: parseScreenshots(row.screenshots),
+    createdAt: row.createdAt,
+  };
+}
+
+/**
+ * GET /api/competitors
+ */
+competitors.get("/", async (c) => {
+  const user = await getUser(c);
+  if (!user) return c.json({ error: "Unauthorized" }, 401);
+
+  try {
+    const db = createDb(c.env.DB);
+    const rows = await db
+      .select()
+      .from(schema.competitors)
+      .where(eq(schema.competitors.userId, user.id))
+      .orderBy(desc(schema.competitors.createdAt));
+    return c.json({ success: true, data: rows.map(toResponse) });
+  } catch (error) {
+    console.error("Failed to list competitors:", error);
+    return c.json({ error: "Failed to list competitors" }, 500);
+  }
+});
+
+/**
+ * POST /api/competitors
+ */
+competitors.post("/", zValidator("json", createSchema), async (c) => {
+  const user = await getUser(c);
+  if (!user) return c.json({ error: "Unauthorized" }, 401);
+
+  const input = c.req.valid("json");
+
+  try {
+    const db = createDb(c.env.DB);
+    const [created] = await db
+      .insert(schema.competitors)
+      .values({
+        id: crypto.randomUUID(),
+        userId: user.id,
+        name: input.name,
+        url: input.url,
+        platform: input.platform,
+        notes: input.notes ?? null,
+        screenshots: JSON.stringify(input.screenshots ?? []),
+        createdAt: new Date(),
+      })
+      .returning();
+    return c.json({ success: true, data: toResponse(created) }, 201);
+  } catch (error) {
+    console.error("Failed to create competitor:", error);
+    return c.json({ error: "Failed to create competitor" }, 500);
+  }
+});
+
+/**
+ * PUT /api/competitors/:id
+ */
+competitors.put("/:id", zValidator("json", updateSchema), async (c) => {
+  const user = await getUser(c);
+  if (!user) return c.json({ error: "Unauthorized" }, 401);
+
+  const id = c.req.param("id");
+  const input = c.req.valid("json");
+
+  try {
+    const db = createDb(c.env.DB);
+    const update: Partial<typeof schema.competitors.$inferInsert> = {};
+    if (input.name !== undefined) update.name = input.name;
+    if (input.url !== undefined) update.url = input.url;
+    if (input.platform !== undefined) update.platform = input.platform;
+    if (input.notes !== undefined) update.notes = input.notes;
+    if (input.screenshots !== undefined) update.screenshots = JSON.stringify(input.screenshots);
+
+    const [updated] = await db
+      .update(schema.competitors)
+      .set(update)
+      .where(and(eq(schema.competitors.id, id), eq(schema.competitors.userId, user.id)))
+      .returning();
+
+    if (!updated) return c.json({ error: "Not found" }, 404);
+    return c.json({ success: true, data: toResponse(updated) });
+  } catch (error) {
+    console.error("Failed to update competitor:", error);
+    return c.json({ error: "Failed to update competitor" }, 500);
+  }
+});
+
+/**
+ * DELETE /api/competitors/:id
+ */
+competitors.delete("/:id", async (c) => {
+  const user = await getUser(c);
+  if (!user) return c.json({ error: "Unauthorized" }, 401);
+
+  const id = c.req.param("id");
+
+  try {
+    const db = createDb(c.env.DB);
+    const result = await db
+      .delete(schema.competitors)
+      .where(and(eq(schema.competitors.id, id), eq(schema.competitors.userId, user.id)))
+      .returning();
+    if (result.length === 0) return c.json({ error: "Not found" }, 404);
+    return c.json({ success: true });
+  } catch (error) {
+    console.error("Failed to delete competitor:", error);
+    return c.json({ error: "Failed to delete competitor" }, 500);
+  }
+});
+
+export default competitors;

--- a/drizzle/migrations/0012_add_competitors_table.sql
+++ b/drizzle/migrations/0012_add_competitors_table.sql
@@ -1,0 +1,18 @@
+-- Competitors table
+-- Manual tracking of competitor products for reference
+
+CREATE TABLE `competitors` (
+	`id` text PRIMARY KEY NOT NULL,
+	`userId` text NOT NULL,
+	`name` text NOT NULL,
+	`platform` text NOT NULL DEFAULT 'other',
+	`url` text NOT NULL,
+	`screenshots` text NOT NULL DEFAULT '[]',
+	`notes` text,
+	`createdAt` integer NOT NULL,
+	FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `competitors_userId_idx` ON `competitors` (`userId`);--> statement-breakpoint
+CREATE INDEX `competitors_platform_idx` ON `competitors` (`platform`);--> statement-breakpoint
+CREATE INDEX `competitors_createdAt_idx` ON `competitors` (`createdAt`);

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -24,6 +24,7 @@ export default function Navbar() {
     { href: "/history", label: m.history_title?.() || "生成历史" },
     { href: "/favorites", label: m.favorites_title?.() || "我的收藏" },
     { href: "/teams", label: "团队" },
+    { href: "/competitors", label: "竞品" },
     { href: "/stats", label: m.stats_title?.() || "统计" },
     { href: "/api-keys", label: "API Keys" },
     { href: "/metrics", label: "性能监控" },

--- a/frontend/src/components/competitors/CompetitorsPage.tsx
+++ b/frontend/src/components/competitors/CompetitorsPage.tsx
@@ -1,0 +1,325 @@
+/**
+ * CompetitorsPage Component
+ */
+
+"use client";
+
+import { useState } from "react";
+import { useCompetitors, PLATFORM_LABELS, type Platform, type Competitor } from "@/hooks/useCompetitors";
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleDateString("zh-CN", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+}
+
+function CompetitorForm({
+  initial,
+  onSubmit,
+  onCancel,
+}: {
+  initial?: Competitor;
+  onSubmit: (data: Omit<Competitor, "id" | "createdAt">) => Promise<void>;
+  onCancel: () => void;
+}) {
+  const [name, setName] = useState(initial?.name ?? "");
+  const [url, setUrl] = useState(initial?.url ?? "");
+  const [platform, setPlatform] = useState<Platform>(initial?.platform ?? "amazon");
+  const [notes, setNotes] = useState(initial?.notes ?? "");
+  const [screenshotInput, setScreenshotInput] = useState("");
+  const [screenshots, setScreenshots] = useState<string[]>(initial?.screenshots ?? []);
+  const [submitting, setSubmitting] = useState(false);
+
+  const addScreenshot = () => {
+    const trimmed = screenshotInput.trim();
+    if (!trimmed) return;
+    try {
+      new URL(trimmed);
+      setScreenshots((prev) => [...prev, trimmed]);
+      setScreenshotInput("");
+    } catch {
+      alert("请输入有效的 URL");
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim() || !url.trim()) return;
+    setSubmitting(true);
+    await onSubmit({
+      name: name.trim(),
+      url: url.trim(),
+      platform,
+      notes: notes.trim() || null,
+      screenshots,
+    });
+    setSubmitting(false);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4" onClick={(e) => e.stopPropagation()}>
+      <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+        {initial ? "编辑竞品" : "添加竞品"}
+      </h2>
+
+      <div>
+        <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+          名称
+        </label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="如：Anker Soundcore 旗舰店"
+          className="w-full px-3 py-2 border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+          maxLength={200}
+          required
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+          链接
+        </label>
+        <input
+          type="url"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://..."
+          className="w-full px-3 py-2 border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+          maxLength={2000}
+          required
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+          平台
+        </label>
+        <select
+          value={platform}
+          onChange={(e) => setPlatform(e.target.value as Platform)}
+          className="w-full px-3 py-2 border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+        >
+          {Object.entries(PLATFORM_LABELS).map(([key, label]) => (
+            <option key={key} value={key}>
+              {label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+          笔记
+        </label>
+        <textarea
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          placeholder="可记录差异化点、定价、风格观察等"
+          rows={3}
+          className="w-full px-3 py-2 border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+          maxLength={2000}
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+          截图 URL（每行一个，最多 20 个）
+        </label>
+        <div className="flex gap-2 mb-2">
+          <input
+            type="url"
+            value={screenshotInput}
+            onChange={(e) => setScreenshotInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                addScreenshot();
+              }
+            }}
+            placeholder="https://... 回车添加"
+            className="flex-1 px-3 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+          />
+          <button
+            type="button"
+            onClick={addScreenshot}
+            className="px-3 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded"
+          >
+            添加
+          </button>
+        </div>
+        {screenshots.length > 0 && (
+          <div className="space-y-1">
+            {screenshots.map((s, i) => (
+              <div key={i} className="flex items-center gap-2 text-xs bg-slate-50 dark:bg-slate-800 p-2 rounded">
+                <span className="flex-1 truncate font-mono text-slate-600 dark:text-slate-400">{s}</span>
+                <button
+                  type="button"
+                  onClick={() => setScreenshots((prev) => prev.filter((_, idx) => idx !== i))}
+                  className="text-slate-400 hover:text-red-500"
+                >
+                  ✕
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="flex gap-2 justify-end pt-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-4 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded"
+        >
+          取消
+        </button>
+        <button
+          type="submit"
+          disabled={!name.trim() || !url.trim() || submitting}
+          className="px-4 py-2 text-sm bg-slate-900 text-white rounded hover:bg-slate-800 disabled:opacity-50"
+        >
+          {submitting ? "保存中..." : "保存"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+export default function CompetitorsPage() {
+  const { competitors, loading, error, createCompetitor, updateCompetitor, deleteCompetitor } = useCompetitors();
+  const [showForm, setShowForm] = useState(false);
+  const [editing, setEditing] = useState<Competitor | null>(null);
+
+  return (
+    <div className="max-w-5xl mx-auto p-6">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">竞品分析</h1>
+          <p className="text-sm text-slate-500 mt-1">记录竞品链接、平台和笔记</p>
+        </div>
+        <button
+          onClick={() => {
+            setEditing(null);
+            setShowForm(true);
+          }}
+          className="px-4 py-2 bg-slate-900 text-white text-sm rounded hover:bg-slate-800"
+        >
+          + 添加竞品
+        </button>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-3 rounded mb-4">
+          <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
+        </div>
+      )}
+
+      {loading && competitors.length === 0 ? (
+        <div className="text-center py-12 text-slate-500">加载中...</div>
+      ) : competitors.length === 0 ? (
+        <div className="text-center py-12 text-slate-500">
+          <p>还没有竞品记录</p>
+          <p className="text-xs mt-1">点击右上角添加第一个</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {competitors.map((c) => (
+            <div
+              key={c.id}
+              className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-4"
+            >
+              <div className="flex items-start justify-between mb-2">
+                <div className="flex-1 min-w-0">
+                  <h3 className="font-semibold text-slate-900 dark:text-slate-100 truncate">{c.name}</h3>
+                  <a
+                    href={c.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-xs text-blue-600 dark:text-blue-400 hover:underline truncate block"
+                  >
+                    {c.url}
+                  </a>
+                </div>
+                <span className="px-2 py-0.5 text-xs rounded bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 ml-2 flex-shrink-0">
+                  {PLATFORM_LABELS[c.platform]}
+                </span>
+              </div>
+              {c.notes && (
+                <p className="text-sm text-slate-600 dark:text-slate-400 mb-2 whitespace-pre-wrap">
+                  {c.notes}
+                </p>
+              )}
+              {c.screenshots.length > 0 && (
+                <div className="grid grid-cols-4 gap-2 mb-2">
+                  {c.screenshots.slice(0, 4).map((s, i) => (
+                    <a
+                      key={i}
+                      href={s}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="block aspect-square bg-slate-100 dark:bg-slate-800 rounded overflow-hidden"
+                    >
+                      <img src={s} alt={`Screenshot ${i + 1}`} className="w-full h-full object-cover" loading="lazy" />
+                    </a>
+                  ))}
+                </div>
+              )}
+              <div className="flex items-center justify-between pt-2 border-t border-slate-100 dark:border-slate-800">
+                <span className="text-xs text-slate-500">{formatDate(c.createdAt)}</span>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => {
+                      setEditing(c);
+                      setShowForm(true);
+                    }}
+                    className="text-xs text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
+                  >
+                    编辑
+                  </button>
+                  <button
+                    onClick={async () => {
+                      if (confirm(`确定删除 "${c.name}"?`)) await deleteCompetitor(c.id);
+                    }}
+                    className="text-xs text-slate-500 hover:text-red-500"
+                  >
+                    删除
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {showForm && (
+        <div
+          className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4 overflow-y-auto"
+          onClick={() => setShowForm(false)}
+        >
+          <div className="bg-white dark:bg-slate-900 rounded-lg shadow-xl max-w-2xl w-full p-6 my-8">
+            <CompetitorForm
+              initial={editing ?? undefined}
+              onSubmit={async (data) => {
+                if (editing) {
+                  await updateCompetitor(editing.id, data);
+                } else {
+                  await createCompetitor(data);
+                }
+                setShowForm(false);
+                setEditing(null);
+              }}
+              onCancel={() => {
+                setShowForm(false);
+                setEditing(null);
+              }}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useCompetitors.ts
+++ b/frontend/src/hooks/useCompetitors.ts
@@ -1,0 +1,115 @@
+/**
+ * useCompetitors Hook
+ */
+
+import { useState, useEffect, useCallback } from "react";
+
+export type Platform = "amazon" | "shopify" | "etsy" | "ebay" | "taobao" | "jd" | "tmall" | "self" | "other";
+
+export const PLATFORM_LABELS: Record<Platform, string> = {
+  amazon: "Amazon",
+  shopify: "Shopify",
+  etsy: "Etsy",
+  ebay: "eBay",
+  taobao: "淘宝",
+  jd: "京东",
+  tmall: "天猫",
+  self: "自营网站",
+  other: "其他",
+};
+
+export interface Competitor {
+  id: string;
+  name: string;
+  url: string;
+  platform: Platform;
+  notes: string | null;
+  screenshots: string[];
+  createdAt: string;
+}
+
+async function api<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, { credentials: "include", ...init });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data.error ?? `Request failed: ${res.status}`);
+  }
+  const json = await res.json();
+  if (!json.success) throw new Error(json.error ?? "Request failed");
+  return json.data as T;
+}
+
+export function useCompetitors() {
+  const [competitors, setCompetitors] = useState<Competitor[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchCompetitors = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await api<Competitor[]>("/api/competitors");
+      setCompetitors(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load competitors");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchCompetitors();
+  }, [fetchCompetitors]);
+
+  const createCompetitor = useCallback(
+    async (input: Omit<Competitor, "id" | "createdAt">): Promise<Competitor | null> => {
+      try {
+        const created = await api<Competitor>("/api/competitors", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(input),
+        });
+        await fetchCompetitors();
+        return created;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to create");
+        return null;
+      }
+    },
+    [fetchCompetitors]
+  );
+
+  const updateCompetitor = useCallback(
+    async (id: string, input: Partial<Omit<Competitor, "id" | "createdAt">>): Promise<boolean> => {
+      try {
+        await api(`/api/competitors/${id}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(input),
+        });
+        await fetchCompetitors();
+        return true;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to update");
+        return false;
+      }
+    },
+    [fetchCompetitors]
+  );
+
+  const deleteCompetitor = useCallback(
+    async (id: string): Promise<boolean> => {
+      try {
+        await api(`/api/competitors/${id}`, { method: "DELETE" });
+        await fetchCompetitors();
+        return true;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to delete");
+        return false;
+      }
+    },
+    [fetchCompetitors]
+  );
+
+  return { competitors, loading, error, refetch: fetchCompetitors, createCompetitor, updateCompetitor, deleteCompetitor };
+}

--- a/frontend/src/pages/competitors.astro
+++ b/frontend/src/pages/competitors.astro
@@ -1,0 +1,8 @@
+---
+import Layout from '../layouts/Layout.astro';
+import CompetitorsPage from '../components/competitors/CompetitorsPage';
+---
+
+<Layout title="竞品分析">
+  <CompetitorsPage client:load />
+</Layout>

--- a/packages/types/src/schema.ts
+++ b/packages/types/src/schema.ts
@@ -683,3 +683,30 @@ export const teamMembers = sqliteTable("team_members", {
   teamUserUniqueIdx: index("team_members_teamId_userId_unique_idx").on(table.teamId, table.userId),
 }));
 
+/**
+ * 竞品表
+ *
+ * 记录用户关注的竞品链接、平台、截图和笔记。
+ * P0 范围：手动添加 + 列表 + 删除。不做抓取和 AI 分析。
+ */
+export const competitors = sqliteTable("competitors", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  userId: text("userId")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  name: text("name").notNull(),
+  platform: text("platform").notNull().default("other"),
+  url: text("url").notNull(),
+  screenshots: text("screenshots").notNull().default("[]"),
+  notes: text("notes"),
+  createdAt: integer("createdAt", { mode: "timestamp_ms" })
+    .notNull()
+    .default(sql`(strftime('%s', 'now') * 1000)`),
+}, (table) => ({
+  userIdIdx: index("competitors_userId_idx").on(table.userId),
+  platformIdx: index("competitors_platform_idx").on(table.platform),
+  createdAtIdx: index("competitors_createdAt_idx").on(table.createdAt),
+}));
+


### PR DESCRIPTION
## Feature #19: 竞品分析 - P0

手动记录竞品链接、平台、截图和笔记。

## Database
- `competitors` 表（7 字段 + 3 索引）
- 9 个平台值：amazon / shopify / etsy / ebay / taobao / jd / tmall / self / other
- Migration: `drizzle/migrations/0012_add_competitors_table.sql`

## API
- `GET /api/competitors` — 列出我的竞品
- `POST /api/competitors` — 添加
- `PUT /api/competitors/:id` — 更新
- `DELETE /api/competitors/:id` — 删除

## Frontend
- `/competitors` 卡片网格
- 添加/编辑表单：链接、平台、笔记、多 URL 截图
- 4 张缩略图预览
- 中文平台标签
- 删除二次确认
- Navbar 集成

## 验证
- ✅ typecheck / lint / build 全部通过

## P1+ 暂缓
- 网页抓取
- AI 分析报告
- 风格提取