### PR TITLE
feat(tool): add batch image processor (P0 #16)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "astro": "^5.0.0",
     "auth-astro": "^4.2.0",
     "axios": "^1.6.0",
+    "jszip": "^3.10.1",
     "lucide-react": "^0.460.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/frontend/src/components/tools/BatchProcessor.tsx
+++ b/frontend/src/components/tools/BatchProcessor.tsx
@@ -1,0 +1,277 @@
+/**
+ * BatchProcessor Tool Component
+ *
+ * Batch image processing: resize, compress, watermark, format conversion.
+ * All client-side via Canvas API.
+ */
+
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { useBatchProcess, type OutputFormat, type BatchItem } from "@/hooks/useBatchProcess";
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(2)} MB`;
+}
+
+export default function BatchProcessor() {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const {
+    items,
+    options,
+    setOptions,
+    processing,
+    progress,
+    addFiles,
+    removeItem,
+    clearAll,
+    processAll,
+    downloadOne,
+    downloadZip,
+  } = useBatchProcess();
+  const [dragActive, setDragActive] = useState(false);
+
+  useEffect(() => {
+    return () => {
+      // Revoke URLs on unmount
+      items.forEach((item) => {
+        URL.revokeObjectURL(item.originalUrl);
+        if (item.resultUrl) URL.revokeObjectURL(item.resultUrl);
+      });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleFiles = (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    addFiles(files);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setDragActive(false);
+    handleFiles(e.dataTransfer.files);
+  };
+
+  const completedCount = items.filter((i) => i.status === "done").length;
+  const totalSavings = items.reduce((acc, i) => {
+    if (i.status === "done" && i.resultSize > 0) {
+      return acc + (i.originalSize - i.resultSize);
+    }
+    return acc;
+  }, 0);
+
+  return (
+    <div className="max-w-6xl mx-auto p-6">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">批量处理工具</h1>
+        <p className="text-sm text-slate-500 mt-1">
+          浏览器内批量处理图片：调整尺寸、压缩、添加水印、格式转换。
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        {/* Options panel */}
+        <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-4 space-y-4">
+          <h2 className="text-sm font-medium text-slate-700 dark:text-slate-300">处理选项</h2>
+
+          <div>
+            <label className="block text-xs text-slate-500 mb-1">输出格式</label>
+            <select
+              value={options.format}
+              onChange={(e) => setOptions({ ...options, format: e.target.value as OutputFormat })}
+              className="w-full px-2 py-1.5 text-sm border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+            >
+              <option value="image/jpeg">JPEG</option>
+              <option value="image/png">PNG</option>
+              <option value="image/webp">WebP</option>
+            </select>
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <label className="block text-xs text-slate-500 mb-1">宽 (px)</label>
+              <input
+                type="number"
+                value={options.resizeWidth ?? ""}
+                onChange={(e) => setOptions({ ...options, resizeWidth: e.target.value ? Number(e.target.value) : undefined })}
+                placeholder="原图"
+                className="w-full px-2 py-1.5 text-sm border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-slate-500 mb-1">高 (px)</label>
+              <input
+                type="number"
+                value={options.resizeHeight ?? ""}
+                onChange={(e) => setOptions({ ...options, resizeHeight: e.target.value ? Number(e.target.value) : undefined })}
+                placeholder="原图"
+                className="w-full px-2 py-1.5 text-sm border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+              />
+            </div>
+          </div>
+
+          {options.format !== "image/png" && (
+            <div>
+              <div className="flex justify-between text-xs text-slate-500 mb-1">
+                <span>质量</span>
+                <span>{Math.round(options.quality * 100)}%</span>
+              </div>
+              <input
+                type="range"
+                min="0.1"
+                max="1"
+                step="0.05"
+                value={options.quality}
+                onChange={(e) => setOptions({ ...options, quality: Number(e.target.value) })}
+                className="w-full accent-slate-900"
+              />
+            </div>
+          )}
+
+          <div className="space-y-2 pt-2 border-t border-slate-100 dark:border-slate-800">
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={options.watermarkEnabled}
+                onChange={(e) => setOptions({ ...options, watermarkEnabled: e.target.checked })}
+                className="rounded"
+              />
+              <span className="text-sm text-slate-700 dark:text-slate-300">添加水印</span>
+            </label>
+            {options.watermarkEnabled && (
+              <input
+                type="text"
+                value={options.watermarkText}
+                onChange={(e) => setOptions({ ...options, watermarkText: e.target.value })}
+                placeholder="水印文字"
+                className="w-full px-2 py-1.5 text-sm border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+              />
+            )}
+          </div>
+
+          <button
+            onClick={processAll}
+            disabled={items.length === 0 || processing}
+            className="w-full px-4 py-2 text-sm bg-slate-900 text-white rounded hover:bg-slate-800 disabled:opacity-50"
+          >
+            {processing ? `处理中 ${progress}%` : `开始处理 (${items.length})`}
+          </button>
+
+          {completedCount > 0 && (
+            <button
+              onClick={downloadZip}
+              className="w-full px-4 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded hover:bg-slate-50 dark:hover:bg-slate-800"
+            >
+              下载 ZIP ({completedCount})
+            </button>
+          )}
+        </div>
+
+        {/* File list / drop zone */}
+        <div className="lg:col-span-2 space-y-4">
+          <div
+            onDragOver={(e) => { e.preventDefault(); setDragActive(true); }}
+            onDragLeave={() => setDragActive(false)}
+            onDrop={handleDrop}
+            className={`border-2 border-dashed rounded-lg p-6 text-center transition-colors ${
+              dragActive
+                ? "border-slate-900 dark:border-slate-100 bg-slate-50 dark:bg-slate-800/50"
+                : "border-slate-300 dark:border-slate-700"
+            }`}
+          >
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              multiple
+              onChange={(e) => handleFiles(e.target.files)}
+              className="hidden"
+              id="batch-input"
+            />
+            <label
+              htmlFor="batch-input"
+              className="inline-block cursor-pointer px-4 py-2 bg-slate-900 text-white text-sm rounded hover:bg-slate-800"
+            >
+              选择多张图片
+            </label>
+            <p className="text-xs text-slate-500 mt-2">或拖放图片到这里</p>
+          </div>
+
+          {items.length > 0 && (
+            <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 overflow-hidden">
+              <div className="px-4 py-2 border-b border-slate-200 dark:border-slate-700 flex items-center justify-between">
+                <div className="text-sm">
+                  共 {items.length} 张 · 完成 {completedCount}
+                  {totalSavings > 0 && ` · 节省 ${formatBytes(totalSavings)}`}
+                </div>
+                <button
+                  onClick={clearAll}
+                  className="text-xs text-slate-500 hover:text-red-500"
+                >
+                  清空
+                </button>
+              </div>
+              <div className="divide-y divide-slate-100 dark:divide-slate-800 max-h-[500px] overflow-y-auto">
+                {items.map((item) => (
+                  <BatchItemRow key={item.id} item={item} onRemove={removeItem} onDownload={downloadOne} />
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BatchItemRow({ item, onRemove, onDownload }: { item: BatchItem; onRemove: (id: string) => void; onDownload: (item: BatchItem) => void }) {
+  return (
+    <div className="px-4 py-3 flex items-center gap-3">
+      <div className="w-12 h-12 bg-slate-100 dark:bg-slate-800 rounded overflow-hidden flex-shrink-0">
+        <img src={item.resultUrl ?? item.originalUrl} alt="" className="w-full h-full object-cover" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="text-sm font-medium text-slate-900 dark:text-slate-100 truncate">
+          {item.file.name}
+        </div>
+        <div className="text-xs text-slate-500">
+          {item.status === "done" ? (
+            <>
+              {item.width}×{item.height} · {formatBytes(item.originalSize)} → {formatBytes(item.resultSize)}
+            </>
+          ) : (
+            <>{formatBytes(item.originalSize)}</>
+          )}
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <span className={`text-xs px-2 py-0.5 rounded ${
+          item.status === "done" ? "bg-green-100 text-green-700" :
+          item.status === "error" ? "bg-red-100 text-red-700" :
+          item.status === "processing" ? "bg-blue-100 text-blue-700" :
+          "bg-slate-100 text-slate-700"
+        }`}>
+          {item.status === "done" ? "完成" : item.status === "error" ? "失败" : item.status === "processing" ? "处理中" : "等待"}
+        </span>
+        {item.status === "done" && (
+          <button
+            onClick={() => onDownload(item)}
+            className="text-xs text-blue-600 hover:underline"
+          >
+            下载
+          </button>
+        )}
+        <button
+          onClick={() => onRemove(item.id)}
+          className="text-slate-400 hover:text-red-500"
+          aria-label="Remove"
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useBatchProcess.ts
+++ b/frontend/src/hooks/useBatchProcess.ts
@@ -1,0 +1,240 @@
+/**
+ * useBatchProcess Hook
+ *
+ * Batch process multiple images with resize, compress, watermark, and format conversion.
+ * Pure client-side via Canvas API.
+ */
+
+import { useState, useCallback } from "react";
+import JSZip from "jszip";
+
+export type OutputFormat = "image/jpeg" | "image/png" | "image/webp";
+
+export interface BatchOptions {
+  resizeWidth?: number;
+  resizeHeight?: number;
+  keepAspect: boolean;
+  quality: number; // 0-1
+  format: OutputFormat;
+  watermarkText: string;
+  watermarkEnabled: boolean;
+}
+
+export interface BatchItem {
+  id: string;
+  file: File;
+  originalUrl: string;
+  resultBlob: Blob | null;
+  resultUrl: string | null;
+  status: "pending" | "processing" | "done" | "error";
+  error?: string;
+  originalSize: number;
+  resultSize: number;
+  width: number;
+  height: number;
+}
+
+const DEFAULT_OPTIONS: BatchOptions = {
+  resizeWidth: undefined,
+  resizeHeight: undefined,
+  keepAspect: true,
+  quality: 0.9,
+  format: "image/jpeg",
+  watermarkText: "",
+  watermarkEnabled: false,
+};
+
+export function useBatchProcess() {
+  const [items, setItems] = useState<BatchItem[]>([]);
+  const [options, setOptions] = useState<BatchOptions>(DEFAULT_OPTIONS);
+  const [processing, setProcessing] = useState(false);
+  const [progress, setProgress] = useState(0);
+
+  const addFiles = useCallback((files: FileList | File[]) => {
+    const newItems: BatchItem[] = Array.from(files)
+      .filter((f) => f.type.startsWith("image/"))
+      .map((file) => ({
+        id: crypto.randomUUID(),
+        file,
+        originalUrl: URL.createObjectURL(file),
+        resultBlob: null,
+        resultUrl: null,
+        status: "pending",
+        originalSize: file.size,
+        resultSize: 0,
+        width: 0,
+        height: 0,
+      }));
+    setItems((prev) => [...prev, ...newItems]);
+  }, []);
+
+  const removeItem = useCallback((id: string) => {
+    setItems((prev) => {
+      const removed = prev.find((i) => i.id === id);
+      if (removed) {
+        URL.revokeObjectURL(removed.originalUrl);
+        if (removed.resultUrl) URL.revokeObjectURL(removed.resultUrl);
+      }
+      return prev.filter((i) => i.id !== id);
+    });
+  }, []);
+
+  const clearAll = useCallback(() => {
+    items.forEach((item) => {
+      URL.revokeObjectURL(item.originalUrl);
+      if (item.resultUrl) URL.revokeObjectURL(item.resultUrl);
+    });
+    setItems([]);
+  }, [items]);
+
+  const processImage = useCallback(
+    async (item: BatchItem, opts: BatchOptions): Promise<Blob> => {
+      return new Promise((resolve, reject) => {
+        const img = new Image();
+        img.onload = () => {
+          // Compute target dimensions
+          let targetW = opts.resizeWidth ?? img.naturalWidth;
+          let targetH = opts.resizeHeight ?? img.naturalHeight;
+          if (opts.keepAspect && (opts.resizeWidth || opts.resizeHeight)) {
+            if (opts.resizeWidth && !opts.resizeHeight) {
+              targetH = Math.round((img.naturalHeight * opts.resizeWidth) / img.naturalWidth);
+            } else if (opts.resizeHeight && !opts.resizeWidth) {
+              targetW = Math.round((img.naturalWidth * opts.resizeHeight) / img.naturalHeight);
+            } else {
+              // Both specified — fit within bounds keeping aspect
+              const ratio = Math.min(opts.resizeWidth! / img.naturalWidth, opts.resizeHeight! / img.naturalHeight);
+              targetW = Math.round(img.naturalWidth * ratio);
+              targetH = Math.round(img.naturalHeight * ratio);
+            }
+          }
+
+          const canvas = document.createElement("canvas");
+          canvas.width = targetW;
+          canvas.height = targetH;
+          const ctx = canvas.getContext("2d");
+          if (!ctx) {
+            reject(new Error("Failed to get canvas context"));
+            return;
+          }
+
+          // White background for JPEG (no alpha)
+          if (opts.format === "image/jpeg") {
+            ctx.fillStyle = "#ffffff";
+            ctx.fillRect(0, 0, targetW, targetH);
+          }
+
+          ctx.drawImage(img, 0, 0, targetW, targetH);
+
+          // Watermark
+          if (opts.watermarkEnabled && opts.watermarkText) {
+            ctx.font = `${Math.max(16, targetH / 25)}px sans-serif`;
+            ctx.fillStyle = "rgba(255,255,255,0.6)";
+            ctx.strokeStyle = "rgba(0,0,0,0.4)";
+            ctx.lineWidth = 2;
+            const text = opts.watermarkText;
+            const metrics = ctx.measureText(text);
+            const x = targetW - metrics.width - 20;
+            const y = targetH - 20;
+            ctx.strokeText(text, x, y);
+            ctx.fillText(text, x, y);
+          }
+
+          canvas.toBlob(
+            (blob) => {
+              if (blob) {
+                item.width = targetW;
+                item.height = targetH;
+                resolve(blob);
+              } else {
+                reject(new Error("Failed to encode image"));
+              }
+            },
+            opts.format,
+            opts.quality
+          );
+        };
+        img.onerror = () => reject(new Error("Failed to load image"));
+        img.src = item.originalUrl;
+      });
+    },
+    []
+  );
+
+  const processAll = useCallback(async () => {
+    if (items.length === 0) return;
+    setProcessing(true);
+    setProgress(0);
+
+    let completed = 0;
+    for (const item of items) {
+      setItems((prev) =>
+        prev.map((i) => (i.id === item.id ? { ...i, status: "processing" } : i))
+      );
+      try {
+        const blob = await processImage(item, options);
+        const url = URL.createObjectURL(blob);
+        setItems((prev) =>
+          prev.map((i) =>
+            i.id === item.id
+              ? { ...i, status: "done", resultBlob: blob, resultUrl: url, resultSize: blob.size }
+              : i
+          )
+        );
+      } catch (err) {
+        setItems((prev) =>
+          prev.map((i) =>
+            i.id === item.id
+              ? { ...i, status: "error", error: err instanceof Error ? err.message : "Error" }
+              : i
+          )
+        );
+      }
+      completed++;
+      setProgress(Math.round((completed / items.length) * 100));
+    }
+
+    setProcessing(false);
+  }, [items, options, processImage]);
+
+  const downloadOne = useCallback((item: BatchItem) => {
+    if (!item.resultBlob || !item.resultUrl) return;
+    const ext = options.format === "image/jpeg" ? "jpg" : options.format === "image/png" ? "png" : "webp";
+    const baseName = item.file.name.replace(/\.[^.]+$/, "");
+    const a = document.createElement("a");
+    a.href = item.resultUrl;
+    a.download = `${baseName}-processed.${ext}`;
+    a.click();
+  }, [options.format]);
+
+  const downloadZip = useCallback(async () => {
+    const zip = new JSZip();
+    const ext = options.format === "image/jpeg" ? "jpg" : options.format === "image/png" ? "png" : "webp";
+    items.forEach((item) => {
+      if (item.resultBlob) {
+        const baseName = item.file.name.replace(/\.[^.]+$/, "");
+        zip.file(`${baseName}-processed.${ext}`, item.resultBlob);
+      }
+    });
+    const blob = await zip.generateAsync({ type: "blob" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "processed-images.zip";
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [items, options.format]);
+
+  return {
+    items,
+    options,
+    setOptions,
+    processing,
+    progress,
+    addFiles,
+    removeItem,
+    clearAll,
+    processAll,
+    downloadOne,
+    downloadZip,
+  };
+}

--- a/frontend/src/pages/tools/batch.astro
+++ b/frontend/src/pages/tools/batch.astro
@@ -1,0 +1,8 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import BatchProcessor from '../../components/tools/BatchProcessor';
+---
+
+<Layout title="批量处理">
+  <BatchProcessor client:load />
+</Layout>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       axios:
         specifier: ^1.6.0
         version: 1.13.6
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       lucide-react:
         specifier: ^0.460.0
         version: 0.460.0(react@18.3.1)
@@ -2546,6 +2549,9 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
     engines: {node: '>=0.8'}
@@ -3120,6 +3126,9 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -3177,6 +3186,9 @@ packages:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -3226,6 +3238,9 @@ packages:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
     engines: {node: '>=12', npm: '>=6'}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
 
@@ -3250,6 +3265,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -3739,6 +3757,9 @@ packages:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -3776,6 +3797,9 @@ packages:
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
@@ -3854,6 +3878,9 @@ packages:
   rou3@0.7.12:
     resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -3878,6 +3905,9 @@ packages:
 
   set-cookie-parser@3.0.1:
     resolution: {integrity: sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q==}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   sha.js@2.4.11:
     resolution: {integrity: sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==}
@@ -3965,6 +3995,9 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -4289,6 +4322,9 @@ packages:
 
   urlpattern-polyfill@10.1.0:
     resolution: {integrity: sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
@@ -6744,6 +6780,8 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  core-util-is@1.0.3: {}
+
   crc-32@1.2.2: {}
 
   cross-spawn@7.0.6:
@@ -7365,6 +7403,8 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immediate@3.0.6: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -7403,6 +7443,8 @@ snapshots:
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
+
+  isarray@1.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -7446,6 +7488,13 @@ snapshots:
       ms: 2.1.3
       semver: 7.7.4
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   jwa@2.0.1:
     dependencies:
       buffer-equal-constant-time: 1.0.1
@@ -7471,6 +7520,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lilconfig@3.1.3: {}
 
@@ -8115,6 +8168,8 @@ snapshots:
 
   prismjs@1.30.0: {}
 
+  process-nextick-args@2.0.1: {}
+
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
@@ -8157,6 +8212,16 @@ snapshots:
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
 
   readdirp@5.0.0: {}
 
@@ -8303,6 +8368,8 @@ snapshots:
 
   rou3@0.7.12: {}
 
+  safe-buffer@5.1.2: {}
+
   safe-buffer@5.2.1: {}
 
   sax@1.6.0: {}
@@ -8318,6 +8385,8 @@ snapshots:
   set-cookie-parser@2.7.2: {}
 
   set-cookie-parser@3.0.1: {}
+
+  setimmediate@1.0.5: {}
 
   sha.js@2.4.11:
     dependencies:
@@ -8450,6 +8519,10 @@ snapshots:
       emoji-regex: 10.6.0
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   stringify-entities@4.0.4:
     dependencies:
@@ -8717,6 +8790,8 @@ snapshots:
       punycode: 2.3.1
 
   urlpattern-polyfill@10.1.0: {}
+
+  util-deprecate@1.0.2: {}
 
   uuid@10.0.0: {}
 


### PR DESCRIPTION
## Feature #16: 商品图片批量处理 - P0

浏览器内批量处理图片：调整尺寸、压缩、添加水印、格式转换。

## 根因
用户经常需要给多张图片统一调整尺寸/压缩/添加水印/转换格式，每次手动处理效率低。需求是高频但每个任务又不够大到要付费 SaaS。

## 方案
**纯前端 Canvas API + JSZip**，无后端改动：
- 100% 浏览器处理，零延迟、零隐私风险
- 不消耗 Workers quota
- 用户数据不离设备
- 替代方案：Cloudflare Images API（付费 + 需上传），不选

## 实现
- `useBatchProcess` hook：Canvas 重绘 + JSZip 打包
- `/tools/batch` 页面：拖放上传 + 处理选项面板
- 支持 JPEG/PNG/WebP 输出
- 可选缩放（保持宽高比）
- 质量滑块（PNG 隐藏）
- 右下水印
- 单独下载或 ZIP 打包
- 实时进度条 + 状态徽章

## 验证
- ✅ typecheck / lint / build 全部通过

## 依赖
- jszip (新增项目级 dep)