### PR TITLE
fix: CI action 版本修正（v5→v4）

### DIFF
--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -18,10 +18,10 @@ jobs:
       HAS_CLOUDFLARE_SECRETS: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
 
@@ -42,7 +42,7 @@ jobs:
       - name: Deploy to Cloudflare Workers
         if: env.HAS_CLOUDFLARE_SECRETS == 'true'
         continue-on-error: true
-        uses: cloudflare/wrangler-action@v5
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,10 +17,10 @@ jobs:
       HAS_CLOUDFLARE_SECRETS: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
 
@@ -43,7 +43,7 @@ jobs:
       - name: Deploy to Cloudflare Workers
         if: env.HAS_CLOUDFLARE_SECRETS == 'true'
         continue-on-error: true
-        uses: cloudflare/wrangler-action@v5
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
 


### PR DESCRIPTION
## CI action 版本修正

3 个 workflow 文件的 action 版本不存在，导致 CI 失败。

## 修改
| Action | 旧版本 | 新版本 |
|---|---|---|
| actions/checkout | v5 | v4 |
| actions/setup-node | v5 | v4 |
| cloudflare/wrangler-action | v5 | v4 |

## 已修改文件
- `.github/workflows/deploy.yml`（frontend）
- `.github/workflows/api-deploy.yml`
- `.github/workflows/pr-validation.yml`

@Martin 请 CR + merge，CI 修完才能正常部署。