### PR TITLE
feat(tool): add image cutout tool (P0 #88)

### DIFF
--- a/frontend/src/components/tools/ImageCutout.tsx
+++ b/frontend/src/components/tools/ImageCutout.tsx
@@ -1,0 +1,226 @@
+/**
+ * ImageCutout Tool Component
+ *
+ * Rectangle or brush-based cutout with feathered edges.
+ * Output PNG with transparent area outside selection.
+ */
+
+"use client";
+
+import { useRef, useState, useEffect, useCallback } from "react";
+import { useImageCutout, type CutoutMode } from "@/hooks/useImageCutout";
+
+export default function ImageCutout() {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const {
+    options,
+    setOptions,
+    imageUrl,
+    setImage,
+    selection,
+    brushPath,
+    displayRef,
+    previewUrl,
+    startSelection,
+    updateSelection,
+    endSelection,
+    clearSelection,
+    download,
+  } = useImageCutout();
+  const dragState = useRef<{ active: boolean; startX: number; startY: number }>({ active: false, startX: 0, startY: 0 });
+  const [scale, setScale] = useState(1);
+
+  const getCanvasPoint = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>): { x: number; y: number } | null => {
+      const canvas = displayRef.current;
+      if (!canvas) return null;
+      const rect = canvas.getBoundingClientRect();
+      const x = (e.clientX - rect.left) / scale;
+      const y = (e.clientY - rect.top) / scale;
+      return { x, y };
+    },
+    [scale, displayRef]
+  );
+
+  const onMouseDown = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    const pt = getCanvasPoint(e);
+    if (!pt) return;
+    dragState.current = { active: true, startX: pt.x, startY: pt.y };
+    startSelection(pt.x, pt.y);
+  };
+
+  const onMouseMove = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    if (!dragState.current.active) return;
+    const pt = getCanvasPoint(e);
+    if (!pt) return;
+    updateSelection(pt.x, pt.y, dragState.current.startX, dragState.current.startY);
+  };
+
+  const onMouseUp = () => {
+    dragState.current.active = false;
+    endSelection();
+  };
+
+  // Compute display scale
+  useEffect(() => {
+    if (!displayRef.current) return;
+    const canvas = displayRef.current;
+    const containerWidth = canvas.parentElement?.clientWidth ?? 600;
+    const maxWidth = Math.min(containerWidth - 32, 800);
+    if (canvas.width > maxWidth) {
+      setScale(maxWidth / canvas.width);
+    } else {
+      setScale(1);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [imageUrl]);
+
+  return (
+    <div className="max-w-6xl mx-auto p-6">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">智能抠图</h1>
+        <p className="text-sm text-slate-500 mt-1">矩形或画笔选区 → 边缘羽化 → 导出透明 PNG</p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-4 space-y-4">
+          <div>
+            <h2 className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">选区模式</h2>
+            <div className="grid grid-cols-2 gap-1.5">
+              {(["rectangle", "brush"] as CutoutMode[]).map((m) => (
+                <button
+                  key={m}
+                  onClick={() => {
+                    setOptions({ ...options, mode: m });
+                    clearSelection();
+                  }}
+                  className={`px-2 py-1.5 text-xs rounded ${
+                    options.mode === m ? "bg-slate-900 text-white" : "bg-slate-100 dark:bg-slate-800"
+                  }`}
+                >
+                  {m === "rectangle" ? "矩形" : "画笔"}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {options.mode === "brush" && (
+            <div>
+              <div className="flex justify-between text-xs text-slate-500 mb-1">
+                <span>画笔大小</span>
+                <span>{options.brushSize}px</span>
+              </div>
+              <input
+                type="range"
+                min="10"
+                max="100"
+                value={options.brushSize}
+                onChange={(e) => setOptions({ ...options, brushSize: Number(e.target.value) })}
+                className="w-full accent-slate-900"
+              />
+            </div>
+          )}
+
+          <div>
+            <div className="flex justify-between text-xs text-slate-500 mb-1">
+              <span>边缘羽化</span>
+              <span>{options.feather}px</span>
+            </div>
+            <input
+              type="range"
+              min="0"
+              max="20"
+              value={options.feather}
+              onChange={(e) => setOptions({ ...options, feather: Number(e.target.value) })}
+              className="w-full accent-slate-900"
+            />
+          </div>
+
+          <div className="flex gap-2">
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              className="flex-1 px-3 py-1.5 text-sm bg-slate-900 text-white rounded hover:bg-slate-800"
+            >
+              {imageUrl ? "更换图片" : "选择图片"}
+            </button>
+            <button
+              onClick={clearSelection}
+              disabled={!selection && brushPath.length === 0}
+              className="px-3 py-1.5 text-sm border border-slate-200 dark:border-slate-700 rounded hover:bg-slate-50 dark:hover:bg-slate-800 disabled:opacity-50"
+            >
+              清除
+            </button>
+          </div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) setImage(f);
+            }}
+            className="hidden"
+            id="cutout-input"
+          />
+
+          {imageUrl && (
+            <button
+              onClick={download}
+              className="w-full px-4 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded hover:bg-slate-50 dark:hover:bg-slate-800"
+            >
+              下载 PNG
+            </button>
+          )}
+
+          {previewUrl && (
+            <a
+              href={previewUrl}
+              download="cutout.png"
+              className="block text-center text-xs text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              重新下载
+            </a>
+          )}
+        </div>
+
+        <div className="lg:col-span-2">
+          <div
+            className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-4"
+            style={{
+              backgroundImage:
+                "linear-gradient(45deg, #f1f5f9 25%, transparent 25%), linear-gradient(-45deg, #f1f5f9 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #f1f5f9 75%), linear-gradient(-45deg, transparent 75%, #f1f5f9 75%)",
+              backgroundSize: "16px 16px",
+              backgroundPosition: "0 0, 0 8px, 8px -8px, -8px 0px",
+            }}
+          >
+            {imageUrl ? (
+              <div className="overflow-auto flex items-center justify-center min-h-[500px]">
+                <canvas
+                  ref={displayRef}
+                  onMouseDown={onMouseDown}
+                  onMouseMove={onMouseMove}
+                  onMouseUp={onMouseUp}
+                  onMouseLeave={onMouseUp}
+                  style={{
+                    width: displayRef.current ? `${displayRef.current.width * scale}px` : "auto",
+                    height: displayRef.current ? `${displayRef.current.height * scale}px` : "auto",
+                    cursor: "crosshair",
+                    maxWidth: "100%",
+                  }}
+                />
+              </div>
+            ) : (
+              <div className="text-center py-12 text-slate-400">
+                上传图片开始<br />
+                <span className="text-xs">支持 PNG / JPG / WebP</span>
+              </div>
+            )}
+          </div>
+          <p className="text-xs text-slate-500 mt-2 text-center">
+            {options.mode === "rectangle" ? "拖动鼠标绘制矩形选区" : "拖动鼠标绘制选区"} · 羽化软化边缘
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useImageCutout.ts
+++ b/frontend/src/hooks/useImageCutout.ts
@@ -1,0 +1,247 @@
+/**
+ * useImageCutout Hook
+ *
+ * Rectangle or brush-based cutout with feathered edges.
+ * Output: PNG with transparency outside selection.
+ */
+
+import { useState, useCallback, useRef } from "react";
+
+export type CutoutMode = "rectangle" | "brush";
+
+export interface CutoutOptions {
+  mode: CutoutMode;
+  feather: number; // 0-20 px
+  brushSize: number; // 10-100 px
+}
+
+const DEFAULT_OPTIONS: CutoutOptions = {
+  mode: "rectangle",
+  feather: 2,
+  brushSize: 30,
+};
+
+export function useImageCutout() {
+  const [options, setOptions] = useState<CutoutOptions>(DEFAULT_OPTIONS);
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [imageSize, setImageSize] = useState<{ width: number; height: number }>({ width: 0, height: 0 });
+  const [selection, setSelection] = useState<{ x: number; y: number; w: number; h: number } | null>(null);
+  const [brushPath, setBrushPath] = useState<Array<{ x: number; y: number }>>([]);
+  const [isDrawing, setIsDrawing] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const displayRef = useRef<HTMLCanvasElement | null>(null);
+
+  const setImage = useCallback(
+    (file: File) => {
+      if (imageUrl) URL.revokeObjectURL(imageUrl);
+      const url = URL.createObjectURL(file);
+      setImageUrl(url);
+      const img = new Image();
+      img.onload = () => {
+        setImageSize({ width: img.naturalWidth, height: img.naturalHeight });
+        setSelection(null);
+        setBrushPath([]);
+      };
+      img.src = url;
+    },
+    [imageUrl]
+  );
+
+  const renderDisplay = useCallback(() => {
+    const display = displayRef.current;
+    if (!display || !imageUrl) return;
+    const img = new Image();
+    img.onload = () => {
+      display.width = img.naturalWidth;
+      display.height = img.naturalHeight;
+      const ctx = display.getContext("2d");
+      if (!ctx) return;
+      ctx.drawImage(img, 0, 0);
+
+      // Overlay selection
+      if (options.mode === "rectangle" && selection) {
+        ctx.save();
+        ctx.strokeStyle = "#3b82f6";
+        ctx.lineWidth = 2;
+        ctx.setLineDash([6, 4]);
+        ctx.strokeRect(selection.x, selection.y, selection.w, selection.h);
+        ctx.fillStyle = "rgba(59,130,246,0.1)";
+        ctx.fillRect(selection.x, selection.y, selection.w, selection.h);
+        ctx.restore();
+      } else if (options.mode === "brush" && brushPath.length > 0) {
+        ctx.save();
+        ctx.strokeStyle = "#3b82f6";
+        ctx.lineWidth = options.brushSize;
+        ctx.lineCap = "round";
+        ctx.lineJoin = "round";
+        ctx.globalAlpha = 0.3;
+        ctx.beginPath();
+        ctx.moveTo(brushPath[0].x, brushPath[0].y);
+        brushPath.forEach((p) => ctx.lineTo(p.x, p.y));
+        ctx.stroke();
+        ctx.restore();
+      }
+    };
+    img.src = imageUrl;
+  }, [imageUrl, options, selection, brushPath]);
+
+  const exportCutout = useCallback(async (): Promise<Blob | null> => {
+    if (!imageUrl) return null;
+    const img = new Image();
+    await new Promise<void>((resolve, reject) => {
+      img.onload = () => resolve();
+      img.onerror = () => reject(new Error("Failed to load image"));
+      img.src = imageUrl;
+    });
+
+    const out = document.createElement("canvas");
+    out.width = img.naturalWidth;
+    out.height = img.naturalHeight;
+    const ctx = out.getContext("2d");
+    if (!ctx) return null;
+
+    // Build alpha mask
+    const mask = document.createElement("canvas");
+    mask.width = img.naturalWidth;
+    mask.height = img.naturalHeight;
+    const mctx = mask.getContext("2d");
+    if (!mctx) return null;
+    mctx.fillStyle = "#000";
+    mctx.fillRect(0, 0, out.width, out.height);
+    mctx.fillStyle = "#fff";
+    if (options.mode === "rectangle" && selection) {
+      mctx.fillRect(selection.x, selection.y, selection.w, selection.h);
+    } else if (options.mode === "brush" && brushPath.length > 0) {
+      mctx.strokeStyle = "#fff";
+      mctx.lineWidth = options.brushSize;
+      mctx.lineCap = "round";
+      mctx.lineJoin = "round";
+      mctx.beginPath();
+      mctx.moveTo(brushPath[0].x, brushPath[0].y);
+      brushPath.forEach((p) => mctx.lineTo(p.x, p.y));
+      mctx.stroke();
+    } else {
+      // No selection: keep whole image
+      mctx.fillStyle = "#fff";
+      mctx.fillRect(0, 0, out.width, out.height);
+    }
+
+    // Apply feather (box blur approximation) to mask
+    if (options.feather > 0) {
+      const imgData = mctx.getImageData(0, 0, out.width, out.height);
+      const blurred = boxBlur(imgData, options.feather);
+      mctx.putImageData(blurred, 0, 0);
+    }
+
+    // Draw image, then erase with inverse mask
+    ctx.drawImage(img, 0, 0);
+    ctx.globalCompositeOperation = "destination-in";
+    ctx.drawImage(mask, 0, 0);
+    ctx.globalCompositeOperation = "source-over";
+
+    return new Promise<Blob | null>((resolve) => {
+      out.toBlob((blob) => resolve(blob), "image/png");
+    });
+  }, [imageUrl, options, selection, brushPath]);
+
+  const download = useCallback(async () => {
+    const blob = await exportCutout();
+    if (!blob) return;
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "cutout.png";
+    a.click();
+    setPreviewUrl(url);
+  }, [exportCutout]);
+
+  // Mouse handlers for selection
+  const startSelection = useCallback(
+    (x: number, y: number) => {
+      if (options.mode === "rectangle") {
+        setSelection({ x, y, w: 0, h: 0 });
+      } else {
+        setIsDrawing(true);
+        setBrushPath([{ x, y }]);
+      }
+    },
+    [options.mode]
+  );
+
+  const updateSelection = useCallback(
+    (x: number, y: number, startX: number, startY: number) => {
+      if (options.mode === "rectangle") {
+        setSelection({
+          x: Math.min(startX, x),
+          y: Math.min(startY, y),
+          w: Math.abs(x - startX),
+          h: Math.abs(y - startY),
+        });
+      } else if (isDrawing) {
+        setBrushPath((prev) => [...prev, { x, y }]);
+      }
+    },
+    [options.mode, isDrawing]
+  );
+
+  const endSelection = useCallback(() => {
+    setIsDrawing(false);
+  }, []);
+
+  const clearSelection = useCallback(() => {
+    setSelection(null);
+    setBrushPath([]);
+  }, []);
+
+  return {
+    options,
+    setOptions,
+    imageUrl,
+    imageSize,
+    setImage,
+    selection,
+    brushPath,
+    canvasRef,
+    displayRef,
+    previewUrl,
+    renderDisplay,
+    startSelection,
+    updateSelection,
+    endSelection,
+    clearSelection,
+    exportCutout,
+    download,
+  };
+}
+
+// Simple box blur for feather
+function boxBlur(imageData: ImageData, radius: number): ImageData {
+  const { data, width, height } = imageData;
+  const output = new ImageData(width, height);
+  const r = Math.max(1, Math.floor(radius));
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      let sum = 0;
+      let count = 0;
+      for (let dy = -r; dy <= r; dy++) {
+        for (let dx = -r; dx <= r; dx++) {
+          const nx = x + dx;
+          const ny = y + dy;
+          if (nx >= 0 && nx < width && ny >= 0 && ny < height) {
+            const i = (ny * width + nx) * 4;
+            sum += data[i]; // alpha
+            count++;
+          }
+        }
+      }
+      const avg = sum / count;
+      const i = (y * width + x) * 4;
+      output.data[i] = avg;
+      output.data[i + 1] = avg;
+      output.data[i + 2] = avg;
+      output.data[i + 3] = avg;
+    }
+  }
+  return output;
+}

--- a/frontend/src/pages/tools/cutout.astro
+++ b/frontend/src/pages/tools/cutout.astro
@@ -1,0 +1,8 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import ImageCutout from '../../components/tools/ImageCutout';
+---
+
+<Layout title="智能抠图">
+  <ImageCutout client:load />
+</Layout>


### PR DESCRIPTION
## Feature #88: 智能抠图

矩形/画笔选区 + 边缘羽化 + PNG 透明导出。

## 根因
与 #15 去背景互补：去背景是整图，抠图是局部精确选择（去掉手指、水印等）。

## 方案
纯前端 Canvas API（@Martin P0 范围）：
- 矩形 / 画笔两种模式
- 羽化 0-20px
- PNG 透明导出

## 验证
- ✅ typecheck / lint / build 全部通过