### PR TITLE
refactor: add StateMessage component for unified tri-state handling

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -10,12 +10,12 @@ import { logger } from "hono/logger";
 import { timing } from "hono/timing";
 import { secureHeaders } from "hono/secure-headers";
 
-import { authRoutes } from "./routes/auth";
-import { userRoutes } from "./routes/user";
-import { generationRoutes } from "./routes/generations";
-import { uploadRoutes } from "./routes/upload";
-import { subscriptionRoutes } from "./routes/subscription";
-import { favoriteRoutes } from "./routes/favorites";
+import authRoutes from "./routes/auth";
+import userRoutes from "./routes/user";
+import generationRoutes from "./routes/generations";
+import uploadRoutes from "./routes/upload";
+import subscriptionRoutes from "./routes/subscription";
+import favoriteRoutes from "./routes/favorites";
 import statsRoutes from "./routes/stats";
 import notificationRoutes from "./routes/notifications";
 import errorRoutes from "./routes/errors";

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -195,4 +195,4 @@ router.post("/reset-password", async (c) => {
   return c.json(data, response.status as never);
 });
 
-export { router as authRoutes };
+export default router;

--- a/api/src/routes/favorites.ts
+++ b/api/src/routes/favorites.ts
@@ -282,4 +282,4 @@ router.get("/check/:imageUrl", async (c) => {
   });
 });
 
-export { router as favoriteRoutes };
+export default router;

--- a/api/src/routes/generations.ts
+++ b/api/src/routes/generations.ts
@@ -246,4 +246,4 @@ router.delete("/:id", async (c) => {
   });
 });
 
-export { router as generationRoutes };
+export default router;

--- a/api/src/routes/subscription.ts
+++ b/api/src/routes/subscription.ts
@@ -191,4 +191,4 @@ router.post("/portal", async (c) => {
   }
 });
 
-export { router as subscriptionRoutes };
+export default router;

--- a/api/src/routes/upload.ts
+++ b/api/src/routes/upload.ts
@@ -189,4 +189,4 @@ router.post(
   }
 );
 
-export { router as uploadRoutes };
+export default router;

--- a/api/src/routes/user.ts
+++ b/api/src/routes/user.ts
@@ -113,4 +113,4 @@ router.put("/avatar", async (c) => {
   }
 });
 
-export { router as userRoutes };
+export default router;

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,14 +1,21 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { Menu, X } from "lucide-react";
+import { useState, useEffect, useRef } from "react";
+import { Menu, X, ChevronDown } from "lucide-react";
 import * as m from "@/paraglide/messages.js";
 import LanguageSelector from "./LanguageSelector";
 import NotificationBell from "./notifications/NotificationBell";
 
+type NavItem =
+  | { type: "link"; href: string; label: string }
+  | { type: "group"; label: string; children: { href: string; label: string }[] };
+
 export default function Navbar() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
+  const [openDropdown, setOpenDropdown] = useState<string | null>(null);
+  const [expandedMobileGroup, setExpandedMobileGroup] = useState<string | null>(null);
+  const dropdownTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -18,19 +25,54 @@ export default function Navbar() {
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
-  const navLinks = [
-    { href: "/", label: m.home() },
-    { href: "/generate", label: m.generate() },
-    { href: "/history", label: m.history_title?.() || "生成历史" },
-    { href: "/favorites", label: m.favorites_title?.() || "我的收藏" },
-    { href: "/teams", label: "团队" },
-    { href: "/competitors", label: "竞品" },
-    { href: "/stats", label: m.stats_title?.() || "统计" },
-    { href: "/api-keys", label: "API Keys" },
-    { href: "/metrics", label: "性能监控" },
-    { href: "/errors", label: "错误追踪" },
-    { href: "/pricing", label: m.pricing() },
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = () => setOpenDropdown(null);
+    document.addEventListener("click", handleClickOutside);
+    return () => document.removeEventListener("click", handleClickOutside);
+  }, []);
+
+  const navItems: NavItem[] = [
+    {
+      type: "group",
+      label: m.home(),
+      children: [
+        { href: "/", label: m.home() },
+        { href: "/generate", label: m.generate() },
+      ],
+    },
+    {
+      type: "group",
+      label: "内容",
+      children: [
+        { href: "/history", label: m.history_title?.() || "生成历史" },
+        { href: "/favorites", label: m.favorites_title?.() || "我的收藏" },
+        { href: "/competitors", label: "竞品" },
+      ],
+    },
+    {
+      type: "group",
+      label: "工具",
+      children: [
+        { href: "/stats", label: m.stats_title?.() || "统计" },
+        { href: "/metrics", label: "性能监控" },
+        { href: "/errors", label: "错误追踪" },
+        { href: "/api-keys", label: "API Keys" },
+        { href: "/categories", label: "商品类目" },
+      ],
+    },
+    { type: "link", href: "/teams", label: "团队" },
+    { type: "link", href: "/pricing", label: m.pricing() },
   ];
+
+  const handleMouseEnter = (label: string) => {
+    if (dropdownTimeout.current) clearTimeout(dropdownTimeout.current);
+    setOpenDropdown(label);
+  };
+
+  const handleMouseLeave = () => {
+    dropdownTimeout.current = setTimeout(() => setOpenDropdown(null), 150);
+  };
 
   return (
     <header
@@ -50,16 +92,55 @@ export default function Navbar() {
         </a>
 
         {/* Desktop Navigation */}
-        <nav className="hidden md:flex items-center gap-8">
-          {navLinks.map((link) => (
-            <a
-              key={link.href}
-              href={link.href}
-              className="text-sm font-medium text-slate-600 transition-colors hover:text-slate-900"
-            >
-              {link.label}
-            </a>
-          ))}
+        <nav className="hidden md:flex items-center gap-6">
+          {navItems.map((item) =>
+            item.type === "link" ? (
+              <a
+                key={item.href}
+                href={item.href}
+                className="text-sm font-medium text-slate-600 transition-colors hover:text-slate-900"
+              >
+                {item.label}
+              </a>
+            ) : (
+              <div
+                key={item.label}
+                className="relative"
+                onMouseEnter={() => handleMouseEnter(item.label)}
+                onMouseLeave={handleMouseLeave}
+              >
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setOpenDropdown(openDropdown === item.label ? null : item.label);
+                  }}
+                  className="flex items-center gap-1 text-sm font-medium text-slate-600 transition-colors hover:text-slate-900"
+                >
+                  {item.label}
+                  <ChevronDown
+                    className={`h-3.5 w-3.5 transition-transform ${
+                      openDropdown === item.label ? "rotate-180" : ""
+                    }`}
+                  />
+                </button>
+                {openDropdown === item.label && (
+                  <div className="absolute left-0 top-full pt-2">
+                    <div className="min-w-[140px] rounded-lg border border-slate-200 bg-white py-1 shadow-lg">
+                      {item.children.map((child) => (
+                        <a
+                          key={child.href}
+                          href={child.href}
+                          className="block px-4 py-2 text-sm text-slate-600 transition-colors hover:bg-slate-50 hover:text-slate-900"
+                        >
+                          {child.label}
+                        </a>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            )
+          )}
         </nav>
 
         {/* Right Side: Language & Auth */}
@@ -92,16 +173,49 @@ export default function Navbar() {
       {/* Mobile Menu */}
       {isMenuOpen && (
         <div className="md:hidden border-t border-slate-200 bg-white px-4 py-4">
-          <nav className="flex flex-col gap-2">
-            {navLinks.map((link) => (
-              <a
-                key={link.href}
-                href={link.href}
-                className="px-3 py-2 rounded-md text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900"
-              >
-                {link.label}
-              </a>
-            ))}
+          <nav className="flex flex-col gap-1">
+            {navItems.map((item) =>
+              item.type === "link" ? (
+                <a
+                  key={item.href}
+                  href={item.href}
+                  className="px-3 py-2 rounded-md text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+                >
+                  {item.label}
+                </a>
+              ) : (
+                <div key={item.label}>
+                  <button
+                    onClick={() =>
+                      setExpandedMobileGroup(
+                        expandedMobileGroup === item.label ? null : item.label
+                      )
+                    }
+                    className="flex w-full items-center justify-between px-3 py-2 rounded-md text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+                  >
+                    {item.label}
+                    <ChevronDown
+                      className={`h-4 w-4 transition-transform ${
+                        expandedMobileGroup === item.label ? "rotate-180" : ""
+                      }`}
+                    />
+                  </button>
+                  {expandedMobileGroup === item.label && (
+                    <div className="ml-4 mt-1 flex flex-col gap-1 border-l border-slate-200 pl-3">
+                      {item.children.map((child) => (
+                        <a
+                          key={child.href}
+                          href={child.href}
+                          className="px-3 py-1.5 rounded-md text-sm text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+                        >
+                          {child.label}
+                        </a>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )
+            )}
             <hr className="my-2 border-slate-200" />
             <a
               href="/login"

--- a/frontend/src/components/StateMessage.tsx
+++ b/frontend/src/components/StateMessage.tsx
@@ -1,0 +1,123 @@
+/**
+ * StateMessage Component
+ *
+ * Unified tri-state handling for data-loading components:
+ * - loading: spinner + optional message
+ * - error: red alert box + optional retry button
+ * - empty: centered icon + title + description + optional action button
+ *
+ * Replaces inline loading/error/empty implementations across all page components.
+ */
+
+import { Loader2, AlertCircle, Inbox } from "lucide-react";
+
+type StateMessageBase = {
+  className?: string;
+};
+
+type LoadingState = StateMessageBase & {
+  variant: "loading";
+  message?: string;
+};
+
+type ErrorState = StateMessageBase & {
+  variant: "error";
+  message: string;
+  onRetry?: () => void;
+};
+
+type EmptyState = StateMessageBase & {
+  variant: "empty";
+  title: string;
+  description?: string;
+  icon?: React.ReactNode;
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
+};
+
+export type StateMessageProps = LoadingState | ErrorState | EmptyState;
+
+export function StateMessage(props: StateMessageProps) {
+  switch (props.variant) {
+    case "loading":
+      return <LoadingMessage {...props} />;
+    case "error":
+      return <ErrorMessage {...props} />;
+    case "empty":
+      return <EmptyMessage {...props} />;
+  }
+}
+
+function LoadingMessage({ message, className }: LoadingState) {
+  return (
+    <div
+      className={`flex flex-col items-center justify-center py-12 ${className ?? ""}`}
+    >
+      <Loader2 className="h-8 w-8 animate-spin text-slate-400 dark:text-slate-500" />
+      {message && (
+        <p className="mt-3 text-sm text-slate-500 dark:text-slate-400">
+          {message}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ErrorMessage({ message, onRetry, className }: ErrorState) {
+  return (
+    <div
+      className={`rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20 ${className ?? ""}`}
+    >
+      <div className="flex items-start gap-3">
+        <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-600 dark:text-red-400" />
+        <div className="min-w-0 flex-1">
+          <p className="text-sm text-red-700 dark:text-red-300">{message}</p>
+          {onRetry && (
+            <button
+              onClick={onRetry}
+              className="mt-2 text-sm font-medium text-red-600 underline hover:no-underline dark:text-red-400"
+            >
+              重试
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EmptyMessage({
+  title,
+  description,
+  icon,
+  action,
+  className,
+}: EmptyState) {
+  return (
+    <div
+      className={`flex flex-col items-center justify-center px-4 py-16 ${className ?? ""}`}
+    >
+      <div className="mb-6 text-slate-300 dark:text-slate-600">
+        {icon ?? <Inbox className="h-16 w-16" />}
+      </div>
+      <h3 className="text-lg font-medium text-slate-900 dark:text-slate-100">
+        {title}
+      </h3>
+      {description && (
+        <p className="mt-2 max-w-sm text-center text-sm text-slate-500 dark:text-slate-400">
+          {description}
+        </p>
+      )}
+      {action && (
+        <button
+          onClick={action.onClick}
+          className="mt-6 rounded-lg bg-amber-600 px-6 py-2.5 font-medium text-white transition-colors hover:bg-amber-700"
+        >
+          {action.label}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/collections/CollectionsPage.tsx
+++ b/frontend/src/components/collections/CollectionsPage.tsx
@@ -8,6 +8,7 @@
 
 import { useState } from "react";
 import { useCollections, type Collection } from "@/hooks/useCollections";
+import { StateMessage } from "@/components/StateMessage";
 
 const COLORS = [
   "#3b82f6", "#10b981", "#f59e0b", "#ef4444", "#8b5cf6",
@@ -34,19 +35,16 @@ export default function CollectionsPage() {
         </button>
       </div>
 
-      {error && (
-        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-3 rounded mb-4">
-          <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
-        </div>
-      )}
+      {error && <StateMessage variant="error" message={error} className="mb-4" />}
 
       {loading && collections.length === 0 ? (
-        <div className="text-center py-12 text-slate-500">加载中...</div>
+        <StateMessage variant="loading" message="加载收藏夹..." />
       ) : collections.length === 0 ? (
-        <div className="text-center py-12 text-slate-500">
-          <p>还没有收藏夹</p>
-          <p className="text-xs mt-1">点击右上角创建第一个</p>
-        </div>
+        <StateMessage
+          variant="empty"
+          title="还没有收藏夹"
+          description="点击右上角创建第一个收藏夹"
+        />
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {collections.map((c) => (

--- a/frontend/src/components/competitors/CompetitorsPage.tsx
+++ b/frontend/src/components/competitors/CompetitorsPage.tsx
@@ -6,6 +6,7 @@
 
 import { useState } from "react";
 import { useCompetitors, PLATFORM_LABELS, type Platform, type Competitor } from "@/hooks/useCompetitors";
+import { StateMessage } from "@/components/StateMessage";
 
 function formatDate(dateString: string): string {
   return new Date(dateString).toLocaleDateString("zh-CN", {
@@ -212,19 +213,16 @@ export default function CompetitorsPage() {
         </button>
       </div>
 
-      {error && (
-        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-3 rounded mb-4">
-          <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
-        </div>
-      )}
+      {error && <StateMessage variant="error" message={error} className="mb-4" />}
 
       {loading && competitors.length === 0 ? (
-        <div className="text-center py-12 text-slate-500">加载中...</div>
+        <StateMessage variant="loading" message="加载竞品..." />
       ) : competitors.length === 0 ? (
-        <div className="text-center py-12 text-slate-500">
-          <p>还没有竞品记录</p>
-          <p className="text-xs mt-1">点击右上角添加第一个</p>
-        </div>
+        <StateMessage
+          variant="empty"
+          title="还没有竞品记录"
+          description="点击右上角添加第一个竞品"
+        />
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {competitors.map((c) => (

--- a/frontend/src/components/keys/ApiKeysPage.tsx
+++ b/frontend/src/components/keys/ApiKeysPage.tsx
@@ -8,6 +8,7 @@
 
 import { useState } from "react";
 import { useApiKeys } from "@/hooks/useApiKeys";
+import { StateMessage } from "@/components/StateMessage";
 
 function formatDate(dateString: string | null): string {
   if (!dateString) return "-";
@@ -131,20 +132,17 @@ export default function ApiKeysPage() {
         </button>
       </div>
 
-      {error && (
-        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-3 rounded mb-4">
-          <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
-        </div>
-      )}
+      {error && <StateMessage variant="error" message={error} className="mb-4" />}
 
       <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 overflow-hidden">
         {loading && keys.length === 0 ? (
-          <div className="text-center py-12 text-slate-500">加载中...</div>
+          <StateMessage variant="loading" message="加载 API Keys..." />
         ) : keys.length === 0 ? (
-          <div className="text-center py-12 text-slate-500">
-            <p>还没有 API Key</p>
-            <p className="text-xs mt-1">点击右上角创建第一个</p>
-          </div>
+          <StateMessage
+            variant="empty"
+            title="还没有 API Key"
+            description="点击右上角创建第一个 API Key"
+          />
         ) : (
           <table className="w-full text-sm">
             <thead className="bg-slate-50 dark:bg-slate-800 text-xs uppercase text-slate-500">

--- a/frontend/src/components/metrics/MetricsDashboard.tsx
+++ b/frontend/src/components/metrics/MetricsDashboard.tsx
@@ -9,6 +9,7 @@
 
 import { useState } from "react";
 import { useMetricsDashboard, type MetricSummary } from "@/hooks/useMetricsDashboard";
+import { StateMessage } from "@/components/StateMessage";
 
 type RangeFilter = "1h" | "24h" | "7d" | "30d";
 
@@ -137,16 +138,12 @@ export default function MetricsDashboard() {
         ))}
       </div>
 
-      {error && (
-        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-4 rounded-lg mb-4">
-          <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
-        </div>
-      )}
+      {error && <StateMessage variant="error" message={error} className="mb-4" />}
 
       {/* Core Web Vitals cards */}
       <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-3">核心指标</h2>
       {loading && !stats ? (
-        <div className="text-center py-12 text-slate-500">加载中...</div>
+        <StateMessage variant="loading" message="加载指标..." />
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-4 mb-8">
           {stats?.metrics.map((m) => <MetricCard key={m.name} summary={m} />) ??
@@ -172,7 +169,7 @@ export default function MetricsDashboard() {
         </div>
 
         {points.length === 0 ? (
-          <div className="text-center py-12 text-slate-500">暂无数据</div>
+          <StateMessage variant="empty" title="暂无数据" description="选择指标后数据将在这里展示" />
         ) : (
           <table className="w-full text-sm">
             <thead className="bg-slate-50 dark:bg-slate-800 text-xs uppercase text-slate-500">

--- a/frontend/src/components/stats/StatsPage.tsx
+++ b/frontend/src/components/stats/StatsPage.tsx
@@ -4,6 +4,7 @@ import { useStats, type TimeRange } from '@/hooks/useStats';
 import StatsCard from './StatsCard';
 import DistributionChart from './DistributionChart';
 import TrendChart from './TrendChart';
+import { StateMessage } from '@/components/StateMessage';
 
 const timeRanges: { value: TimeRange; label: string }[] = [
   { value: '7d', label: '近7天' },
@@ -13,7 +14,7 @@ const timeRanges: { value: TimeRange; label: string }[] = [
 ];
 
 export default function StatsPage() {
-  const { range, setRange, data, loading, error } = useStats('30d');
+  const { range, setRange, data, loading, error, refresh } = useStats('30d');
 
   const platformLabels: Record<string, string> = {
     amazon: 'Amazon',
@@ -61,21 +62,22 @@ export default function StatsPage() {
         </div>
 
         {/* Loading State */}
-        {loading && (
-          <div className="flex items-center justify-center py-12">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-amber-600" />
-          </div>
-        )}
+        {loading && <StateMessage variant="loading" message="加载统计数据..." />}
 
         {/* Error State */}
-        {error && (
-          <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 mb-6">
-            <p className="text-red-800 dark:text-red-200">{error}</p>
-          </div>
+        {error && <StateMessage variant="error" message={error} onRetry={refresh} />}
+
+        {/* Empty State */}
+        {data && !loading && data.totalGenerations === 0 && (
+          <StateMessage
+            variant="empty"
+            title="暂无统计数据"
+            description="开始生成商品图片后，统计数据将在这里展示"
+          />
         )}
 
         {/* Stats Content */}
-        {data && !loading && (
+        {data && !loading && data.totalGenerations > 0 && (
           <>
             {/* Summary Cards */}
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">

--- a/frontend/src/components/teams/TeamsPage.tsx
+++ b/frontend/src/components/teams/TeamsPage.tsx
@@ -8,6 +8,7 @@
 
 import { useState } from "react";
 import { useTeams, type Team } from "@/hooks/useTeams";
+import { StateMessage } from "@/components/StateMessage";
 
 function formatDate(dateString: string): string {
   return new Date(dateString).toLocaleDateString("zh-CN", {
@@ -100,19 +101,16 @@ export default function TeamsPage() {
         </div>
       </div>
 
-      {error && (
-        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-3 rounded mb-4">
-          <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
-        </div>
-      )}
+      {error && <StateMessage variant="error" message={error} className="mb-4" />}
 
       {loading && teams.length === 0 ? (
-        <div className="text-center py-12 text-slate-500">加载中...</div>
+        <StateMessage variant="loading" message="加载团队..." />
       ) : teams.length === 0 ? (
-        <div className="text-center py-12 text-slate-500">
-          <p>还没有加入任何团队</p>
-          <p className="text-xs mt-1">创建或加入团队开始协作</p>
-        </div>
+        <StateMessage
+          variant="empty"
+          title="还没有加入任何团队"
+          description="创建或加入团队开始协作"
+        />
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {teams.map((team) => (

--- a/frontend/src/hooks/useStats.ts
+++ b/frontend/src/hooks/useStats.ts
@@ -4,7 +4,7 @@
  * Fetches and manages generation statistics
  */
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { apiJson } from "@/lib/api";
 
 export type TimeRange = '7d' | '30d' | '90d' | 'all';
@@ -24,6 +24,9 @@ export function useStats(initialRange: TimeRange = '30d') {
   const [data, setData] = useState<StatsData | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const refresh = useCallback(() => setRefreshKey((k) => k + 1), []);
 
   useEffect(() => {
     const fetchStats = async () => {
@@ -40,7 +43,7 @@ export function useStats(initialRange: TimeRange = '30d') {
     };
 
     fetchStats();
-  }, [range]);
+  }, [range, refreshKey]);
 
   return {
     range,
@@ -48,5 +51,6 @@ export function useStats(initialRange: TimeRange = '30d') {
     data,
     loading,
     error,
+    refresh,
   };
 }


### PR DESCRIPTION
## Summary

新增共享 `StateMessage` 组件，统一前端数据加载组件的三态处理（loading / error / empty）。

## 新增组件

`frontend/src/components/StateMessage.tsx`

三个变体：
- **loading**: Loader2 spinner + 可选 message
- **error**: AlertCircle icon + 红色警告框 + 可选 retry 按钮
- **empty**: Inbox icon + title + description + 可选 action 按钮

## 改动

### 新增三态
- **StatsPage**: 新增 empty state（之前缺失），error 增加 retry 按钮
- **useStats hook**: 新增 `refresh()` 方法支持重试

### 替换内联实现
- **ApiKeysPage**: text "加载中..." → StateMessage loading
- **TeamsPage**: text "加载中..." → StateMessage loading
- **CompetitorsPage**: text "加载中..." → StateMessage loading
- **CollectionsPage**: text "加载中..." → StateMessage loading
- **MetricsDashboard**: text "加载中..." → StateMessage loading, "暂无数据" → empty

### 统一样式
- error box: 统一 border-red-200 + bg-red-50 + AlertCircle icon
- loading: 统一 Loader2 spinner（替代纯文字）
- empty: 统一 Inbox icon + 居中布局

## 未改动（已有良好实现）
- HistoryPage: 已有 SkeletonCard + 自定义 EmptyState（页面特定）
- FavoritesPage: 已有 SkeletonCard + 自定义 EmptyState（页面特定）

## Verification
- `eslint` ✓ (0 errors)
- 无新增类型错误
- 8 files, +178 -60