### PR TITLE
refactor: unify route export style to default export

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -10,12 +10,12 @@ import { logger } from "hono/logger";
 import { timing } from "hono/timing";
 import { secureHeaders } from "hono/secure-headers";
 
-import { authRoutes } from "./routes/auth";
-import { userRoutes } from "./routes/user";
-import { generationRoutes } from "./routes/generations";
-import { uploadRoutes } from "./routes/upload";
-import { subscriptionRoutes } from "./routes/subscription";
-import { favoriteRoutes } from "./routes/favorites";
+import authRoutes from "./routes/auth";
+import userRoutes from "./routes/user";
+import generationRoutes from "./routes/generations";
+import uploadRoutes from "./routes/upload";
+import subscriptionRoutes from "./routes/subscription";
+import favoriteRoutes from "./routes/favorites";
 import statsRoutes from "./routes/stats";
 import notificationRoutes from "./routes/notifications";
 import errorRoutes from "./routes/errors";

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -195,4 +195,4 @@ router.post("/reset-password", async (c) => {
   return c.json(data, response.status as never);
 });
 
-export { router as authRoutes };
+export default router;

--- a/api/src/routes/favorites.ts
+++ b/api/src/routes/favorites.ts
@@ -282,4 +282,4 @@ router.get("/check/:imageUrl", async (c) => {
   });
 });
 
-export { router as favoriteRoutes };
+export default router;

--- a/api/src/routes/generations.ts
+++ b/api/src/routes/generations.ts
@@ -246,4 +246,4 @@ router.delete("/:id", async (c) => {
   });
 });
 
-export { router as generationRoutes };
+export default router;

--- a/api/src/routes/subscription.ts
+++ b/api/src/routes/subscription.ts
@@ -191,4 +191,4 @@ router.post("/portal", async (c) => {
   }
 });
 
-export { router as subscriptionRoutes };
+export default router;

--- a/api/src/routes/upload.ts
+++ b/api/src/routes/upload.ts
@@ -189,4 +189,4 @@ router.post(
   }
 );
 
-export { router as uploadRoutes };
+export default router;

--- a/api/src/routes/user.ts
+++ b/api/src/routes/user.ts
@@ -113,4 +113,4 @@ router.put("/avatar", async (c) => {
   }
 });
 
-export { router as userRoutes };
+export default router;


### PR DESCRIPTION
## Summary

Convert 6 route files from named export to default export for consistency with the other 10 route files.

## Changes

### Route files (named → default export)
- `auth.ts`: `export { router as authRoutes }` → `export default router`
- `favorites.ts`: `export { router as favoriteRoutes }` → `export default router`
- `generations.ts`: `export { router as generationRoutes }` → `export default router`
- `subscription.ts`: `export { router as subscriptionRoutes }` → `export default router`
- `upload.ts`: `export { router as uploadRoutes }` → `export default router`
- `user.ts`: `export { router as userRoutes }` → `export default router`

### index.ts
All route imports now use default import style:
```ts
import authRoutes from "./routes/auth";
// ... (6 imports updated)
```

## Verification
- `tsc --noEmit` ✓
- `eslint` ✓
- All 16 route files registered in index.ts, no missing/extra files
- All files < 500 lines (max: teams.ts 319 lines), no splitting needed

## Diff
7 files changed, 12 insertions(+), 12 deletions(-)