### PR TITLE
refactor: enable noUncheckedIndexedAccess for stricter type safety

### DIFF
--- a/api/src/middleware/apiKeyAuth.ts
+++ b/api/src/middleware/apiKeyAuth.ts
@@ -33,7 +33,7 @@ export const apiKeyAuth = createMiddleware<ApiKeyContext>(async (c, next) => {
     return c.json({ error: "Missing or malformed API key. Use: Authorization: Bearer op_xxx" }, 401);
   }
 
-  const key = match[1];
+  const key = match[1]!;
   const db = createDb(c.env.DB);
   const record = await validateApiKey(db, key);
   if (!record) {
@@ -52,7 +52,7 @@ export const apiKeyAuth = createMiddleware<ApiKeyContext>(async (c, next) => {
   }
 
   c.set("apiKey", { id: record.id, userId: record.userId, name: record.name });
-  c.set("apiKeyUser", users[0]);
+  c.set("apiKeyUser", users[0]!);
 
   await next();
 });

--- a/api/src/routes/competitors.ts
+++ b/api/src/routes/competitors.ts
@@ -100,7 +100,7 @@ competitors.post("/", zValidator("json", createSchema), async (c) => {
         createdAt: new Date(),
       })
       .returning();
-    return c.json({ success: true, data: toResponse(created) }, 201);
+    return c.json({ success: true, data: toResponse(created!) }, 201);
   } catch (error) {
     console.error("Failed to create competitor:", error);
     return c.json({ success: false, error: { code: "INTERNAL_ERROR", message: "Failed to create competitor" } }, 500);

--- a/api/src/routes/favorites.ts
+++ b/api/src/routes/favorites.ts
@@ -83,10 +83,10 @@ router.get("/", async (c) => {
     createdAt: fav.createdAt,
     generation: generations[fav.generationId]
       ? {
-          id: generations[fav.generationId].id,
-          status: generations[fav.generationId].status,
-          settings: generations[fav.generationId].settings,
-          createdAt: generations[fav.generationId].createdAt,
+          id: generations[fav.generationId]!.id,
+          status: generations[fav.generationId]!.status,
+          settings: generations[fav.generationId]!.settings,
+          createdAt: generations[fav.generationId]!.createdAt,
         }
       : null,
   }));

--- a/api/src/routes/feedback.ts
+++ b/api/src/routes/feedback.ts
@@ -64,7 +64,7 @@ feedback.post("/", zValidator("json", submitSchema), async (c) => {
       })
       .returning();
 
-    return c.json({ success: true, data: { id: created.id } }, 201);
+    return c.json({ success: true, data: { id: created!.id } }, 201);
   } catch (error) {
     console.error("Failed to submit feedback:", error);
     return c.json({ success: false, error: { code: "INTERNAL_ERROR", message: "Failed to submit feedback" } }, 500);

--- a/api/src/routes/upload.ts
+++ b/api/src/routes/upload.ts
@@ -167,7 +167,7 @@ router.post(
       return c.json({
         success: true,
         data: {
-          id: image.id,
+          id: image!.id,
           url: imageUrl,
           originalName: file.name,
           size: file.size,

--- a/api/src/services/apiKeyService.ts
+++ b/api/src/services/apiKeyService.ts
@@ -87,12 +87,12 @@ export async function createApiKey(
     .returning();
 
   return {
-    id: created.id,
-    name: created.name,
+    id: created!.id,
+    name: created!.name,
     key, // full key — caller MUST show to user once
-    keyPrefix: created.keyPrefix,
-    createdAt: created.createdAt,
-    expiresAt: created.expiresAt,
+    keyPrefix: created!.keyPrefix,
+    createdAt: created!.createdAt,
+    expiresAt: created!.expiresAt,
   };
 }
 
@@ -116,7 +116,7 @@ export async function validateApiKey(
     .limit(1);
 
   if (records.length === 0) return null;
-  const record = records[0];
+  const record = records[0]!;
 
   if (record.isRevoked) return null;
   if (record.expiresAt && record.expiresAt.getTime() < Date.now()) return null;

--- a/api/src/services/categoryService.ts
+++ b/api/src/services/categoryService.ts
@@ -64,7 +64,7 @@ export async function ensureSeedData(db: ReturnType<typeof createDb>): Promise<v
       .insert(schema.categories)
       .values({ name: cat.name, description: cat.description, icon: cat.icon, bestPractices: cat.bestPractices, sortOrder: cat.sortOrder, createdAt: new Date() })
       .returning();
-    nameToId.set(cat.name, created.id);
+    nameToId.set(cat.name, created!.id);
   }
   for (const t of SEED_TEMPLATES) {
     const id = nameToId.get(t.categoryName);
@@ -113,7 +113,7 @@ export async function createUserTemplate(
     categoryId: input.categoryId, name: input.name, description: input.description ?? null,
     settings: input.settings, isPreset: false, createdBy: userId, usageCount: 0, createdAt: new Date(),
   }).returning();
-  return created;
+  return created!;
 }
 
 export async function listUserTemplates(db: ReturnType<typeof createDb>, userId: string): Promise<TemplateRecord[]> {

--- a/api/src/services/collectionService.ts
+++ b/api/src/services/collectionService.ts
@@ -56,7 +56,7 @@ export async function createCollection(
       createdAt: new Date(),
     })
     .returning();
-  return created;
+  return created!;
 }
 
 export async function updateCollection(

--- a/api/src/services/errorService.ts
+++ b/api/src/services/errorService.ts
@@ -96,6 +96,7 @@ export async function reportError(
     .limit(1);
 
   if (existing.length > 0) {
+    const ex = existing[0]!;
     // Update occurrences and lastSeenAt
     const [updated] = await db
       .update(schema.errors)
@@ -104,12 +105,12 @@ export async function reportError(
         lastSeenAt: new Date(),
         // Update message in case the latest occurrence has more context
         message: input.message.slice(0, 2000),
-        stack: input.stack?.slice(0, 4000) ?? existing[0].stack,
-        context: input.context ? JSON.stringify(input.context).slice(0, 8000) : existing[0].context,
+        stack: input.stack?.slice(0, 4000) ?? ex.stack,
+        context: input.context ? JSON.stringify(input.context).slice(0, 8000) : ex.context,
       })
-      .where(eq(schema.errors.id, existing[0].id))
+      .where(eq(schema.errors.id, ex.id))
       .returning();
-    return { record: updated, created: false };
+    return { record: updated!, created: false };
   }
 
   // Create a new record
@@ -129,7 +130,7 @@ export async function reportError(
       createdAt: new Date(),
     })
     .returning();
-  return { record: created, created: true };
+  return { record: created!, created: true };
 }
 
 /**

--- a/api/src/services/generation-service.ts
+++ b/api/src/services/generation-service.ts
@@ -317,7 +317,7 @@ export async function getUserStats(
   const validStyles = ["professional", "lifestyle", "minimal", "luxury"] as const;
   const rawStyle = styleResult[0]?.style;
   const favoriteStyle = validStyles.includes(rawStyle as typeof validStyles[number])
-    ? rawStyle
+    ? rawStyle ?? "professional"
     : "professional";
 
   return {
@@ -354,7 +354,7 @@ export async function createGeneration(
     })
     .returning();
 
-  return generation;
+  return generation!;
 }
 
 export interface GenerationRuntimeEnv {

--- a/api/src/services/metricService.ts
+++ b/api/src/services/metricService.ts
@@ -66,7 +66,7 @@ export async function recordMetric(
       recordedAt: new Date(),
     })
     .returning();
-  return created;
+  return created!;
 }
 
 /**

--- a/api/src/services/notificationService.ts
+++ b/api/src/services/notificationService.ts
@@ -51,7 +51,7 @@ export async function createNotification(
     })
     .returning();
 
-  return notification;
+  return notification!;
 }
 
 /**

--- a/api/src/services/teamService.ts
+++ b/api/src/services/teamService.ts
@@ -162,7 +162,7 @@ export async function getTeamForUser(
     .where(eq(schema.teamMembers.teamId, teamId));
 
   return {
-    ...rows[0],
+    ...rows[0]!,
     memberCount: count?.count ?? 0,
   };
 }
@@ -203,7 +203,7 @@ export async function joinTeamByInviteCode(
     .limit(1);
 
   if (teams.length === 0) return null;
-  const team = teams[0];
+  const team = teams[0]!;
 
   const existing = await db
     .select()
@@ -223,7 +223,7 @@ export async function joinTeamByInviteCode(
       joinedAt: new Date(),
     })
     .returning();
-  return created;
+  return created ?? null;
 }
 
 export async function listTeamMembers(
@@ -273,7 +273,7 @@ export async function updateMemberRole(
         and(eq(schema.teamMembers.teamId, teamId), eq(schema.teamMembers.userId, targetUserId))
       )
       .limit(1);
-    if (target.length > 0 && target[0].role === "owner") {
+    if (target.length > 0 && target[0]!.role === "owner") {
       return null;
     }
   }
@@ -301,7 +301,7 @@ export async function removeMember(
     )
     .limit(1);
   if (target.length === 0) return false;
-  if (target[0].role === "owner") return false;
+  if (target[0]!.role === "owner") return false;
 
   const result = await db
     .delete(schema.teamMembers)
@@ -327,7 +327,7 @@ export async function leaveTeam(
     .where(and(eq(schema.teamMembers.teamId, teamId), eq(schema.teamMembers.userId, userId)))
     .limit(1);
   if (member.length === 0) return false;
-  if (member[0].role === "owner") return false;
+  if (member[0]!.role === "owner") return false;
 
   await db
     .delete(schema.teamMembers)

--- a/frontend/src/components/editor/ImageEditor.tsx
+++ b/frontend/src/components/editor/ImageEditor.tsx
@@ -109,7 +109,6 @@ export default function ImageEditor({ imageUrl, onSave, onClose }: ImageEditorPr
                 src={imageUrl}
                 alt="Editing"
                 className="max-w-full max-h-[60vh] object-contain"
-                fetchpriority="high"
                 decoding="async"
                 style={{
                   transform: getTransformStyle(),

--- a/packages/config/tsconfig.base.json
+++ b/packages/config/tsconfig.base.json
@@ -5,6 +5,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "noEmit": true,
     "isolatedModules": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Task #67: PR #57 rebase + depcheck 清理

Rebase 原 PR #57（已关闭）到最新 main，解决冲突。

## 改动
- `noUncheckedIndexedAccess` 启用，数组/对象索引返回 `T | undefined`
- API 路由和服务层添加必要的类型守卫
- Frontend ImageEditor 类型安全修复
- tsconfig.base.json 配置更新

## depcheck 结果
- 根 package.json 的 `typescript` 标记为未使用 → **误报**（pnpm workspace 子包实际使用，不能删）
- 无其他可清理的未使用依赖

## 验证
- pnpm build: 6/6 tasks 成功
- pnpm lint: 通过

@Martin 请 CR