### PR TITLE
feat: add categories and templates (Feature #32 - P0)

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -24,6 +24,7 @@ import apiKeyRoutes from "./routes/keys";
 import teamRoutes from "./routes/teams";
 import competitorRoutes from "./routes/competitors";
 import feedbackRoutes from "./routes/feedback";
+import categoryRoutes from "./routes/categories";
 import v1Routes from "./routes/v1";
 import { stripeWebhookRoutes } from "./routes/webhooks/stripe";
 import { authMiddleware } from "./middleware/auth";
@@ -116,6 +117,7 @@ app.route("/api/keys", apiKeyRoutes);
 app.route("/api/teams", teamRoutes);
 app.route("/api/competitors", competitorRoutes);
 app.route("/api/feedback", feedbackRoutes);
+app.route("/api/categories", categoryRoutes);
 app.route("/api/v1", v1Routes);
 app.route("/api/webhooks", stripeWebhookRoutes);
 

--- a/api/src/routes/categories.ts
+++ b/api/src/routes/categories.ts
@@ -1,0 +1,95 @@
+/**
+ * Categories Routes
+ */
+
+import { Hono } from "hono";
+import { z } from "zod";
+import { zValidator } from "@hono/zod-validator";
+import { createDb } from "@oura-pix/database";
+import { getUser } from "../middleware/auth";
+import {
+  listCategories, getCategory, listCategoryTemplates,
+  createUserTemplate, listUserTemplates, deleteUserTemplate,
+} from "../services/categoryService";
+
+const categories = new Hono<{
+  Bindings: { DB: D1Database };
+  Variables: { user: { id: string; email: string; name?: string | null }; session: { id: string; expiresAt: Date } };
+}>();
+
+categories.get("/", async (c) => {
+  try {
+    const db = createDb(c.env.DB);
+    const data = await listCategories(db);
+    return c.json({ success: true, data });
+  } catch { return c.json({ error: "Failed to list categories" }, 500); }
+});
+
+categories.get("/:id", async (c) => {
+  const id = c.req.param("id");
+  try {
+    const db = createDb(c.env.DB);
+    const cat = await getCategory(db, id);
+    if (!cat) return c.json({ error: "Category not found" }, 404);
+    return c.json({ success: true, data: cat });
+  } catch { return c.json({ error: "Failed to get category" }, 500); }
+});
+
+categories.get("/:id/templates", async (c) => {
+  const id = c.req.param("id");
+  try {
+    const db = createDb(c.env.DB);
+    const data = await listCategoryTemplates(db, id);
+    return c.json({ success: true, data });
+  } catch { return c.json({ error: "Failed to list templates" }, 500); }
+});
+
+const createTemplateSchema = z.object({
+  categoryId: z.string().min(1),
+  name: z.string().min(1).max(100),
+  description: z.string().max(500).optional(),
+  settings: z.object({
+    targetPlatform: z.enum(["amazon", "ebay", "shopify", "etsy", "generic"]).optional(),
+    language: z.string().max(10).optional(),
+    style: z.enum(["professional", "lifestyle", "minimal", "luxury"]).optional(),
+    count: z.number().int().min(1).max(10).optional(),
+    aspectRatio: z.enum(["1:1", "3:4", "4:3", "9:16", "16:9"]).optional(),
+    allowPersons: z.boolean().optional(),
+    imageCount: z.number().int().min(1).max(10).optional(),
+  }),
+});
+
+categories.post("/templates", zValidator("json", createTemplateSchema), async (c) => {
+  const user = await getUser(c);
+  if (!user) return c.json({ error: "Unauthorized" }, 401);
+  const input = c.req.valid("json");
+  try {
+    const db = createDb(c.env.DB);
+    const created = await createUserTemplate(db, user.id, input);
+    return c.json({ success: true, data: created }, 201);
+  } catch { return c.json({ error: "Failed to create template" }, 500); }
+});
+
+categories.get("/templates/mine", async (c) => {
+  const user = await getUser(c);
+  if (!user) return c.json({ error: "Unauthorized" }, 401);
+  try {
+    const db = createDb(c.env.DB);
+    const data = await listUserTemplates(db, user.id);
+    return c.json({ success: true, data });
+  } catch { return c.json({ error: "Failed to list templates" }, 500); }
+});
+
+categories.delete("/templates/:id", async (c) => {
+  const user = await getUser(c);
+  if (!user) return c.json({ error: "Unauthorized" }, 401);
+  const id = c.req.param("id");
+  try {
+    const db = createDb(c.env.DB);
+    const ok = await deleteUserTemplate(db, id, user.id);
+    if (!ok) return c.json({ error: "Template not found or is a preset" }, 404);
+    return c.json({ success: true });
+  } catch { return c.json({ error: "Failed to delete template" }, 500); }
+});
+
+export default categories;

--- a/api/src/services/categoryService.ts
+++ b/api/src/services/categoryService.ts
@@ -1,0 +1,137 @@
+/**
+ * Category & Template Service
+ */
+
+import { createDb, schema, type TemplateSettings } from "@oura-pix/database";
+import { eq, and, asc, desc, sql } from "drizzle-orm";
+
+export interface CategoryRecord {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  bestPractices: string | null;
+  sortOrder: number;
+  createdAt: Date;
+  templateCount?: number;
+}
+
+export interface TemplateRecord {
+  id: string;
+  categoryId: string;
+  name: string;
+  description: string | null;
+  settings: TemplateSettings;
+  isPreset: boolean;
+  createdBy: string | null;
+  usageCount: number;
+  createdAt: Date;
+}
+
+export const SEED_CATEGORIES: Array<Omit<CategoryRecord, "id" | "createdAt" | "templateCount">> = [
+  { name: "服装", description: "服装、鞋帽、配件等穿戴类商品", icon: "👕", sortOrder: 1, bestPractices: "## 服装类目最佳实践\n\n### 详情页结构\n- 模特展示图（1-2 张）\n- 细节特写（面料、做工、五金）\n- 尺码对照表\n- 搭配建议\n- 洗涤说明\n\n### 文案风格\n- 强调材质和工艺\n- 真实场景展示" },
+  { name: "电子产品", description: "手机、配件、智能设备等", icon: "📱", sortOrder: 2, bestPractices: "## 电子产品最佳实践\n\n### 详情页结构\n- 产品多角度图\n- 核心参数对比\n- 适用场景演示\n- 包装清单" },
+  { name: "美妆", description: "彩妆、护肤、香水等", icon: "💄", sortOrder: 3, bestPractices: "## 美妆类目最佳实践\n\n### 详情页结构\n- 真人上脸/上妆效果\n- 成分解析\n- 持久度测试\n- 肤色适配范围" },
+  { name: "食品", description: "零食、饮料、调味品等", icon: "🍪", sortOrder: 4, bestPractices: "## 食品类目最佳实践\n\n### 详情页结构\n- 产品包装正面\n- 配料表\n- 营养成分表\n- 食用场景" },
+  { name: "家居", description: "家具、装饰、收纳等", icon: "🏠", sortOrder: 5, bestPractices: "## 家居类目最佳实践\n\n### 详情页结构\n- 整体场景图\n- 尺寸标注\n- 材质细节\n- 空间搭配示例" },
+];
+
+export const SEED_TEMPLATES: Array<{ categoryName: string; name: string; description: string; settings: TemplateSettings }> = [
+  { categoryName: "服装", name: "白底主图 + 模特图", description: "Amazon 主图风格", settings: { targetPlatform: "amazon", style: "professional", count: 5, aspectRatio: "1:1" } },
+  { categoryName: "服装", name: "生活场景图", description: "Lifestyle 风格", settings: { targetPlatform: "shopify", style: "lifestyle", count: 8, aspectRatio: "4:3" } },
+  { categoryName: "服装", name: "细节特写组", description: "聚焦做工细节", settings: { targetPlatform: "shopify", style: "minimal", count: 5, aspectRatio: "1:1" } },
+  { categoryName: "电子产品", name: "产品多角度图", description: "四角度展示", settings: { targetPlatform: "amazon", style: "professional", count: 5, aspectRatio: "1:1" } },
+  { categoryName: "电子产品", name: "使用场景演示", description: "实际应用", settings: { targetPlatform: "shopify", style: "lifestyle", count: 6, aspectRatio: "16:9" } },
+  { categoryName: "电子产品", name: "参数对比图", description: "突出技术参数", settings: { targetPlatform: "amazon", style: "professional", count: 4, aspectRatio: "1:1" } },
+  { categoryName: "美妆", name: "上脸效果展示", description: "真人上妆对比", settings: { targetPlatform: "shopify", style: "lifestyle", count: 6, aspectRatio: "4:3", allowPersons: true } },
+  { categoryName: "美妆", name: "产品特写", description: "包装、质地", settings: { targetPlatform: "amazon", style: "minimal", count: 5, aspectRatio: "1:1" } },
+  { categoryName: "美妆", name: "奢华场景图", description: "Luxury 风格", settings: { targetPlatform: "etsy", style: "luxury", count: 5, aspectRatio: "1:1" } },
+  { categoryName: "食品", name: "产品包装正面", description: "突出品牌品名", settings: { targetPlatform: "amazon", style: "professional", count: 4, aspectRatio: "1:1" } },
+  { categoryName: "食品", name: "食用场景", description: "真实使用场景", settings: { targetPlatform: "shopify", style: "lifestyle", count: 6, aspectRatio: "4:3" } },
+  { categoryName: "食品", name: "配料成分图", description: "突出天然原料", settings: { targetPlatform: "amazon", style: "minimal", count: 4, aspectRatio: "1:1" } },
+  { categoryName: "家居", name: "空间搭配图", description: "整体家居搭配", settings: { targetPlatform: "shopify", style: "lifestyle", count: 6, aspectRatio: "16:9" } },
+  { categoryName: "家居", name: "产品细节图", description: "材质做工", settings: { targetPlatform: "amazon", style: "professional", count: 5, aspectRatio: "1:1" } },
+  { categoryName: "家居", name: "多色多款展示", description: "配套组合", settings: { targetPlatform: "etsy", style: "luxury", count: 8, aspectRatio: "1:1" } },
+];
+
+export async function ensureSeedData(db: ReturnType<typeof createDb>): Promise<void> {
+  const existing = await db.select().from(schema.categories).limit(1);
+  if (existing.length > 0) return;
+
+  const nameToId = new Map<string, string>();
+  for (const cat of SEED_CATEGORIES) {
+    const [created] = await db
+      .insert(schema.categories)
+      .values({ name: cat.name, description: cat.description, icon: cat.icon, bestPractices: cat.bestPractices, sortOrder: cat.sortOrder, createdAt: new Date() })
+      .returning();
+    nameToId.set(cat.name, created.id);
+  }
+  for (const t of SEED_TEMPLATES) {
+    const id = nameToId.get(t.categoryName);
+    if (!id) continue;
+    await db.insert(schema.templates).values({
+      categoryId: id, name: t.name, description: t.description, settings: t.settings, isPreset: true, createdBy: null, usageCount: 0, createdAt: new Date(),
+    });
+  }
+}
+
+export async function listCategories(db: ReturnType<typeof createDb>): Promise<CategoryRecord[]> {
+  await ensureSeedData(db);
+  const rows = await db
+    .select({
+      id: schema.categories.id, name: schema.categories.name, description: schema.categories.description,
+      icon: schema.categories.icon, bestPractices: schema.categories.bestPractices, sortOrder: schema.categories.sortOrder,
+      createdAt: schema.categories.createdAt, templateCount: sql<number>`count(${schema.templates.id})`,
+    })
+    .from(schema.categories)
+    .leftJoin(schema.templates, eq(schema.templates.categoryId, schema.categories.id))
+    .groupBy(schema.categories.id)
+    .orderBy(asc(schema.categories.sortOrder));
+  return rows.map((r) => ({ ...r, templateCount: r.templateCount }));
+}
+
+export async function getCategory(db: ReturnType<typeof createDb>, id: string): Promise<CategoryRecord | null> {
+  await ensureSeedData(db);
+  const rows = await db.select().from(schema.categories).where(eq(schema.categories.id, id)).limit(1);
+  return rows[0] ?? null;
+}
+
+export async function listCategoryTemplates(db: ReturnType<typeof createDb>, categoryId: string): Promise<TemplateRecord[]> {
+  await ensureSeedData(db);
+  return db
+    .select()
+    .from(schema.templates)
+    .where(eq(schema.templates.categoryId, categoryId))
+    .orderBy(desc(schema.templates.isPreset), desc(schema.templates.usageCount));
+}
+
+export async function createUserTemplate(
+  db: ReturnType<typeof createDb>, userId: string,
+  input: { categoryId: string; name: string; description?: string; settings: TemplateSettings }
+): Promise<TemplateRecord> {
+  const [created] = await db.insert(schema.templates).values({
+    categoryId: input.categoryId, name: input.name, description: input.description ?? null,
+    settings: input.settings, isPreset: false, createdBy: userId, usageCount: 0, createdAt: new Date(),
+  }).returning();
+  return created;
+}
+
+export async function listUserTemplates(db: ReturnType<typeof createDb>, userId: string): Promise<TemplateRecord[]> {
+  return db
+    .select()
+    .from(schema.templates)
+    .where(and(eq(schema.templates.createdBy, userId), eq(schema.templates.isPreset, false)))
+    .orderBy(desc(schema.templates.createdAt));
+}
+
+export async function incrementTemplateUsage(db: ReturnType<typeof createDb>, templateId: string): Promise<void> {
+  await db.update(schema.templates).set({ usageCount: sql`${schema.templates.usageCount} + 1` }).where(eq(schema.templates.id, templateId)).catch((err) => console.error("Failed to increment template usage:", err));
+}
+
+export async function deleteUserTemplate(db: ReturnType<typeof createDb>, templateId: string, userId: string): Promise<boolean> {
+  const result = await db
+    .delete(schema.templates)
+    .where(and(eq(schema.templates.id, templateId), eq(schema.templates.createdBy, userId), eq(schema.templates.isPreset, false)))
+    .returning();
+  return result.length > 0;
+}

--- a/drizzle/migrations/0014_add_categories_and_templates.sql
+++ b/drizzle/migrations/0014_add_categories_and_templates.sql
@@ -1,0 +1,30 @@
+-- Categories and templates tables
+
+CREATE TABLE `categories` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`description` text NOT NULL,
+	`icon` text NOT NULL,
+	`bestPractices` text,
+	`sortOrder` integer NOT NULL DEFAULT 0,
+	`createdAt` integer NOT NULL
+);
+
+--> statement-breakpoint
+CREATE TABLE `templates` (
+	`id` text PRIMARY KEY NOT NULL,
+	`categoryId` text NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	`settings` text NOT NULL DEFAULT '{}',
+	`isPreset` integer NOT NULL DEFAULT false,
+	`createdBy` text,
+	`usageCount` integer NOT NULL DEFAULT 0,
+	`createdAt` integer NOT NULL,
+	FOREIGN KEY (`categoryId`) REFERENCES `categories`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`createdBy`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `templates_categoryId_idx` ON `templates` (`categoryId`);--> statement-breakpoint
+CREATE INDEX `templates_isPreset_idx` ON `templates` (`isPreset`);--> statement-breakpoint
+CREATE INDEX `templates_createdBy_idx` ON `templates` (`createdBy`);

--- a/frontend/src/components/categories/CategoriesPage.tsx
+++ b/frontend/src/components/categories/CategoriesPage.tsx
@@ -1,0 +1,174 @@
+/**
+ * CategoriesPage Component
+ */
+
+"use client";
+
+import { useState } from "react";
+import { useCategories, useCategoryTemplates, type Category, type Template } from "@/hooks/useCategories";
+
+function TemplateCard({ template, isSelected, onClick }: { template: Template; isSelected: boolean; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className={`text-left p-4 rounded-lg border w-full transition-colors ${
+        isSelected
+          ? "border-slate-900 dark:border-slate-100 bg-slate-50 dark:bg-slate-800"
+          : "border-slate-200 dark:border-slate-700 hover:border-slate-400 dark:hover:border-slate-500"
+      }`}
+    >
+      <div className="flex items-start justify-between mb-1">
+        <h4 className="font-medium text-slate-900 dark:text-slate-100">{template.name}</h4>
+        {template.isPreset ? (
+          <span className="px-1.5 py-0.5 text-xs rounded bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">预设</span>
+        ) : (
+          <span className="px-1.5 py-0.5 text-xs rounded bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300">自定义</span>
+        )}
+      </div>
+      {template.description && <p className="text-xs text-slate-500 mb-2">{template.description}</p>}
+      <div className="flex flex-wrap gap-1.5">
+        {Object.entries(template.settings).map(([k, v]) => (
+          <span key={k} className="text-xs px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400">
+            {k}: {String(v)}
+          </span>
+        ))}
+      </div>
+      {template.usageCount > 0 && <p className="text-xs text-slate-400 mt-2">使用 {template.usageCount} 次</p>}
+    </button>
+  );
+}
+
+export default function CategoriesPage() {
+  const { categories, loading, error } = useCategories();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [tab, setTab] = useState<"templates" | "practices">("templates");
+  const selected = categories.find((c) => c.id === selectedId) ?? null;
+
+  if (loading && categories.length === 0) {
+    return <div className="max-w-6xl mx-auto p-6 text-center text-slate-500">加载中...</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="max-w-6xl mx-auto p-6">
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-3 rounded">
+          <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto p-6">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">商品类目与模板</h1>
+        <p className="text-sm text-slate-500 mt-1">选择类目，使用预设模板快速生成</p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-4">
+        <aside className="lg:col-span-3">
+          <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 overflow-hidden">
+            {categories.map((cat) => (
+              <button
+                key={cat.id}
+                onClick={() => { setSelectedId(cat.id); setTab("templates"); }}
+                className={`w-full text-left px-4 py-3 border-b border-slate-100 dark:border-slate-800 last:border-b-0 transition-colors ${
+                  selectedId === cat.id ? "bg-slate-100 dark:bg-slate-800" : "hover:bg-slate-50 dark:hover:bg-slate-800/50"
+                }`}
+              >
+                <div className="flex items-center gap-2">
+                  <span className="text-2xl">{cat.icon}</span>
+                  <div className="flex-1 min-w-0">
+                    <div className="font-medium text-slate-900 dark:text-slate-100">{cat.name}</div>
+                    <div className="text-xs text-slate-500">{cat.templateCount ?? 0} 模板</div>
+                  </div>
+                </div>
+              </button>
+            ))}
+          </div>
+        </aside>
+
+        <main className="lg:col-span-9">
+          {selected ? (
+            <CategoryDetail key={selected.id} category={selected} tab={tab} setTab={setTab} />
+          ) : (
+            <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-12 text-center text-slate-500">
+              ← 选择一个类目查看模板和最佳实践
+            </div>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function CategoryDetail({ category, tab, setTab }: { category: Category; tab: "templates" | "practices"; setTab: (t: "templates" | "practices") => void }) {
+  const { templates, loading, error } = useCategoryTemplates(category.id);
+  const [selectedTemplate, setSelectedTemplate] = useState<Template | null>(null);
+
+  return (
+    <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700">
+      <div className="p-6 border-b border-slate-200 dark:border-slate-700">
+        <div className="flex items-center gap-3 mb-2">
+          <span className="text-4xl">{category.icon}</span>
+          <div>
+            <h2 className="text-xl font-bold text-slate-900 dark:text-slate-100">{category.name}</h2>
+            <p className="text-sm text-slate-500">{category.description}</p>
+          </div>
+        </div>
+        <div className="flex gap-2 mt-4">
+          <button
+            onClick={() => setTab("templates")}
+            className={`px-3 py-1.5 text-sm rounded ${tab === "templates" ? "bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900" : "bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700"}`}
+          >
+            模板 ({templates.length})
+          </button>
+          <button
+            onClick={() => setTab("practices")}
+            className={`px-3 py-1.5 text-sm rounded ${tab === "practices" ? "bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900" : "bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700"}`}
+          >
+            最佳实践
+          </button>
+        </div>
+      </div>
+
+      <div className="p-6">
+        {tab === "templates" ? (
+          <>
+            {error && (
+              <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-3 rounded mb-4">
+                <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
+              </div>
+            )}
+            {loading && templates.length === 0 ? (
+              <p className="text-center text-slate-500 py-8">加载中...</p>
+            ) : templates.length === 0 ? (
+              <p className="text-center text-slate-500 py-8">暂无模板</p>
+            ) : (
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                {templates.map((t) => (
+                  <TemplateCard key={t.id} template={t} isSelected={selectedTemplate?.id === t.id} onClick={() => setSelectedTemplate(t)} />
+                ))}
+              </div>
+            )}
+            {selectedTemplate && (
+              <div className="mt-6 p-4 bg-slate-50 dark:bg-slate-800 rounded-lg">
+                <div className="flex items-start justify-between mb-2">
+                  <h3 className="font-medium text-slate-900 dark:text-slate-100">使用模板: {selectedTemplate.name}</h3>
+                  <button onClick={() => setSelectedTemplate(null)} className="text-slate-400 hover:text-slate-600" aria-label="Close">✕</button>
+                </div>
+                <a href={`/generate?template=${selectedTemplate.id}`} className="inline-block mt-2 px-4 py-2 bg-slate-900 text-white text-sm rounded hover:bg-slate-800">
+                  用此模板生成 →
+                </a>
+              </div>
+            )}
+          </>
+        ) : (
+          <pre className="text-xs whitespace-pre-wrap font-sans bg-slate-50 dark:bg-slate-800 p-3 rounded text-slate-700 dark:text-slate-300">
+            {category.bestPractices ?? "暂无最佳实践"}
+          </pre>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useCategories.ts
+++ b/frontend/src/hooks/useCategories.ts
@@ -1,0 +1,79 @@
+/**
+ * useCategories Hook
+ */
+
+import { useState, useEffect, useCallback } from "react";
+
+export interface Category {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  bestPractices: string | null;
+  sortOrder: number;
+  createdAt: string;
+  templateCount?: number;
+}
+
+export interface Template {
+  id: string;
+  categoryId: string;
+  name: string;
+  description: string | null;
+  settings: Record<string, unknown>;
+  isPreset: boolean;
+  createdBy: string | null;
+  usageCount: number;
+  createdAt: string;
+}
+
+async function api<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, { credentials: "include", ...init });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data.error ?? `Request failed: ${res.status}`);
+  }
+  const json = await res.json();
+  if (!json.success) throw new Error(json.error ?? "Request failed");
+  return json.data as T;
+}
+
+export function useCategories() {
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchCategories = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await api<Category[]>("/api/categories");
+      setCategories(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load categories");
+    } finally { setLoading(false); }
+  }, []);
+
+  useEffect(() => { fetchCategories(); }, [fetchCategories]);
+  return { categories, loading, error, refetch: fetchCategories };
+}
+
+export function useCategoryTemplates(categoryId: string | null) {
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchTemplates = useCallback(async () => {
+    if (!categoryId) return;
+    setLoading(true); setError(null);
+    try {
+      const data = await api<Template[]>(`/api/categories/${categoryId}/templates`);
+      setTemplates(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load templates");
+    } finally { setLoading(false); }
+  }, [categoryId]);
+
+  useEffect(() => { fetchTemplates(); }, [fetchTemplates]);
+  return { templates, loading, error, refetch: fetchTemplates };
+}

--- a/frontend/src/pages/categories.astro
+++ b/frontend/src/pages/categories.astro
@@ -1,0 +1,8 @@
+---
+import Layout from '../layouts/Layout.astro';
+import CategoriesPage from '../components/categories/CategoriesPage';
+---
+
+<Layout title="商品类目与模板">
+  <CategoriesPage client:load />
+</Layout>

--- a/packages/types/src/schema.ts
+++ b/packages/types/src/schema.ts
@@ -740,3 +740,55 @@ export const feedback = sqliteTable("feedback", {
   ratingIdx: index("feedback_rating_idx").on(table.rating),
 }));
 
+/**
+ * 商品类目表
+ */
+export const categories = sqliteTable("categories", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  name: text("name").notNull(),
+  description: text("description").notNull(),
+  icon: text("icon").notNull(),
+  bestPractices: text("bestPractices"),
+  sortOrder: integer("sortOrder").notNull().default(0),
+  createdAt: integer("createdAt", { mode: "timestamp_ms" })
+    .notNull()
+    .default(sql`(strftime('%s', 'now') * 1000)`),
+});
+
+/**
+ * 模板表
+ */
+export const templates = sqliteTable("templates", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  categoryId: text("categoryId")
+    .notNull()
+    .references(() => categories.id, { onDelete: "cascade" }),
+  name: text("name").notNull(),
+  description: text("description"),
+  settings: text("settings", { mode: "json" }).$type<TemplateSettings>().notNull().default({}),
+  isPreset: integer("isPreset", { mode: "boolean" }).notNull().default(false),
+  createdBy: text("createdBy").references(() => users.id, { onDelete: "set null" }),
+  usageCount: integer("usageCount").notNull().default(0),
+  createdAt: integer("createdAt", { mode: "timestamp_ms" })
+    .notNull()
+    .default(sql`(strftime('%s', 'now') * 1000)`),
+}, (table) => ({
+  categoryIdIdx: index("templates_categoryId_idx").on(table.categoryId),
+  isPresetIdx: index("templates_isPreset_idx").on(table.isPreset),
+  createdByIdx: index("templates_createdBy_idx").on(table.createdBy),
+}));
+
+export interface TemplateSettings {
+  targetPlatform?: "amazon" | "ebay" | "shopify" | "etsy" | "generic";
+  language?: string;
+  style?: "professional" | "lifestyle" | "minimal" | "luxury";
+  count?: number;
+  aspectRatio?: "1:1" | "3:4" | "4:3" | "9:16" | "16:9";
+  allowPersons?: boolean;
+  imageCount?: number;
+}
+


### PR DESCRIPTION
## Feature #32: 商品类目与行业模板 - P0

5 个类目 × 3 个预设模板 + 用户自定义 + 最佳实践。

## Database
- `categories` 表（7 字段）
- `templates` 表（9 字段 + 3 索引）
- TemplateSettings 类型
- Migration: `drizzle/migrations/0014_add_categories_and_templates.sql`

## Seed Data
- 5 个类目：服装 / 电子产品 / 美妆 / 食品 / 家居
- 15 个预设模板（每个类目 3 个）
- 每个类目有 Markdown 最佳实践指南
- 幂等插入（`ensureSeedData` 首次读取时触发）

## API
- `GET /api/categories` — 列表 + 模板数
- `GET /api/categories/:id` — 详情 + bestPractices
- `GET /api/categories/:id/templates` — 类目模板
- `POST /api/categories/templates` (auth) — 创建用户模板
- `GET /api/categories/templates/mine` (auth)
- `DELETE /api/categories/templates/:id` (auth) — 预置不可删

## Frontend
- `/categories` — 侧边栏 + tab 视图
- 模板卡片：settings badges + 预设/自定义标签
- 点击模板 → /generate?template=xxx 链接

## 验证
- ✅ typecheck / lint / build 全部通过