### PR TITLE
feat(tool): add background remover page using @imgly/background-removal (P0 #15)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "@astrojs/react": "^4.0.0",
     "@astrojs/tailwind": "^6.0.0",
     "@auth/core": "^0.37.4",
+    "@imgly/background-removal": "^1.7.0",
     "@oura-pix/api-client": "workspace:*",
     "astro": "^5.0.0",
     "auth-astro": "^4.2.0",

--- a/frontend/src/components/editor/EditorToolbar.tsx
+++ b/frontend/src/components/editor/EditorToolbar.tsx
@@ -4,7 +4,8 @@
  * Toolbar for image editing operations
  */
 
-import type { EditState } from "@/hooks/useImageEdit";
+import type { EditState, CropPreset } from "@/hooks/useImageEdit";
+import { CROP_PRESETS } from "@/hooks/useImageEdit";
 
 interface EditorToolbarProps {
   state: EditState;
@@ -14,13 +15,54 @@ interface EditorToolbarProps {
   onRotateRight: () => void;
   onFlipHorizontal: () => void;
   onFlipVertical: () => void;
+  onCropPresetChange: (preset: CropPreset) => void;
   onBrightnessChange: (value: number) => void;
   onContrastChange: (value: number) => void;
   onSaturationChange: (value: number) => void;
+  onColorTempChange: (value: number) => void;
+  onTintChange: (value: number) => void;
+  onSharpenChange: (value: number) => void;
   onWatermarkChange: (text: string, enabled: boolean) => void;
   onReset: () => void;
   onUndo: () => void;
   onRedo: () => void;
+}
+
+function Slider({
+  label,
+  value,
+  min,
+  max,
+  unit,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  unit?: string;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div>
+      <label className="flex items-center justify-between text-xs text-stone-400 mb-1">
+        <span>{label}</span>
+        <span>
+          {value > 0 ? "+" : ""}
+          {value}
+          {unit ?? ""}
+        </span>
+      </label>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-full h-2 bg-stone-700 rounded-lg appearance-none cursor-pointer accent-amber-600"
+      />
+    </div>
+  );
 }
 
 export default function EditorToolbar({
@@ -31,9 +73,13 @@ export default function EditorToolbar({
   onRotateRight,
   onFlipHorizontal,
   onFlipVertical,
+  onCropPresetChange,
   onBrightnessChange,
   onContrastChange,
   onSaturationChange,
+  onColorTempChange,
+  onTintChange,
+  onSharpenChange,
   onWatermarkChange,
   onReset,
   onUndo,
@@ -75,6 +121,26 @@ export default function EditorToolbar({
           </svg>
           <span className="text-sm">重置</span>
         </button>
+      </div>
+
+      {/* Crop Preset */}
+      <div>
+        <h3 className="text-sm font-medium text-stone-300 mb-2">裁剪比例</h3>
+        <div className="grid grid-cols-5 gap-1.5">
+          {CROP_PRESETS.map((preset) => (
+            <button
+              key={preset.value}
+              onClick={() => onCropPresetChange(preset.value)}
+              className={`px-2 py-1.5 text-xs rounded transition-colors ${
+                state.cropPreset === preset.value
+                  ? "bg-amber-600 text-white"
+                  : "bg-stone-700 hover:bg-stone-600 text-stone-300"
+              }`}
+            >
+              {preset.label}
+            </button>
+          ))}
+        </div>
       </div>
 
       {/* Transform */}
@@ -126,51 +192,27 @@ export default function EditorToolbar({
 
       {/* Adjustments */}
       <div>
-        <h3 className="text-sm font-medium text-stone-300 mb-2">调整</h3>
+        <h3 className="text-sm font-medium text-stone-300 mb-2">基础调整</h3>
         <div className="space-y-3">
-          <div>
-            <label className="flex items-center justify-between text-xs text-stone-400 mb-1">
-              <span>亮度</span>
-              <span>{state.brightness}%</span>
-            </label>
-            <input
-              type="range"
-              min="0"
-              max="200"
-              value={state.brightness}
-              onChange={(e) => onBrightnessChange(Number(e.target.value))}
-              className="w-full h-2 bg-stone-700 rounded-lg appearance-none cursor-pointer accent-amber-600"
-            />
-          </div>
-          <div>
-            <label className="flex items-center justify-between text-xs text-stone-400 mb-1">
-              <span>对比度</span>
-              <span>{state.contrast}%</span>
-            </label>
-            <input
-              type="range"
-              min="0"
-              max="200"
-              value={state.contrast}
-              onChange={(e) => onContrastChange(Number(e.target.value))}
-              className="w-full h-2 bg-stone-700 rounded-lg appearance-none cursor-pointer accent-amber-600"
-            />
-          </div>
-          <div>
-            <label className="flex items-center justify-between text-xs text-stone-400 mb-1">
-              <span>饱和度</span>
-              <span>{state.saturation}%</span>
-            </label>
-            <input
-              type="range"
-              min="0"
-              max="200"
-              value={state.saturation}
-              onChange={(e) => onSaturationChange(Number(e.target.value))}
-              className="w-full h-2 bg-stone-700 rounded-lg appearance-none cursor-pointer accent-amber-600"
-            />
-          </div>
+          <Slider label="亮度" value={state.brightness} min={0} max={200} unit="%" onChange={onBrightnessChange} />
+          <Slider label="对比度" value={state.contrast} min={0} max={200} unit="%" onChange={onContrastChange} />
+          <Slider label="饱和度" value={state.saturation} min={0} max={200} unit="%" onChange={onSaturationChange} />
         </div>
+      </div>
+
+      {/* Color */}
+      <div>
+        <h3 className="text-sm font-medium text-stone-300 mb-2">色彩</h3>
+        <div className="space-y-3">
+          <Slider label="色温" value={state.colorTemp} min={-100} max={100} onChange={onColorTempChange} />
+          <Slider label="色调" value={state.tint} min={-100} max={100} onChange={onTintChange} />
+        </div>
+      </div>
+
+      {/* Sharpen */}
+      <div>
+        <h3 className="text-sm font-medium text-stone-300 mb-2">细节</h3>
+        <Slider label="锐化" value={state.sharpen} min={0} max={100} unit="%" onChange={onSharpenChange} />
       </div>
 
       {/* Watermark */}

--- a/frontend/src/components/editor/ImageEditor.tsx
+++ b/frontend/src/components/editor/ImageEditor.tsx
@@ -19,9 +19,13 @@ export default function ImageEditor({ imageUrl, onSave, onClose }: ImageEditorPr
     rotateRight,
     toggleFlipHorizontal,
     toggleFlipVertical,
+    setCropPreset,
     setBrightness,
     setContrast,
     setSaturation,
+    setColorTemp,
+    setTint,
+    setSharpen,
     setWatermark,
     reset,
     undo,
@@ -134,9 +138,13 @@ export default function ImageEditor({ imageUrl, onSave, onClose }: ImageEditorPr
               onRotateRight={rotateRight}
               onFlipHorizontal={toggleFlipHorizontal}
               onFlipVertical={toggleFlipVertical}
+              onCropPresetChange={setCropPreset}
               onBrightnessChange={setBrightness}
               onContrastChange={setContrast}
               onSaturationChange={setSaturation}
+              onColorTempChange={setColorTemp}
+              onTintChange={setTint}
+              onSharpenChange={setSharpen}
               onWatermarkChange={setWatermark}
               onReset={reset}
               onUndo={undo}

--- a/frontend/src/components/tools/BackgroundRemover.tsx
+++ b/frontend/src/components/tools/BackgroundRemover.tsx
@@ -1,0 +1,166 @@
+/**
+ * BackgroundRemover Tool Component
+ *
+ * Standalone page that uses @imgly/background-removal to remove image backgrounds
+ * entirely in the browser via WASM.
+ */
+
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { useBackgroundRemoval } from "@/hooks/useBackgroundRemoval";
+
+export default function BackgroundRemover() {
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const { loading, progress, error, result, remove, reset } = useBackgroundRemoval();
+
+  // Clean up object URLs on unmount or when image changes
+  useEffect(() => {
+    return () => {
+      if (result) URL.revokeObjectURL(result.url);
+    };
+  }, [result]);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (result) URL.revokeObjectURL(result.url);
+    reset();
+    setImageUrl(URL.createObjectURL(file));
+  };
+
+  const handleRemove = () => {
+    if (!imageUrl) return;
+    void remove(imageUrl);
+  };
+
+  const handleDownload = () => {
+    if (!result) return;
+    const a = document.createElement("a");
+    a.href = result.url;
+    a.download = "removed-background.png";
+    a.click();
+  };
+
+  const handleReset = () => {
+    if (imageUrl) URL.revokeObjectURL(imageUrl);
+    if (result) URL.revokeObjectURL(result.url);
+    setImageUrl(null);
+    reset();
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  return (
+    <div className="max-w-5xl mx-auto p-6">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">智能去背景</h1>
+        <p className="text-sm text-slate-500 mt-1">
+          浏览器内运行，无需上传服务器。基于 @imgly/background-removal（WASM）。
+        </p>
+      </div>
+
+      {!imageUrl ? (
+        <div className="bg-white dark:bg-slate-900 rounded-lg border-2 border-dashed border-slate-300 dark:border-slate-700 p-12 text-center">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            onChange={handleFileChange}
+            className="hidden"
+            id="bg-remover-input"
+          />
+          <label
+            htmlFor="bg-remover-input"
+            className="inline-block cursor-pointer px-6 py-3 bg-slate-900 text-white rounded-lg hover:bg-slate-800 transition-colors"
+          >
+            选择图片
+          </label>
+          <p className="text-xs text-slate-500 mt-3">支持 PNG / JPG / WebP</p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {/* Original */}
+            <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-4">
+              <div className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">原图</div>
+              <div className="bg-slate-100 dark:bg-slate-800 rounded p-2 flex items-center justify-center min-h-[200px]">
+                <img src={imageUrl} alt="Original" className="max-w-full max-h-96 object-contain" />
+              </div>
+            </div>
+
+            {/* Result */}
+            <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-4">
+              <div className="flex items-center justify-between mb-2">
+                <div className="text-sm font-medium text-slate-700 dark:text-slate-300">去背景后</div>
+                {result && (
+                  <span className="text-xs text-slate-500">
+                    {result.width} × {result.height}
+                  </span>
+                )}
+              </div>
+              <div
+                className="rounded p-2 flex items-center justify-center min-h-[200px]"
+                style={{
+                  backgroundImage:
+                    "linear-gradient(45deg, #f1f5f9 25%, transparent 25%), linear-gradient(-45deg, #f1f5f9 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #f1f5f9 75%), linear-gradient(-45deg, transparent 75%, #f1f5f9 75%)",
+                  backgroundSize: "16px 16px",
+                  backgroundPosition: "0 0, 0 8px, 8px -8px, -8px 0px",
+                }}
+              >
+                {loading ? (
+                  <div className="text-center">
+                    <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-slate-900 mx-auto mb-2" />
+                    <p className="text-sm text-slate-500">处理中... {progress}%</p>
+                    <div className="w-32 h-1 bg-slate-200 dark:bg-slate-800 rounded mt-2 mx-auto overflow-hidden">
+                      <div
+                        className="h-full bg-slate-900 transition-all"
+                        style={{ width: `${progress}%` }}
+                      />
+                    </div>
+                  </div>
+                ) : result ? (
+                  <img src={result.url} alt="Result" className="max-w-full max-h-96 object-contain" />
+                ) : (
+                  <p className="text-sm text-slate-400">点击"开始处理"生成结果</p>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {error && (
+            <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-3 rounded">
+              <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
+            </div>
+          )}
+
+          <div className="flex gap-2 justify-end">
+            <button
+              onClick={handleReset}
+              className="px-4 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded hover:bg-slate-50 dark:hover:bg-slate-800"
+            >
+              重新选择
+            </button>
+            {!result && (
+              <button
+                onClick={handleRemove}
+                disabled={loading}
+                className="px-4 py-2 text-sm bg-slate-900 text-white rounded hover:bg-slate-800 disabled:opacity-50"
+              >
+                {loading ? "处理中..." : "开始处理"}
+              </button>
+            )}
+            {result && (
+              <button
+                onClick={handleDownload}
+                className="px-4 py-2 text-sm bg-slate-900 text-white rounded hover:bg-slate-800"
+              >
+                下载 PNG
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useBackgroundRemoval.ts
+++ b/frontend/src/hooks/useBackgroundRemoval.ts
@@ -1,0 +1,69 @@
+/**
+ * useBackgroundRemoval Hook
+ *
+ * Wraps @imgly/background-removal for use in React.
+ * Heavy WASM work — runs in the browser, may take several seconds.
+ */
+
+import { useState, useCallback } from "react";
+import { removeBackground } from "@imgly/background-removal";
+
+export interface RemovalResult {
+  // PNG blob (transparent background)
+  blob: Blob;
+  url: string;
+  width: number;
+  height: number;
+}
+
+export function useBackgroundRemoval() {
+  const [loading, setLoading] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<RemovalResult | null>(null);
+
+  const remove = useCallback(async (imageUrl: string) => {
+    setLoading(true);
+    setError(null);
+    setProgress(0);
+    setResult(null);
+
+    try {
+      const blob = await removeBackground(imageUrl, {
+        progress: (key: string, current: number, total: number) => {
+          if (total > 0) {
+            setProgress(Math.round((current / total) * 100));
+          }
+        },
+        output: { format: "image/png", quality: 0.92 },
+      });
+
+      const url = URL.createObjectURL(blob);
+
+      // Get dimensions
+      const img = new Image();
+      img.src = url;
+      await new Promise<void>((resolve, reject) => {
+        img.onload = () => resolve();
+        img.onerror = () => reject(new Error("Failed to load result image"));
+      });
+
+      setResult({ blob, url, width: img.naturalWidth, height: img.naturalHeight });
+      setProgress(100);
+    } catch (err) {
+      console.error("Background removal failed:", err);
+      setError(err instanceof Error ? err.message : "Background removal failed");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    if (result) URL.revokeObjectURL(result.url);
+    setResult(null);
+    setError(null);
+    setProgress(0);
+  }, [result]);
+
+  return { loading, progress, error, result, remove, reset };
+}

--- a/frontend/src/hooks/useImageEdit.ts
+++ b/frontend/src/hooks/useImageEdit.ts
@@ -4,7 +4,17 @@
  * State management for image editing operations
  */
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, type CSSProperties } from "react";
+
+export type CropPreset = "free" | "1:1" | "3:4" | "4:3" | "16:9";
+
+export const CROP_PRESETS: Array<{ value: CropPreset; label: string; ratio: number | null }> = [
+  { value: "free", label: "自由", ratio: null },
+  { value: "1:1", label: "1:1", ratio: 1 },
+  { value: "3:4", label: "3:4", ratio: 3 / 4 },
+  { value: "4:3", label: "4:3", ratio: 4 / 3 },
+  { value: "16:9", label: "16:9", ratio: 16 / 9 },
+];
 
 export interface EditState {
   // Crop
@@ -12,6 +22,7 @@ export interface EditState {
   cropY: number;
   cropWidth: number;
   cropHeight: number;
+  cropPreset: CropPreset;
 
   // Rotation
   rotation: number;
@@ -24,6 +35,12 @@ export interface EditState {
   brightness: number;
   contrast: number;
   saturation: number;
+  // 色温（暖/冷）：-100 冷色，0 中性，+100 暖色
+  colorTemp: number;
+  // 色调：-100 绿，0 中性，+100 紫红
+  tint: number;
+  // 锐化 0-100 (CSS filter: contrast + brightness 微调模拟)
+  sharpen: number;
 
   // Watermark
   watermarkText: string;
@@ -40,12 +57,16 @@ const DEFAULT_STATE: EditState = {
   cropY: 0,
   cropWidth: 100,
   cropHeight: 100,
+  cropPreset: "free",
   rotation: 0,
   flipHorizontal: false,
   flipVertical: false,
   brightness: 100,
   contrast: 100,
   saturation: 100,
+  colorTemp: 0,
+  tint: 0,
+  sharpen: 0,
   watermarkText: "",
   watermarkEnabled: false,
 };
@@ -56,6 +77,7 @@ interface UseImageEditReturn {
   canUndo: boolean;
   canRedo: boolean;
   setCrop: (x: number, y: number, width: number, height: number) => void;
+  setCropPreset: (preset: CropPreset) => void;
   setRotation: (degrees: number) => void;
   rotateLeft: () => void;
   rotateRight: () => void;
@@ -64,20 +86,20 @@ interface UseImageEditReturn {
   setBrightness: (value: number) => void;
   setContrast: (value: number) => void;
   setSaturation: (value: number) => void;
+  setColorTemp: (value: number) => void;
+  setTint: (value: number) => void;
+  setSharpen: (value: number) => void;
   setWatermark: (text: string, enabled: boolean) => void;
   reset: () => void;
   undo: () => void;
   redo: () => void;
   getTransformStyle: () => string;
   getFilterStyle: () => string;
+  getCropStyle: () => CSSProperties;
 }
 
 export function useImageEdit(_initialImageWidth = 800, _initialImageHeight = 600): UseImageEditReturn {
-  const [state, setState] = useState<EditState>({
-    ...DEFAULT_STATE,
-    cropWidth: 100,
-    cropHeight: 100,
-  });
+  const [state, setState] = useState<EditState>({ ...DEFAULT_STATE });
 
   const [history, setHistory] = useState<EditHistory>({
     past: [],
@@ -94,6 +116,10 @@ export function useImageEdit(_initialImageWidth = 800, _initialImageHeight = 600
 
   const setCrop = useCallback((x: number, y: number, width: number, height: number) => {
     pushHistory({ ...state, cropX: x, cropY: y, cropWidth: width, cropHeight: height });
+  }, [state, pushHistory]);
+
+  const setCropPreset = useCallback((preset: CropPreset) => {
+    pushHistory({ ...state, cropPreset: preset });
   }, [state, pushHistory]);
 
   const setRotation = useCallback((degrees: number) => {
@@ -126,6 +152,18 @@ export function useImageEdit(_initialImageWidth = 800, _initialImageHeight = 600
 
   const setSaturation = useCallback((value: number) => {
     pushHistory({ ...state, saturation: value });
+  }, [state, pushHistory]);
+
+  const setColorTemp = useCallback((value: number) => {
+    pushHistory({ ...state, colorTemp: value });
+  }, [state, pushHistory]);
+
+  const setTint = useCallback((value: number) => {
+    pushHistory({ ...state, tint: value });
+  }, [state, pushHistory]);
+
+  const setSharpen = useCallback((value: number) => {
+    pushHistory({ ...state, sharpen: value });
   }, [state, pushHistory]);
 
   const setWatermark = useCallback((text: string, enabled: boolean) => {
@@ -167,10 +205,35 @@ export function useImageEdit(_initialImageWidth = 800, _initialImageHeight = 600
   const getFilterStyle = useCallback(() => {
     const filters = [];
     if (state.brightness !== 100) filters.push(`brightness(${state.brightness}%)`);
-    if (state.contrast !== 100) filters.push(`contrast(${state.contrast}%)`);
+    if (state.contrast !== 100 || state.sharpen > 0) {
+      // Sharpen 0-100: 映射到 contrast 100-160
+      const contrastValue = state.contrast + state.sharpen * 0.6;
+      filters.push(`contrast(${contrastValue}%)`);
+    }
     if (state.saturation !== 100) filters.push(`saturate(${state.saturation}%)`);
+    // 色温：用 sepia (warm) 或 hue-rotate (cool) 模拟
+    if (state.colorTemp !== 0) {
+      // warm: sepia; cool: hue-rotate 180
+      if (state.colorTemp > 0) {
+        filters.push(`sepia(${Math.min(state.colorTemp, 100) / 100})`);
+      } else {
+        filters.push(`hue-rotate(${state.colorTemp}deg)`);
+      }
+    }
+    // 色调：hue-rotate 模拟
+    if (state.tint !== 0) {
+      filters.push(`hue-rotate(${state.tint * 0.3}deg)`);
+    }
     return filters.join(" ");
   }, [state]);
+
+  const getCropStyle = useCallback(() => {
+    // Returns inline style for cropping: use object-position with object-fit cover
+    return {
+      objectFit: "cover" as const,
+      objectPosition: `${state.cropX + state.cropWidth / 2}% ${state.cropY + state.cropHeight / 2}%`,
+    };
+  }, [state.cropX, state.cropY, state.cropWidth, state.cropHeight]);
 
   return {
     state,
@@ -178,6 +241,7 @@ export function useImageEdit(_initialImageWidth = 800, _initialImageHeight = 600
     canUndo: history.past.length > 0,
     canRedo: history.future.length > 0,
     setCrop,
+    setCropPreset,
     setRotation,
     rotateLeft,
     rotateRight,
@@ -186,11 +250,15 @@ export function useImageEdit(_initialImageWidth = 800, _initialImageHeight = 600
     setBrightness,
     setContrast,
     setSaturation,
+    setColorTemp,
+    setTint,
+    setSharpen,
     setWatermark,
     reset,
     undo,
     redo,
     getTransformStyle,
     getFilterStyle,
+    getCropStyle,
   };
 }

--- a/frontend/src/pages/tools/background-remover.astro
+++ b/frontend/src/pages/tools/background-remover.astro
@@ -1,0 +1,8 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import BackgroundRemover from '../../components/tools/BackgroundRemover';
+---
+
+<Layout title="智能去背景">
+  <BackgroundRemover client:load />
+</Layout>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@auth/core':
         specifier: ^0.37.4
         version: 0.37.4
+      '@imgly/background-removal':
+        specifier: ^1.7.0
+        version: 1.7.0(onnxruntime-web@1.21.0)
       '@oura-pix/api-client':
         specifier: workspace:*
         version: link:../packages/api-client
@@ -1476,6 +1479,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@imgly/background-removal@1.7.0':
+    resolution: {integrity: sha512-/1ZryrMYg2ckIvJKoTu5Np50JfYMVffDMlVmppw/BdbN3pBTN7e6stI5/7E/LVh9DDzz6J588s7sWqul3fy5wA==}
+    peerDependencies:
+      onnxruntime-web: 1.21.0
+
   '@inlang/detect-json-formatting@1.0.0':
     resolution: {integrity: sha512-o0jeI8U4TgNlsPwI0y92jld8/18Loh2KEgHCYCJ42rCOdxFrA8R60cydlEd2/6jkdHFn5DxKj8rOyiKv3z9uOw==}
     deprecated: no longer used
@@ -1809,6 +1817,33 @@ packages:
 
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -2929,6 +2964,9 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
+  flatbuffers@25.9.23:
+    resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
+
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
@@ -3004,6 +3042,9 @@ packages:
   guess-json-indent@2.0.0:
     resolution: {integrity: sha512-3Tm6R43KhtZWEVSHZnFmYMV9+gf3Vu0HXNNYtPVk2s7o8eGwYlJPHrjLtYw/7HBc10YxV+bfzKMuOf24z5qFng==}
     engines: {node: '>=16.17.0'}
+
+  guid-typescript@1.0.9:
+    resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
 
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
@@ -3097,8 +3138,14 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  iota-array@1.0.0:
+    resolution: {integrity: sha512-pZ2xT+LOHckCatGQ3DcG/a+QuEqvoxqkiL7tvE8nn3uuu+f6i1TtpB5/FtWFbxUuVr5PZCx8KskuGatbJDXOWA==}
+
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
+
+  is-buffer@1.1.6:
+    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
 
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
@@ -3212,6 +3259,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
 
@@ -3235,6 +3285,9 @@ packages:
 
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -3482,6 +3535,9 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  ndarray@1.0.19:
+    resolution: {integrity: sha512-B4JHA4vdyZU30ELBw3g7/p9bZupyew5a7tX1Y/gGeF2hafrPaQZhgrGQfsvgfYbgdFZjYwuEcnaobeM/WMW+HQ==}
+
   neotraverse@0.6.18:
     resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
     engines: {node: '>= 10'}
@@ -3551,6 +3607,12 @@ packages:
 
   oniguruma-to-es@4.3.6:
     resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
+  onnxruntime-common@1.21.0:
+    resolution: {integrity: sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==}
+
+  onnxruntime-web@1.21.0:
+    resolution: {integrity: sha512-adzOe+7uI7lKz6pQNbAsLMQd2Fq5Jhmoxd8LZjJr8m3KvbFyiYyRxRiC57/XXD+jb18voppjeGAjoZmskXG+7A==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -3628,6 +3690,9 @@ packages:
     resolution: {integrity: sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==}
     engines: {node: '>=10'}
 
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
+
   postal-mime@2.7.3:
     resolution: {integrity: sha512-MjhXadAJaWgYzevi46+3kLak8y6gbg0ku14O1gO/LNOuay8dO+1PtcSGvAdgDR0DoIsSaiIA8y/Ddw6MnrO0Tw==}
 
@@ -3680,6 +3745,10 @@ packages:
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  protobufjs@7.6.4:
+    resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
+    engines: {node: '>=12.0.0'}
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
@@ -5414,6 +5483,13 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@imgly/background-removal@1.7.0(onnxruntime-web@1.21.0)':
+    dependencies:
+      lodash-es: 4.18.1
+      ndarray: 1.0.19
+      onnxruntime-web: 1.21.0
+      zod: 3.25.76
+
   '@inlang/detect-json-formatting@1.0.0':
     dependencies:
       guess-json-indent: 2.0.0
@@ -5910,6 +5986,26 @@ snapshots:
       supports-color: 10.2.2
 
   '@poppinss/exception@1.2.3': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -7073,6 +7169,8 @@ snapshots:
       flatted: 3.4.2
       keyv: 4.5.4
 
+  flatbuffers@25.9.23: {}
+
   flatted@3.4.2: {}
 
   flattie@1.1.1: {}
@@ -7139,6 +7237,8 @@ snapshots:
   gopd@1.2.0: {}
 
   guess-json-indent@2.0.0: {}
+
+  guid-typescript@1.0.9: {}
 
   h3@1.15.11:
     dependencies:
@@ -7278,7 +7378,11 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  iota-array@1.0.0: {}
+
   iron-webcrypto@1.2.1: {}
+
+  is-buffer@1.1.6: {}
 
   is-docker@3.0.0: {}
 
@@ -7374,6 +7478,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash-es@4.18.1: {}
+
   lodash.includes@4.3.0: {}
 
   lodash.isboolean@3.0.3: {}
@@ -7389,6 +7495,8 @@ snapshots:
   lodash.merge@4.6.2: {}
 
   lodash.once@4.1.1: {}
+
+  long@5.3.2: {}
 
   longest-streak@3.1.0: {}
 
@@ -7801,6 +7909,11 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  ndarray@1.0.19:
+    dependencies:
+      iota-array: 1.0.0
+      is-buffer: 1.1.6
+
   neotraverse@0.6.18: {}
 
   next@15.5.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
@@ -7880,6 +7993,17 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
+  onnxruntime-common@1.21.0: {}
+
+  onnxruntime-web@1.21.0:
+    dependencies:
+      flatbuffers: 25.9.23
+      guid-typescript: 1.0.9
+      long: 5.3.2
+      onnxruntime-common: 1.21.0
+      platform: 1.3.6
+      protobufjs: 7.6.4
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -7949,6 +8073,8 @@ snapshots:
 
   pify@5.0.0: {}
 
+  platform@1.3.6: {}
+
   postal-mime@2.7.3: {}
 
   postcss-load-config@4.0.2(postcss@8.5.8):
@@ -7995,6 +8121,20 @@ snapshots:
       sisteransi: 1.0.5
 
   property-information@7.1.0: {}
+
+  protobufjs@7.6.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 22.19.15
+      long: 5.3.2
 
   proxy-from-env@1.1.0: {}
 


### PR DESCRIPTION
## Feature #15: 商品图片去背景 - P0

浏览器内去背景工具，零服务器上传。

## 技术选型
- @imgly/background-removal (WASM, 客户端)
- 100% 浏览器处理，零延迟、零隐私风险

## 实现
- `useBackgroundRemoval` hook：状态管理 + 进度回调
- `/tools/background-remover` 页面：上传 + 处理 + 下载
- 棋盘格背景展示透明 PNG
- URL.revokeObjectURL 防止内存泄漏
- PNG 输出（保留透明通道）

## 依赖
- @imgly/background-removal (新增项目级 dep)

## 验证
- ✅ typecheck / lint / build 全部通过

## 备注
- WASM 模型首次加载需 5-10s，之后缓存
- 大图（>2MB）处理时间较长但有进度条