### PR TITLE
fix: temporary API URL switch to workers.dev for testing

### DIFF
--- a/frontend/wrangler.toml
+++ b/frontend/wrangler.toml
@@ -13,7 +13,7 @@ binding = "ASSETS"
 
 # Environment variables
 [vars]
-PUBLIC_API_URL = "https://api.ourapix.jiahongw.com"
+PUBLIC_API_URL = "https://oura-pix-api.wujiahong2013.workers.dev"
 
 # Observability
 [observability]


### PR DESCRIPTION
## Summary

临时将前端 API URL 切换到 workers.dev，绕过自定义域名 SSL 证书问题。

## 改动

`frontend/wrangler.toml`:
```diff
- PUBLIC_API_URL = "https://api.ourapix.jiahongw.com"
+ PUBLIC_API_URL = "https://oura-pix-api.wujiahong2013.workers.dev"
```

## 原因

`api.ourapix.jiahongw.com` 的 SSL 证书持续失败，阻塞线上功能测试。
临时使用 workers.dev URL 继续测试，SSL 修复后恢复。

1 file, +1 -1