### PR TITLE
Fix frontend deploy asset handling

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,9 +38,11 @@ jobs:
         env:
           PUBLIC_API_URL: ${{ secrets.PUBLIC_API_URL }}
 
+      - name: Exclude worker bundle from static assets
+        run: echo "_worker.js" > frontend/dist/.assetsignore
+
       - name: Deploy to Cloudflare Workers
         if: env.HAS_CLOUDFLARE_SECRETS == 'true'
-        continue-on-error: true
         uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary\n- exclude Astro's generated _worker.js server bundle from static asset upload before wrangler deploy\n- remove continue-on-error so frontend deployment failures are reported as failed Actions runs\n\n## Verification\n- pnpm --filter @oura-pix/frontend typecheck\n- pnpm --filter @oura-pix/frontend build\n- echo "_worker.js" > frontend/dist/.assetsignore\n- pnpm --dir frontend exec wrangler deploy --dry-run\n\n## Root Cause\nThe previous Deploy Frontend run built the new bundle but wrangler failed with "Uploading a Pages _worker.js directory as an asset". The workflow used continue-on-error, so GitHub marked the deploy step/job successful even though production remained on the old Minimalist build.\n