### PR TITLE
fix: remove pnpm version from pr-validation workflow

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

修复 CI pnpm 版本冲突。

## 改动

`.github/workflows/pr-validation.yml`: 删除 `version: 9`

## 原因

`package.json` 已指定 `packageManager: pnpm@9.0.0`，action 中再声明 `version: 9` 导致冲突。

1 file, -2 lines