### PR TITLE
feat: add user feedback for generations (Feature #24 - P0)

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -23,6 +23,7 @@ import metricRoutes from "./routes/metrics";
 import apiKeyRoutes from "./routes/keys";
 import teamRoutes from "./routes/teams";
 import competitorRoutes from "./routes/competitors";
+import feedbackRoutes from "./routes/feedback";
 import v1Routes from "./routes/v1";
 import { stripeWebhookRoutes } from "./routes/webhooks/stripe";
 import { authMiddleware } from "./middleware/auth";
@@ -114,6 +115,7 @@ app.route("/api/metrics", metricRoutes);
 app.route("/api/keys", apiKeyRoutes);
 app.route("/api/teams", teamRoutes);
 app.route("/api/competitors", competitorRoutes);
+app.route("/api/feedback", feedbackRoutes);
 app.route("/api/v1", v1Routes);
 app.route("/api/webhooks", stripeWebhookRoutes);
 

--- a/api/src/routes/feedback.ts
+++ b/api/src/routes/feedback.ts
@@ -1,0 +1,154 @@
+/**
+ * Feedback Routes
+ *
+ * - POST /api/feedback (auth) — submit feedback for a generation
+ * - GET  /api/feedback/stats?generationId= (auth) — aggregated stats for a generation
+ * - GET  /api/feedback?generationId= (auth) — list feedback for a generation
+ */
+
+import { Hono } from "hono";
+import { z } from "zod";
+import { zValidator } from "@hono/zod-validator";
+import { createDb, schema } from "@oura-pix/database";
+import { eq, and, count, avg, desc } from "drizzle-orm";
+import { getUser } from "../middleware/auth";
+
+const feedback = new Hono<{
+  Bindings: {
+    DB: D1Database;
+  };
+  Variables: {
+    user: { id: string; email: string; name?: string | null };
+    session: { id: string; expiresAt: Date };
+  };
+}>();
+
+const submitSchema = z.object({
+  generationId: z.string().min(1),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().max(2000).optional(),
+});
+
+/**
+ * POST /api/feedback
+ * Submit feedback for a generation
+ */
+feedback.post("/", zValidator("json", submitSchema), async (c) => {
+  const user = await getUser(c);
+  if (!user) return c.json({ error: "Unauthorized" }, 401);
+
+  const input = c.req.valid("json");
+
+  try {
+    const db = createDb(c.env.DB);
+
+    // Verify the generation belongs to this user
+    const gen = await db
+      .select({ id: schema.generations.id })
+      .from(schema.generations)
+      .where(and(eq(schema.generations.id, input.generationId), eq(schema.generations.userId, user.id)))
+      .limit(1);
+    if (gen.length === 0) {
+      return c.json({ error: "Generation not found" }, 404);
+    }
+
+    const [created] = await db
+      .insert(schema.feedback)
+      .values({
+        id: crypto.randomUUID(),
+        generationId: input.generationId,
+        userId: user.id,
+        rating: input.rating,
+        comment: input.comment ?? null,
+        createdAt: new Date(),
+      })
+      .returning();
+
+    return c.json({ success: true, data: { id: created.id } }, 201);
+  } catch (error) {
+    console.error("Failed to submit feedback:", error);
+    return c.json({ error: "Failed to submit feedback" }, 500);
+  }
+});
+
+/**
+ * GET /api/feedback?generationId=xxx
+ * List feedback for a specific generation
+ */
+feedback.get("/", async (c) => {
+  const user = await getUser(c);
+  if (!user) return c.json({ error: "Unauthorized" }, 401);
+
+  const generationId = c.req.query("generationId");
+  if (!generationId) return c.json({ error: "generationId is required" }, 400);
+
+  try {
+    const db = createDb(c.env.DB);
+    // Verify ownership
+    const gen = await db
+      .select({ id: schema.generations.id })
+      .from(schema.generations)
+      .where(and(eq(schema.generations.id, generationId), eq(schema.generations.userId, user.id)))
+      .limit(1);
+    if (gen.length === 0) {
+      return c.json({ error: "Generation not found" }, 404);
+    }
+
+    const rows = await db
+      .select()
+      .from(schema.feedback)
+      .where(eq(schema.feedback.generationId, generationId))
+      .orderBy(desc(schema.feedback.createdAt));
+
+    return c.json({ success: true, data: rows });
+  } catch (error) {
+    console.error("Failed to list feedback:", error);
+    return c.json({ error: "Failed to list feedback" }, 500);
+  }
+});
+
+/**
+ * GET /api/feedback/stats?generationId=xxx
+ * Aggregated stats: count + avg rating
+ */
+feedback.get("/stats", async (c) => {
+  const user = await getUser(c);
+  if (!user) return c.json({ error: "Unauthorized" }, 401);
+
+  const generationId = c.req.query("generationId");
+  if (!generationId) return c.json({ error: "generationId is required" }, 400);
+
+  try {
+    const db = createDb(c.env.DB);
+    const gen = await db
+      .select({ id: schema.generations.id })
+      .from(schema.generations)
+      .where(and(eq(schema.generations.id, generationId), eq(schema.generations.userId, user.id)))
+      .limit(1);
+    if (gen.length === 0) {
+      return c.json({ error: "Generation not found" }, 404);
+    }
+
+    const [agg] = await db
+      .select({
+        count: count(),
+        avgRating: avg(schema.feedback.rating),
+      })
+      .from(schema.feedback)
+      .where(eq(schema.feedback.generationId, generationId));
+
+    return c.json({
+      success: true,
+      data: {
+        generationId,
+        count: agg?.count ?? 0,
+        avgRating: agg?.avgRating ? Number(agg.avgRating) : null,
+      },
+    });
+  } catch (error) {
+    console.error("Failed to get feedback stats:", error);
+    return c.json({ error: "Failed to get feedback stats" }, 500);
+  }
+});
+
+export default feedback;

--- a/drizzle/migrations/0013_add_feedback_table.sql
+++ b/drizzle/migrations/0013_add_feedback_table.sql
@@ -1,0 +1,17 @@
+-- Feedback table
+-- User ratings (1-5) and comments for individual generations
+
+CREATE TABLE `feedback` (
+	`id` text PRIMARY KEY NOT NULL,
+	`generationId` text NOT NULL,
+	`userId` text NOT NULL,
+	`rating` integer NOT NULL,
+	`comment` text,
+	`createdAt` integer NOT NULL,
+	FOREIGN KEY (`generationId`) REFERENCES `generations`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `feedback_generationId_idx` ON `feedback` (`generationId`);--> statement-breakpoint
+CREATE INDEX `feedback_userId_idx` ON `feedback` (`userId`);--> statement-breakpoint
+CREATE INDEX `feedback_rating_idx` ON `feedback` (`rating`);

--- a/frontend/src/components/feedback/FeedbackForm.tsx
+++ b/frontend/src/components/feedback/FeedbackForm.tsx
@@ -1,0 +1,192 @@
+/**
+ * FeedbackForm Component
+ *
+ * Star rating + optional comment for a generation
+ */
+
+"use client";
+
+import { useState } from "react";
+import { useFeedback } from "@/hooks/useFeedback";
+
+interface FeedbackFormProps {
+  generationId: string;
+}
+
+function StarIcon({ filled, half }: { filled: boolean; half?: boolean }) {
+  return (
+    <svg viewBox="0 0 20 20" className="w-5 h-5">
+      <defs>
+        <linearGradient id={`half-${filled}-${half}`}>
+          <stop offset="50%" stopColor="#facc15" />
+          <stop offset="50%" stopColor="#e2e8f0" />
+        </linearGradient>
+      </defs>
+      <path
+        d="M10 1.5l2.6 5.3 5.9.9-4.3 4.1 1 5.7L10 14.9l-5.2 2.6 1-5.7L1.5 7.7l5.9-.9L10 1.5z"
+        fill={half ? `url(#half-${filled}-${half})` : filled ? "#facc15" : "#e2e8f0"}
+        stroke={filled ? "#facc15" : "#cbd5e1"}
+        strokeWidth={0.5}
+      />
+    </svg>
+  );
+}
+
+function RatingStars({ value, onChange, readonly = false }: { value: number; onChange?: (v: number) => void; readonly?: boolean }) {
+  return (
+    <div className="inline-flex gap-0.5">
+      {[1, 2, 3, 4, 5].map((n) => (
+        <button
+          key={n}
+          type="button"
+          disabled={readonly}
+          onClick={() => onChange?.(n)}
+          onMouseEnter={(e) => {
+            if (readonly) return;
+            const buttons = e.currentTarget.parentElement?.querySelectorAll("button");
+            buttons?.forEach((b, i) => {
+              const star = b.querySelector("path");
+              if (!star) return;
+              star.setAttribute("fill", i < n ? "#facc15" : "#e2e8f0");
+            });
+          }}
+          onMouseLeave={(e) => {
+            if (readonly) return;
+            const buttons = e.currentTarget.parentElement?.querySelectorAll("button");
+            buttons?.forEach((b, i) => {
+              const star = b.querySelector("path");
+              if (!star) return;
+              star.setAttribute("fill", i < value ? "#facc15" : "#e2e8f0");
+            });
+          }}
+          className={readonly ? "cursor-default" : "cursor-pointer hover:scale-110 transition-transform"}
+          aria-label={`${n} star${n > 1 ? "s" : ""}`}
+        >
+          <StarIcon filled={n <= value} />
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleString("zh-CN", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export default function FeedbackForm({ generationId }: FeedbackFormProps) {
+  const { list, stats, loading, error, submit } = useFeedback(generationId);
+  const [rating, setRating] = useState(0);
+  const [comment, setComment] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [showForm, setShowForm] = useState(false);
+  const [showThanks, setShowThanks] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (rating === 0) return;
+    setSubmitting(true);
+    const ok = await submit(rating, comment.trim() || undefined);
+    setSubmitting(false);
+    if (ok) {
+      setRating(0);
+      setComment("");
+      setShowForm(false);
+      setShowThanks(true);
+      setTimeout(() => setShowThanks(false), 2500);
+    }
+  };
+
+  return (
+    <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-4">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-medium text-slate-700 dark:text-slate-300">用户反馈</h3>
+        {stats && stats.count > 0 && (
+          <div className="flex items-center gap-2 text-sm text-slate-500">
+            <span>{stats.count} 条评价</span>
+            <span className="flex items-center gap-1">
+              <span className="text-yellow-500">★</span>
+              <span className="font-medium text-slate-700 dark:text-slate-300">
+                {stats.avgRating?.toFixed(1) ?? "-"}
+              </span>
+            </span>
+          </div>
+        )}
+      </div>
+
+      {error && (
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-2 rounded mb-3">
+          <p className="text-xs text-red-700 dark:text-red-300">{error}</p>
+        </div>
+      )}
+
+      {showThanks ? (
+        <p className="text-sm text-green-600 dark:text-green-400 text-center py-2">感谢您的反馈！</p>
+      ) : showForm ? (
+        <form onSubmit={handleSubmit}>
+          <div className="mb-3">
+            <label className="block text-xs text-slate-500 mb-1">评分</label>
+            <RatingStars value={rating} onChange={setRating} />
+          </div>
+          <div className="mb-3">
+            <label className="block text-xs text-slate-500 mb-1">评论（可选）</label>
+            <textarea
+              value={comment}
+              onChange={(e) => setComment(e.target.value)}
+              rows={3}
+              maxLength={2000}
+              className="w-full px-3 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+              placeholder="说说你的感受..."
+            />
+          </div>
+          <div className="flex gap-2 justify-end">
+            <button
+              type="button"
+              onClick={() => setShowForm(false)}
+              className="px-3 py-1.5 text-sm border border-slate-200 dark:border-slate-700 rounded"
+            >
+              取消
+            </button>
+            <button
+              type="submit"
+              disabled={rating === 0 || submitting}
+              className="px-3 py-1.5 text-sm bg-slate-900 text-white rounded hover:bg-slate-800 disabled:opacity-50"
+            >
+              {submitting ? "提交中..." : "提交"}
+            </button>
+          </div>
+        </form>
+      ) : (
+        <button
+          onClick={() => setShowForm(true)}
+          className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          提交反馈 →
+        </button>
+      )}
+
+      {loading && list.length === 0 ? (
+        <p className="text-xs text-slate-400 mt-3">加载反馈...</p>
+      ) : list.length > 0 ? (
+        <div className="mt-4 space-y-2">
+          {list.slice(0, 5).map((f) => (
+            <div key={f.id} className="border-t border-slate-100 dark:border-slate-800 pt-2">
+              <div className="flex items-center gap-2 mb-1">
+                <RatingStars value={f.rating} readonly />
+                <span className="text-xs text-slate-400">{formatDate(f.createdAt)}</span>
+              </div>
+              {f.comment && <p className="text-sm text-slate-600 dark:text-slate-400">{f.comment}</p>}
+            </div>
+          ))}
+          {list.length > 5 && (
+            <p className="text-xs text-slate-400 text-center">还有 {list.length - 5} 条反馈...</p>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useFeedback.ts
+++ b/frontend/src/hooks/useFeedback.ts
@@ -1,0 +1,77 @@
+/**
+ * useFeedback Hook
+ */
+
+import { useState, useCallback } from "react";
+
+export interface FeedbackItem {
+  id: string;
+  generationId: string;
+  userId: string;
+  rating: number;
+  comment: string | null;
+  createdAt: string;
+}
+
+export interface FeedbackStats {
+  generationId: string;
+  count: number;
+  avgRating: number | null;
+}
+
+async function api<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, { credentials: "include", ...init });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data.error ?? `Request failed: ${res.status}`);
+  }
+  const json = await res.json();
+  if (!json.success) throw new Error(json.error ?? "Request failed");
+  return json.data as T;
+}
+
+export function useFeedback(generationId: string | null) {
+  const [list, setList] = useState<FeedbackItem[]>([]);
+  const [stats, setStats] = useState<FeedbackStats | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAll = useCallback(async () => {
+    if (!generationId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const [listData, statsData] = await Promise.all([
+        api<FeedbackItem[]>(`/api/feedback?generationId=${generationId}`),
+        api<FeedbackStats>(`/api/feedback/stats?generationId=${generationId}`),
+      ]);
+      setList(listData);
+      setStats(statsData);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load feedback");
+    } finally {
+      setLoading(false);
+    }
+  }, [generationId]);
+
+  const submit = useCallback(
+    async (rating: number, comment?: string): Promise<boolean> => {
+      if (!generationId) return false;
+      try {
+        await api(`/api/feedback`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ generationId, rating, ...(comment ? { comment } : {}) }),
+        });
+        await fetchAll();
+        return true;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to submit");
+        return false;
+      }
+    },
+    [generationId, fetchAll]
+  );
+
+  return { list, stats, loading, error, refetch: fetchAll, submit };
+}

--- a/packages/types/src/schema.ts
+++ b/packages/types/src/schema.ts
@@ -710,3 +710,33 @@ export const competitors = sqliteTable("competitors", {
   createdAtIdx: index("competitors_createdAt_idx").on(table.createdAt),
 }));
 
+/**
+ * 用户反馈表
+ *
+ * 用户对生成结果的评分和评论。用于改进生成质量。
+ */
+export const feedback = sqliteTable("feedback", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  // 关联的生成记录
+  generationId: text("generationId")
+    .notNull()
+    .references(() => generations.id, { onDelete: "cascade" }),
+  // 反馈用户
+  userId: text("userId")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  // 评分 1-5
+  rating: integer("rating").notNull(),
+  // 评论
+  comment: text("comment"),
+  createdAt: integer("createdAt", { mode: "timestamp_ms" })
+    .notNull()
+    .default(sql`(strftime('%s', 'now') * 1000)`),
+}, (table) => ({
+  generationIdIdx: index("feedback_generationId_idx").on(table.generationId),
+  userIdIdx: index("feedback_userId_idx").on(table.userId),
+  ratingIdx: index("feedback_rating_idx").on(table.rating),
+}));
+


### PR DESCRIPTION
## Feature #24: 用户反馈 - P0

用户对生成结果的评分和评论。

## Database
- `feedback` 表（6 字段 + 3 索引）
- rating 1-5，generationId 外键级联删除
- Migration: `drizzle/migrations/0013_add_feedback_table.sql`

## API
- `POST /api/feedback` — 提交评分 + 评论
- `GET /api/feedback?generationId=` — 列出反馈
- `GET /api/feedback/stats?generationId=` — count + avg
- 所有端点都验证 generation 属于当前用户

## Frontend
- `FeedbackForm` 组件：5 星 RatingStars + 可选评论
- 聚合统计（count + avg）
- 最近 5 条反馈预览
- 内联表单 + 提交后感谢提示
- 设计为嵌入到 generation 详情/历史页

## 验证
- ✅ typecheck / lint / build 全部通过