### PR TITLE
chore: clean up console.log and add no-console ESLint rule

### DIFF
--- a/api/eslint.config.js
+++ b/api/eslint.config.js
@@ -14,6 +14,7 @@ export default tseslint.config(
     rules: {
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+      'no-console': ['warn', { allow: ['warn', 'error', 'info'] }],
     },
   },
   {

--- a/api/src/lib/mail.ts
+++ b/api/src/lib/mail.ts
@@ -56,7 +56,7 @@ export async function sendPasswordResetEmail(
       `,
     });
 
-    console.log("[Mail] Password reset email sent to:", user.email);
+    console.info("[Mail] Password reset email sent to:", user.email);
   } catch (error) {
     console.error("[Mail] Failed to send password reset email:", error);
     throw error;
@@ -86,7 +86,7 @@ export async function sendWelcomeEmail(user: UserInfo, env: Env) {
       `,
     });
 
-    console.log("[Mail] Welcome email sent to:", user.email);
+    console.info("[Mail] Welcome email sent to:", user.email);
   } catch (error) {
     console.error("[Mail] Failed to send welcome email:", error);
   }

--- a/api/src/routes/webhooks/stripe.ts
+++ b/api/src/routes/webhooks/stripe.ts
@@ -94,7 +94,7 @@ router.post("/stripe", async (c) => {
               },
             });
 
-          console.log("[Webhook] Checkout completed for user:", userId, "plan:", plan);
+          console.info("[Webhook] Checkout completed for user:", userId, "plan:", plan);
         }
         break;
       }
@@ -121,7 +121,7 @@ router.post("/stripe", async (c) => {
             })
             .where(eq(schema.subscriptions.id, existing.id));
 
-          console.log(
+          console.info(
             "[Webhook] Subscription updated:",
             externalSubscriptionId,
             "status:",
@@ -149,7 +149,7 @@ router.post("/stripe", async (c) => {
             })
             .where(eq(schema.subscriptions.id, existing.id));
 
-          console.log("[Webhook] Subscription canceled:", externalSubscriptionId);
+          console.info("[Webhook] Subscription canceled:", externalSubscriptionId);
         }
         break;
       }
@@ -173,13 +173,13 @@ router.post("/stripe", async (c) => {
             })
             .where(eq(schema.subscriptions.id, existing.id));
 
-          console.log("[Webhook] Payment failed for subscription:", subscriptionId);
+          console.info("[Webhook] Payment failed for subscription:", subscriptionId);
         }
         break;
       }
 
       default:
-        console.log("[Webhook] Unhandled event type:", event.type);
+        console.info("[Webhook] Unhandled event type:", event.type);
     }
 
     return c.json({ success: true, received: true });

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -14,6 +14,7 @@ export default tseslint.config(
       ...reactHooks.configs.recommended.rules,
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+      'no-console': ['warn', { allow: ['warn', 'error', 'info'] }],
     },
   },
   {

--- a/frontend/src/components/HistoryPage.tsx
+++ b/frontend/src/components/HistoryPage.tsx
@@ -209,9 +209,8 @@ export default function HistoryPage() {
         <ImageEditor
           imageUrl={editingImage}
           onClose={() => setEditingImage(null)}
-          onSave={async (blob) => {
+          onSave={async (_blob) => {
             // TODO: Implement save to backend
-            console.log("Saving edited image:", blob);
             setEditingImage(null);
           }}
         />

--- a/frontend/src/components/ProfilePage.tsx
+++ b/frontend/src/components/ProfilePage.tsx
@@ -139,8 +139,8 @@ function UserInfoCard() {
 
 // Generation History Component
 function GenerationHistory() {
-  const handleDelete = (id: string) => {
-    console.log("Delete record:", id);
+  const handleDelete = (_id: string) => {
+    // TODO: Implement delete functionality
   };
 
   return (


### PR DESCRIPTION
## Summary

清理 console.log 调试语句，添加 ESLint no-console 规则防止未来残留。

## 改动

### 移除 frontend console.log（调试语句）
- `HistoryPage.tsx`: 移除 onSave 中的 console.log（保留 TODO 注释）
- `ProfilePage.tsx`: 移除 handleDelete 中的 console.log（保留 TODO 注释）

### 转换 API console.log → console.info（操作日志）
- `lib/mail.ts`: [Mail] 信息日志
- `routes/webhooks/stripe.ts`: [Webhook] 信息日志

### 保留 console.error
所有 console.error 均在 try-catch 块中，为合法错误处理

### ESLint 规则
两个包均添加 `no-console: ['warn', { allow: ['warn', 'error', 'info'] }]`
- 阻止未来的 console.log
- 允许结构化的 info/error 日志

## Verification
- 0 console.log 残留（api/src/ 和 frontend/src/）
- eslint 通过（0 errors，1 pre-existing warning）
- `@typescript-eslint/no-unused-vars` 已覆盖未使用 import（无违规）
- 6 files, +12 -11