### PR TITLE
重构前端工作台 UI/UX

### DIFF
--- a/docs/reference/design.md
+++ b/docs/reference/design.md
@@ -4,10 +4,18 @@ This file records the current frontend design baseline. It should describe the c
 
 ## Visual Direction
 
-- Dark-first interface with restrained purple accents.
+- Light-first product workbench inspired by ecommerce photo review, packing labels, and listing proof sheets.
+- The primary accent is proof blue for actions and selection states; shipping amber is reserved for workflow labels and warnings.
+- The signature visual device is `.proof-strip`, a blue-and-paper diagonal strip used sparingly on hero and generation workbench panels.
 - Dense product workflow screens should stay practical: clear navigation, compact controls, readable tables/lists, and predictable action placement.
 - Browser-side tools should prioritize direct manipulation and obvious controls over explanatory copy.
-- Cards use the shared `.card` utility. Avoid stacking decorative cards inside other cards.
+- Cards use the shared `.card` utility for real panels, repeated items, and modals. Avoid stacking decorative cards inside other cards.
+
+## Typography
+
+- Display: `Fraunces`, used with restraint for brand-level page titles.
+- Body: `Inter`, used for product UI and long-form interface copy.
+- Utility: `IBM Plex Mono`, used for labels, proof metadata, and compact status text.
 
 ## Theme Tokens
 
@@ -38,6 +46,10 @@ Semantic colors are exposed as `--color-success`, `--color-warning`, `--color-er
 | `.card-hover` | Hover treatment for interactive cards |
 | `.input` | Shared text/select input style |
 | `.badge` | Compact status/category label |
+| `.bench-grid` | Product review grid surface |
+| `.proof-strip` | Signature listing/proof sheet stripe |
+| `.font-display` | Display face utility |
+| `.font-utility` | Metadata and compact label face |
 | `.tooltip` | Floating tooltip surface |
 
 ## Frontend Structure
@@ -59,7 +71,9 @@ frontend/src/
 | Route Area | Primary Components |
 |------------|--------------------|
 | Home | `HomePage`, `Navbar`, `Footer` |
-| Generate | `GeneratePage`, `UploadDropzone`, `GenerationProgress`, `CompareView` |
+| Generate | `Navbar`, `GeneratePage`, `UploadDropzone`, `GenerationProgress`, `CompareView` |
+| Pricing | `Navbar`, `PricingPage`, `Footer` |
+| Auth | `LoginPage`, `RegisterPage` |
 | History/Favorites | `HistoryPage`, `GenerationCard`, `FavoritesPage`, `FavoriteCard` |
 | Tools | `BackgroundRemover`, `ImageCutout`, `CollageMaker`, `BatchProcessor`, `ImageBorder`, `ExportDemo`, `ShortcutsDemo` |
 | Admin-style views | `MetricsDashboard`, `ErrorsDashboard`, `ApiKeysPage`, `TeamsPage` |
@@ -69,4 +83,6 @@ frontend/src/
 - Prefer icon plus text for primary workflow actions and icon-only buttons for compact tool controls when the icon is familiar.
 - Keep text within stable control dimensions; avoid controls changing size when state labels change.
 - Use actual product/user content in previews where possible; avoid decorative placeholders for inspection-heavy flows.
+- Keep the generation flow organized as upload, specification, and review; do not hide navigation on core workflow pages.
+- Pricing and authentication pages should keep the proof-sheet visual language instead of reintroducing generic gradient marketing panels.
 - Mobile layouts should collapse to one column without hiding critical commands.

--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -6,6 +6,7 @@ import { paraglideVitePlugin } from '@inlang/paraglide-js';
 
 export default defineConfig({
   output: 'server',
+  publicDir: '../public',
   adapter: cloudflare({
     imageService: 'passthrough',
   }),

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -59,31 +59,31 @@ export class ErrorBoundary extends Component<Props, State> {
 
       return (
         <div className="flex min-h-[400px] flex-col items-center justify-center px-4 py-16">
-          <div className="mb-6 rounded-full bg-red-100 p-4 dark:bg-red-900/30">
-            <AlertTriangle className="h-10 w-10 text-red-600 dark:text-red-400" />
+          <div className="mb-6 rounded-md bg-[hsl(var(--color-error-light))] p-4 text-[hsl(var(--color-error))]">
+            <AlertTriangle className="h-10 w-10" aria-hidden="true" />
           </div>
-          <h2 className="mb-2 text-xl font-semibold text-slate-900 dark:text-slate-100">
+          <h2 className="mb-2 font-display text-2xl font-semibold text-foreground">
             {m.errorBoundary_title()}
           </h2>
-          <p className="mb-2 max-w-md text-center text-sm text-slate-500 dark:text-slate-400">
+          <p className="mb-2 max-w-md text-center text-sm text-foreground-muted">
             {m.errorBoundary_description()}
           </p>
           {this.state.error && (
-            <p className="mb-6 max-w-md truncate text-center text-xs font-mono text-slate-400 dark:text-slate-500">
+            <p className="font-utility mb-6 max-w-md truncate text-center text-xs text-foreground-muted">
               {this.state.error.message}
             </p>
           )}
           <div className="flex gap-3">
             <button
               onClick={this.handleReload}
-              className="inline-flex items-center gap-2 rounded-lg bg-slate-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white"
+              className="btn-primary h-10 gap-2 px-4"
             >
-              <RefreshCw className="h-4 w-4" />
+              <RefreshCw className="h-4 w-4" aria-hidden="true" />
               {m.errorBoundary_reload()}
             </button>
             <button
               onClick={this.handleReset}
-              className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+              className="btn-secondary h-10 px-4"
             >
               {m.common_retry()}
             </button>

--- a/frontend/src/components/FavoriteButton.tsx
+++ b/frontend/src/components/FavoriteButton.tsx
@@ -5,6 +5,7 @@
  */
 
 import { useState, useEffect, useCallback } from "react";
+import { Heart } from "lucide-react";
 import * as m from "@/paraglide/messages.js";
 import { useFavorites } from "@/hooks/useFavorites";
 
@@ -69,7 +70,7 @@ export default function FavoriteButton({
 
   if (isLoading) {
     return (
-      <div className={`w-8 h-8 rounded-full bg-white/80 animate-pulse ${className}`} />
+      <div className={`h-8 w-8 animate-pulse rounded-full bg-[hsl(var(--card)/0.8)] ${className}`} />
     );
   }
 
@@ -79,24 +80,17 @@ export default function FavoriteButton({
       disabled={isToggling}
       className={`p-1.5 rounded-full transition-all duration-200 ${
         isFavorited
-          ? "text-red-500 hover:text-red-600"
+          ? "text-[hsl(var(--color-error))] hover:text-[hsl(var(--color-error))]"
           : "text-white/80 hover:text-white"
       } ${isToggling ? "opacity-50 cursor-not-allowed" : ""} ${className}`}
       title={isFavorited ? m.favorite_remove() : m.favorite_add()}
+      aria-label={isFavorited ? m.favorite_remove() : m.favorite_add()}
     >
-      <svg
-        className={`w-5 h-5 transition-transform ${isToggling ? "scale-90" : "scale-100"}`}
+      <Heart
+        className={`h-5 w-5 transition-transform ${isToggling ? "scale-90" : "scale-100"}`}
         fill={isFavorited ? "currentColor" : "none"}
-        stroke="currentColor"
-        viewBox="0 0 24 24"
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={2}
-          d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
-        />
-      </svg>
+        aria-hidden="true"
+      />
     </button>
   );
 }

--- a/frontend/src/components/FavoriteCard.tsx
+++ b/frontend/src/components/FavoriteCard.tsx
@@ -5,6 +5,7 @@
  */
 
 import { useState } from "react";
+import { Check, Eye, HeartOff } from "lucide-react";
 import * as m from "@/paraglide/messages.js";
 import type { Favorite } from "@/hooks/useFavorites";
 
@@ -63,16 +64,24 @@ export default function FavoriteCard({
 
   return (
     <div
-      className={`group relative aspect-square rounded-xl overflow-hidden cursor-pointer transition-all duration-200 ${
+      className={`group card relative aspect-square cursor-pointer overflow-hidden transition-all duration-200 ${
         isSelected
-          ? "ring-4 ring-amber-500 ring-offset-2 dark:ring-offset-stone-900"
+          ? "ring-4 ring-[hsl(var(--primary)/0.42)] ring-offset-2 ring-offset-[hsl(var(--background))]"
           : "hover:shadow-lg"
       }`}
       onMouseEnter={() => setShowActions(true)}
       onMouseLeave={() => setShowActions(false)}
       onClick={handleClick}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          handleClick();
+        }
+      }}
+      role="button"
+      tabIndex={0}
+      aria-label={m.profile_history_viewDetail()}
     >
-      {/* Image */}
       <img
         src={favorite.imageUrl}
         alt={m.favorite_imageAlt()}
@@ -85,24 +94,21 @@ export default function FavoriteCard({
       {selectionMode && (
         <div className="absolute top-2 left-2">
           <div
-            className={`w-6 h-6 rounded-full border-2 flex items-center justify-center transition-colors ${
+            className={`flex h-6 w-6 items-center justify-center rounded-full border-2 transition-colors ${
               isSelected
-                ? "bg-amber-500 border-amber-500"
-                : "bg-white/80 border-white/80"
+                ? "border-[hsl(var(--primary))] bg-[hsl(var(--primary))]"
+                : "border-[hsl(var(--card))] bg-[hsl(var(--card)/0.86)]"
             }`}
           >
             {isSelected && (
-              <svg className="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
-              </svg>
+              <Check className="h-4 w-4 text-white" aria-hidden="true" />
             )}
           </div>
         </div>
       )}
 
-      {/* Hover Overlay */}
       <div
-        className={`absolute inset-0 bg-black/40 flex items-center justify-center gap-2 transition-opacity duration-200 ${
+        className={`absolute inset-0 flex items-center justify-center gap-2 bg-[hsl(var(--foreground)/0.42)] transition-opacity duration-200 ${
           showActions && !selectionMode ? "opacity-100" : "opacity-0"
         }`}
       >
@@ -111,31 +117,27 @@ export default function FavoriteCard({
             e.stopPropagation();
             onView(favorite);
           }}
-          className="p-2 rounded-full bg-white/90 hover:bg-white transition-colors"
+          className="icon-button h-10 w-10 bg-[hsl(var(--card)/0.92)] text-foreground hover:bg-[hsl(var(--card))]"
           title={m.profile_history_viewDetail()}
+          aria-label={m.profile_history_viewDetail()}
         >
-          <svg className="w-5 h-5 text-stone-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-          </svg>
+          <Eye className="h-5 w-5" aria-hidden="true" />
         </button>
         <button
           onClick={(e) => {
             e.stopPropagation();
             onRemove(favorite.id);
           }}
-          className="p-2 rounded-full bg-white/90 hover:bg-white transition-colors"
+          className="icon-button h-10 w-10 bg-[hsl(var(--card)/0.92)] text-[hsl(var(--color-error))] hover:bg-[hsl(var(--card))]"
           title={m.favorite_remove()}
+          aria-label={m.favorite_remove()}
         >
-          <svg className="w-5 h-5 text-red-500" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
-          </svg>
+          <HeartOff className="h-5 w-5" aria-hidden="true" />
         </button>
       </div>
 
-      {/* Info Overlay */}
-      <div className="absolute bottom-0 left-0 right-0 p-2 bg-gradient-to-t from-black/70 to-transparent">
-        <div className="flex items-center justify-between text-xs text-white">
+      <div className="absolute bottom-0 left-0 right-0 bg-[hsl(var(--foreground)/0.72)] p-2">
+        <div className="flex items-center justify-between text-xs font-semibold text-[hsl(var(--background))]">
           <span>{getPlatformLabel(favorite.generation?.settings?.targetPlatform)}</span>
           <span>{formatTime(favorite.createdAt)}</span>
         </div>

--- a/frontend/src/components/FavoritesPage.tsx
+++ b/frontend/src/components/FavoritesPage.tsx
@@ -5,6 +5,7 @@
  */
 
 import { useState, useCallback } from "react";
+import { Check, Download, Heart, Images, Sparkles, Trash2, X } from "lucide-react";
 import * as m from "@/paraglide/messages.js";
 import { localizeHref } from "@/paraglide/runtime.js";
 import { useFavorites, type Favorite } from "@/hooks/useFavorites";
@@ -12,28 +13,25 @@ import FavoriteCard from "./FavoriteCard";
 
 function SkeletonCard() {
   return (
-    <div className="aspect-square bg-stone-200 dark:bg-stone-700 rounded-xl animate-pulse" />
+    <div className="card aspect-square animate-pulse bg-[hsl(var(--secondary))]" />
   );
 }
 
 function EmptyState({ onBrowse }: { onBrowse: () => void }) {
   return (
-    <div className="flex flex-col items-center justify-center py-16 px-4">
-      <div className="w-24 h-24 mb-6 text-stone-300 dark:text-stone-600">
-        <svg fill="currentColor" viewBox="0 0 24 24" className="w-full h-full">
-          <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
-        </svg>
-      </div>
-      <h3 className="text-lg font-medium text-stone-900 dark:text-stone-100 mb-2">
+    <div className="panel-muted flex flex-col items-center justify-center px-4 py-16">
+      <Images className="mb-6 h-16 w-16 text-foreground-muted" aria-hidden="true" />
+      <h2 className="mb-2 text-lg font-semibold text-foreground">
         {m.favorites_empty()}
-      </h3>
-      <p className="text-stone-500 dark:text-stone-400 text-center mb-6 max-w-sm">
+      </h2>
+      <p className="mb-6 max-w-sm text-center text-sm text-foreground-muted">
         {m.favorites_emptyDescription()}
       </p>
       <button
         onClick={onBrowse}
-        className="px-6 py-2.5 bg-amber-600 hover:bg-amber-700 text-white rounded-lg font-medium transition-colors"
+        className="btn-primary h-10 gap-2 px-6"
       >
+        <Sparkles className="h-4 w-4" aria-hidden="true" />
         {m.favorites_goGenerate()}
       </button>
     </div>
@@ -51,26 +49,24 @@ function ImageModal({
 }) {
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[hsl(var(--foreground)/0.72)] p-4"
       onClick={onClose}
       role="dialog"
       aria-modal="true"
+      aria-labelledby="favorite-modal-title"
     >
       <div
-        className="relative max-w-4xl max-h-[90vh] bg-white dark:bg-stone-800 rounded-xl overflow-hidden shadow-2xl"
+        className="panel relative max-h-[90vh] max-w-4xl overflow-hidden shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
-        {/* Close Button */}
         <button
           onClick={onClose}
-          className="absolute top-4 right-4 z-10 p-2 rounded-full bg-black/50 hover:bg-black/70 text-white transition-colors"
+          className="icon-button absolute right-4 top-4 z-10 h-10 w-10 bg-[hsl(var(--card)/0.88)] text-foreground hover:bg-[hsl(var(--card))]"
+          aria-label="关闭预览"
         >
-          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-          </svg>
+          <X className="h-5 w-5" aria-hidden="true" />
         </button>
 
-        {/* Image */}
         <img
           src={favorite.imageUrl}
           alt={m.favorite_imageAlt()}
@@ -78,10 +74,9 @@ function ImageModal({
           decoding="async"
         />
 
-        {/* Actions */}
-        <div className="absolute bottom-0 left-0 right-0 p-4 bg-gradient-to-t from-black/80 to-transparent flex items-center justify-between">
-          <div className="text-white text-sm">
-            <span className="font-medium">
+        <div className="absolute bottom-0 left-0 right-0 flex items-center justify-between bg-[hsl(var(--foreground)/0.78)] p-4">
+          <div id="favorite-modal-title" className="text-sm text-[hsl(var(--background))]">
+            <span className="font-semibold">
               {favorite.generation?.settings?.targetPlatform || m.common_custom()}
             </span>
             <span className="ml-4 opacity-75">
@@ -92,8 +87,9 @@ function ImageModal({
             <a
               href={favorite.imageUrl}
               download
-              className="px-4 py-2 bg-white/20 hover:bg-white/30 text-white rounded-lg text-sm transition-colors"
+              className="btn-secondary h-10 gap-2 bg-[hsl(var(--card)/0.9)] px-4 text-foreground"
             >
+              <Download className="h-4 w-4" aria-hidden="true" />
               {m.favorites_download()}
             </a>
             <button
@@ -101,8 +97,9 @@ function ImageModal({
                 onRemove(favorite.id);
                 onClose();
               }}
-              className="px-4 py-2 bg-red-500/80 hover:bg-red-500 text-white rounded-lg text-sm transition-colors"
+              className="btn-primary h-10 gap-2 bg-[hsl(var(--color-error))] px-4 hover:bg-[hsl(var(--color-error))]"
             >
+              <Trash2 className="h-4 w-4" aria-hidden="true" />
               {m.favorite_remove()}
             </button>
           </div>
@@ -165,37 +162,36 @@ export default function FavoritesPage() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-stone-100 dark:bg-stone-950">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {/* Header */}
-        <div className="flex items-center justify-between mb-6">
+    <div className="workbench-page">
+      <div className="workbench-container">
+        <header className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-stone-900 dark:text-stone-100 flex items-center gap-2">
-              <svg className="w-6 h-6 text-red-500" fill="currentColor" viewBox="0 0 24 24">
-                <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
-              </svg>
+            <p className="page-kicker">Library / Favorites</p>
+            <h1 className="page-title mt-2 flex items-center gap-3">
+              <Heart className="h-8 w-8 text-[hsl(var(--color-error))]" aria-hidden="true" />
               {m.favorites_title()}
             </h1>
-            <p className="text-stone-500 dark:text-stone-400 text-sm mt-1">
+            <p className="page-description mt-2">
               {pagination ? m.favorites_total({ count: pagination.total.toString() }) : ""}
             </p>
           </div>
 
-          {/* Selection Controls */}
           <div className="flex items-center gap-2">
             {selectionMode ? (
               <>
                 <button
                   onClick={selectAll}
-                  className="px-3 py-1.5 text-sm text-stone-600 dark:text-stone-400 hover:text-stone-900 dark:hover:text-stone-100 transition-colors"
+                  className="btn-secondary h-9 gap-2 px-3"
                 >
+                  <Check className="h-4 w-4" aria-hidden="true" />
                   {selectedIds.size === favorites.length ? m.favorites_deselectAll() : m.favorites_selectAll()}
                 </button>
                 <button
                   onClick={handleBatchRemove}
                   disabled={selectedIds.size === 0}
-                  className="px-4 py-1.5 text-sm bg-red-500 hover:bg-red-600 text-white rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  className="btn-primary h-9 gap-2 bg-[hsl(var(--color-error))] px-4 hover:bg-[hsl(var(--color-error))] disabled:cursor-not-allowed disabled:opacity-50"
                 >
+                  <Trash2 className="h-4 w-4" aria-hidden="true" />
                   {m.favorite_remove()} ({selectedIds.size})
                 </button>
                 <button
@@ -203,7 +199,7 @@ export default function FavoritesPage() {
                     setSelectionMode(false);
                     setSelectedIds(new Set());
                   }}
-                  className="px-3 py-1.5 text-sm text-stone-600 dark:text-stone-400 hover:text-stone-900 dark:hover:text-stone-100 transition-colors"
+                  className="btn-ghost h-9 px-3"
                 >
                   {m.common_cancel()}
                 </button>
@@ -212,22 +208,21 @@ export default function FavoritesPage() {
               favorites.length > 0 && (
                 <button
                   onClick={() => setSelectionMode(true)}
-                  className="px-4 py-1.5 text-sm bg-stone-200 dark:bg-stone-700 hover:bg-stone-300 dark:hover:bg-stone-600 text-stone-700 dark:text-stone-300 rounded-lg transition-colors"
+                  className="btn-secondary h-9 px-4"
                 >
                   {m.favorites_batchManage()}
                 </button>
               )
             )}
           </div>
-        </div>
+        </header>
 
-        {/* Content */}
         {error && (
-          <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg mb-4">
-            <p className="text-red-700 dark:text-red-400 text-sm">{error}</p>
+          <div className="error-banner mb-4">
+            <p>{error}</p>
             <button
               onClick={refresh}
-              className="mt-2 text-sm text-red-600 dark:text-red-400 underline hover:no-underline"
+              className="mt-2 text-sm font-semibold underline hover:no-underline"
             >
               {m.common_retry()}
             </button>
@@ -258,23 +253,22 @@ export default function FavoritesPage() {
               ))}
             </div>
 
-            {/* Pagination */}
             {pagination && pagination.totalPages > 1 && (
               <div className="flex items-center justify-center gap-2 mt-8">
                 <button
                   onClick={() => setPage(page - 1)}
                   disabled={page === 1}
-                  className="px-3 py-1.5 text-sm rounded-lg bg-white dark:bg-stone-800 border border-stone-200 dark:border-stone-700 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-stone-50 dark:hover:bg-stone-700 transition-colors"
+                  className="btn-secondary h-9 px-3 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {m.common_previousPage()}
                 </button>
-                <span className="text-sm text-stone-600 dark:text-stone-400">
+                <span className="font-utility text-sm text-foreground-muted">
                   {page} / {pagination.totalPages}
                 </span>
                 <button
                   onClick={() => setPage(page + 1)}
                   disabled={page === pagination.totalPages}
-                  className="px-3 py-1.5 text-sm rounded-lg bg-white dark:bg-stone-800 border border-stone-200 dark:border-stone-700 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-stone-50 dark:hover:bg-stone-700 transition-colors"
+                  className="btn-secondary h-9 px-3 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {m.common_nextPage()}
                 </button>

--- a/frontend/src/components/FilterBar.tsx
+++ b/frontend/src/components/FilterBar.tsx
@@ -23,20 +23,20 @@ const timeFilters: { value: TimeFilter; label: string }[] = [
   { value: "month", label: m.history_filterMonth() },
 ];
 
-const platformFilters: { value: PlatformFilter; label: string; icon: string }[] = [
-  { value: "all", label: m.history_filterAllPlatforms(), icon: "🌐" },
-  { value: "amazon", label: "Amazon", icon: "🅰️" },
-  { value: "shopify", label: "Shopify", icon: "🛍️" },
-  { value: "ebay", label: "eBay", icon: "🏷️" },
-  { value: "etsy", label: "Etsy", icon: "🎨" },
-  { value: "generic", label: m.common_custom(), icon: "📦" },
+const platformFilters: { value: PlatformFilter; label: string }[] = [
+  { value: "all", label: m.history_filterAllPlatforms() },
+  { value: "amazon", label: "Amazon" },
+  { value: "shopify", label: "Shopify" },
+  { value: "ebay", label: "eBay" },
+  { value: "etsy", label: "Etsy" },
+  { value: "generic", label: m.common_custom() },
 ];
 
-const statusFilters: { value: StatusFilter; label: string; color: string }[] = [
-  { value: "all", label: m.history_filterAllStatus(), color: "gray" },
-  { value: "success", label: m.history_statusSuccess(), color: "green" },
-  { value: "pending", label: m.history_statusPending(), color: "yellow" },
-  { value: "failed", label: m.history_statusFailed(), color: "red" },
+const statusFilters: { value: StatusFilter; label: string }[] = [
+  { value: "all", label: m.history_filterAllStatus() },
+  { value: "success", label: m.history_statusSuccess() },
+  { value: "pending", label: m.history_statusPending() },
+  { value: "failed", label: m.history_statusFailed() },
 ];
 
 export default function FilterBar({
@@ -48,53 +48,37 @@ export default function FilterBar({
   onStatusFilterChange,
 }: FilterBarProps) {
   return (
-    <div className="flex flex-col sm:flex-row gap-3 p-4 bg-stone-50 dark:bg-stone-900 rounded-xl">
-      {/* Time Filter */}
+    <div className="panel flex flex-col gap-3 p-3 sm:flex-row">
       <div className="flex flex-wrap gap-1">
         {timeFilters.map((f) => (
           <button
             key={f.value}
             onClick={() => onTimeFilterChange(f.value)}
-            className={`px-3 py-1.5 text-sm rounded-lg transition-colors ${
-              timeFilter === f.value
-                ? "bg-amber-600 text-white"
-                : "bg-white dark:bg-stone-800 text-stone-600 dark:text-stone-400 hover:bg-stone-100 dark:hover:bg-stone-700"
-            }`}
+            className={`segmented-option ${timeFilter === f.value ? "segmented-option-active" : ""}`}
           >
             {f.label}
           </button>
         ))}
       </div>
 
-      {/* Platform Filter */}
       <div className="flex flex-wrap gap-1 sm:ml-auto">
         {platformFilters.map((f) => (
           <button
             key={f.value}
             onClick={() => onPlatformFilterChange(f.value)}
-            className={`px-3 py-1.5 text-sm rounded-lg transition-colors flex items-center gap-1 ${
-              platformFilter === f.value
-                ? "bg-amber-600 text-white"
-                : "bg-white dark:bg-stone-800 text-stone-600 dark:text-stone-400 hover:bg-stone-100 dark:hover:bg-stone-700"
-            }`}
+            className={`segmented-option ${platformFilter === f.value ? "segmented-option-active" : ""}`}
           >
-            <span>{f.icon}</span>
-            <span className="hidden sm:inline">{f.label}</span>
+            <span>{f.label}</span>
           </button>
         ))}
       </div>
 
-      {/* Status Filter */}
       <div className="flex flex-wrap gap-1">
         {statusFilters.map((f) => (
           <button
             key={f.value}
             onClick={() => onStatusFilterChange(f.value)}
-            className={`px-3 py-1.5 text-sm rounded-lg transition-colors ${
-              statusFilter === f.value
-                ? "bg-amber-600 text-white"
-                : "bg-white dark:bg-stone-800 text-stone-600 dark:text-stone-400 hover:bg-stone-100 dark:hover:bg-stone-700"
-            }`}
+            className={`segmented-option ${statusFilter === f.value ? "segmented-option-active" : ""}`}
           >
             {f.label}
           </button>

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,42 +1,39 @@
 "use client";
 
-import { Sparkles } from "lucide-react";
+import { PackageCheck } from "lucide-react";
 import { localizeHref } from "@/paraglide/runtime.js";
 
 export default function Footer() {
   const currentYear = new Date().getFullYear();
 
   return (
-    <footer className="border-t border-[hsl(var(--border))] bg-[hsl(var(--background))]">
+    <footer className="border-t border-[hsl(var(--border))] bg-[hsl(var(--card))]">
       <div className="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
         <div className="grid gap-8 md:grid-cols-4">
           {/* Logo & Description */}
           <div className="md:col-span-2">
-            <div className="flex items-center gap-2">
-              <div className="relative flex h-8 w-8 items-center justify-center rounded-xl overflow-hidden">
-                <div className="absolute inset-0 bg-gradient-to-br from-[hsl(var(--primary))] to-violet-500 opacity-80" />
-                <span className="relative text-sm font-bold text-white">
-                  <Sparkles className="h-4 w-4" />
-                </span>
+            <div className="flex items-center gap-3">
+              <div className="flex h-8 w-8 items-center justify-center rounded-md bg-[hsl(var(--foreground))] text-[hsl(var(--background))]">
+                <PackageCheck className="h-4 w-4" aria-hidden="true" />
               </div>
-              <span className="text-lg font-semibold text-foreground">OuraPix</span>
+              <span className="font-display text-xl font-semibold text-foreground">OuraPix</span>
             </div>
             <p className="mt-4 text-sm text-foreground-muted max-w-sm">
-              AI-powered cross-border e-commerce product detail page generator
+              A product photo workbench for cross-border listings, scene assets, and marketplace-ready copy.
             </p>
           </div>
 
           {/* Links */}
           <div>
-            <h3 className="text-sm font-semibold text-foreground">Product</h3>
+            <h3 className="font-utility text-xs font-semibold uppercase text-foreground">Product</h3>
             <ul className="mt-4 space-y-2">
               <li>
-                <a href={localizeHref("/generate")} className="text-sm text-foreground-muted hover:text-foreground transition-colors">
+                <a href={localizeHref("/generate")} className="text-sm text-foreground-muted transition-colors hover:text-foreground">
                   Generate
                 </a>
               </li>
               <li>
-                <a href={localizeHref("/pricing")} className="text-sm text-foreground-muted hover:text-foreground transition-colors">
+                <a href={localizeHref("/pricing")} className="text-sm text-foreground-muted transition-colors hover:text-foreground">
                   Pricing
                 </a>
               </li>
@@ -44,15 +41,15 @@ export default function Footer() {
           </div>
 
           <div>
-            <h3 className="text-sm font-semibold text-foreground">Support</h3>
+            <h3 className="font-utility text-xs font-semibold uppercase text-foreground">Support</h3>
             <ul className="mt-4 space-y-2">
               <li>
-                <a href={localizeHref("/docs")} className="text-sm text-foreground-muted hover:text-foreground transition-colors">
+                <a href={localizeHref("/docs")} className="text-sm text-foreground-muted transition-colors hover:text-foreground">
                   Documentation
                 </a>
               </li>
               <li>
-                <a href={localizeHref("/blog")} className="text-sm text-foreground-muted hover:text-foreground transition-colors">
+                <a href={localizeHref("/blog")} className="text-sm text-foreground-muted transition-colors hover:text-foreground">
                   Blog
                 </a>
               </li>

--- a/frontend/src/components/ForgotPasswordPage.tsx
+++ b/frontend/src/components/ForgotPasswordPage.tsx
@@ -1,9 +1,21 @@
 "use client";
 
 import { useState } from "react";
+import { CheckCircle2, MailCheck, PackageCheck, Send } from "lucide-react";
 import * as m from "@/paraglide/messages.js";
 import { localizeHref } from "@/paraglide/runtime.js";
 import { requestPasswordReset } from "@/lib/auth";
+
+function BrandLink() {
+  return (
+    <a href={localizeHref("/")} className="flex items-center gap-3">
+      <div className="flex h-11 w-11 items-center justify-center rounded-md bg-[hsl(var(--foreground))] text-[hsl(var(--background))]">
+        <PackageCheck className="h-5 w-5" aria-hidden="true" />
+      </div>
+      <span className="font-display text-2xl font-semibold text-foreground">OuraPix</span>
+    </a>
+  );
+}
 
 export default function ForgotPasswordPage() {
   const [email, setEmail] = useState("");
@@ -31,113 +43,76 @@ export default function ForgotPasswordPage() {
   };
 
   return (
-    <div className="flex min-h-screen">
-      {/* Left side - Marketing */}
-      <div className="hidden lg:flex lg:w-1/2 relative overflow-hidden bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">
-        {/* Background decorations */}
-        <div className="absolute inset-0">
-          <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-amber-500/20 rounded-full blur-3xl" />
-          <div className="absolute bottom-1/4 right-1/4 w-96 h-96 bg-orange-500/20 rounded-full blur-3xl" />
-          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-64 h-64 bg-yellow-500/10 rounded-full blur-2xl" />
-        </div>
-
-        {/* Grid pattern */}
-        <div
-          className="absolute inset-0 opacity-20"
-          style={{
-            backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.1'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
-          }}
-        />
-
-        {/* Content */}
-        <div className="relative z-10 flex flex-col justify-center px-12 xl:px-20">
-          <div className="mb-8">
-            <a href={localizeHref("/")} className="flex items-center gap-3 group">
-              <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-white/10 backdrop-blur-sm border border-white/20 group-hover:bg-white/20 transition-colors">
-                <span className="text-2xl font-bold text-white">O</span>
-              </div>
-              <span className="text-3xl font-bold text-white">OuraPix</span>
-            </a>
-          </div>
-
-          <h1 className="text-4xl xl:text-5xl font-bold text-white leading-tight mb-6">
-            忘记密码？<br />
-            <span className="bg-gradient-to-r from-amber-400 to-orange-400 bg-clip-text text-transparent">
-              别担心
-            </span>
-          </h1>
-
-          <p className="text-lg text-slate-300 mb-8 max-w-md">
-            我们会向您发送一封包含重置链接的邮件，帮您快速找回账户访问权限。
+    <div className="grid min-h-screen lg:grid-cols-[0.95fr_1.05fr]">
+      <aside className="relative hidden overflow-hidden border-r border-[hsl(var(--border))] bg-[hsl(var(--card))] lg:block">
+        <div className="proof-strip absolute inset-x-0 top-0 h-2" />
+        <div className="bench-grid absolute inset-0 opacity-40" />
+        <div className="relative z-10 flex min-h-screen flex-col justify-center px-12 xl:px-20">
+          <BrandLink />
+          <p className="page-kicker mt-12">Account recovery</p>
+          <h2 className="font-display mt-4 max-w-xl text-5xl font-semibold leading-none text-foreground">
+            Return the seller bench to the right operator.
+          </h2>
+          <p className="mt-6 max-w-md text-lg text-foreground-muted">
+            发送一次性重置链接，避免商品图、模板和团队访问被锁在错误的登录状态里。
           </p>
-
-          <div className="flex items-center gap-3 text-slate-300">
-            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-white/10">
-              <svg className="w-5 h-5 text-amber-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-              </svg>
+          <div className="card mt-10 overflow-hidden">
+            <div className="proof-strip h-2" />
+            <div className="space-y-4 p-5">
+              {["链接发送到注册邮箱", "重置后可继续访问历史生成", "不改变现有团队权限"].map((item) => (
+                <div key={item} className="flex items-center gap-3 text-sm font-semibold text-foreground">
+                  <CheckCircle2 className="h-5 w-5 text-[hsl(var(--primary))]" aria-hidden="true" />
+                  {item}
+                </div>
+              ))}
             </div>
-            <span>检查收件箱，邮件可能被归类到垃圾邮件</span>
           </div>
         </div>
-      </div>
+      </aside>
 
-      {/* Right side - Form */}
-      <div className="w-full lg:w-1/2 flex flex-col justify-center px-6 py-12 sm:px-8 lg:px-12 xl:px-16 bg-white">
-        <div className="w-full max-w-md mx-auto">
-          {/* Mobile Logo */}
-          <div className="lg:hidden flex justify-center mb-8">
-            <a href={localizeHref("/")} className="flex items-center gap-2">
-              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-slate-900">
-                <span className="text-xl font-bold text-white">O</span>
-              </div>
-              <span className="text-2xl font-bold text-slate-900">OuraPix</span>
-            </a>
+      <main className="flex min-h-screen flex-col justify-center bg-[hsl(var(--background))] px-6 py-12 sm:px-8 lg:px-12 xl:px-16">
+        <div className="mx-auto w-full max-w-md">
+          <div className="mb-8 flex justify-center lg:hidden">
+            <BrandLink />
           </div>
 
           {isSent ? (
-            <div className="text-center animate-fade-in">
-              <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-green-100 mb-6">
-                <svg className="h-8 w-8 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                </svg>
+            <section className="text-center animate-fade-in">
+              <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-md bg-[hsl(var(--color-success-light))] text-[hsl(var(--color-success))]">
+                <MailCheck className="h-8 w-8" aria-hidden="true" />
               </div>
-              <h2 className="text-2xl font-bold text-slate-900 mb-3">
+              <p className="page-kicker">Reset link sent</p>
+              <h1 className="font-display mt-2 text-4xl font-semibold text-foreground">
                 邮件已发送
-              </h2>
-              <p className="text-slate-500 mb-8">
+              </h1>
+              <p className="mt-3 text-foreground-muted">
                 请检查您的邮箱，点击邮件中的链接重置密码。
               </p>
-              <a
-                href={localizeHref("/login")}
-                className="inline-flex items-center justify-center h-11 px-6 rounded-md bg-slate-900 hover:bg-slate-800 text-white font-medium transition-colors"
-              >
+              <a href={localizeHref("/login")} className="btn-primary mt-8 h-11 px-6">
                 返回登录
               </a>
-            </div>
+            </section>
           ) : (
             <>
-              {/* Title */}
               <div className="mb-8">
-                <h2 className="text-2xl font-bold text-slate-900 mb-2">
+                <p className="page-kicker">Reset password</p>
+                <h1 className="font-display mt-2 text-4xl font-semibold text-foreground">
                   重置密码
-                </h2>
-                <p className="text-slate-500">
+                </h1>
+                <p className="mt-2 text-foreground-muted">
                   输入您的邮箱地址，我们将发送重置链接。
                 </p>
               </div>
 
-              {/* Error message */}
               {error && (
-                <div className="mb-6 p-4 rounded-lg bg-red-50 border border-red-100">
-                  <p className="text-sm text-red-600">{error}</p>
+                <div className="error-banner mb-6">
+                  <p>{error}</p>
                 </div>
               )}
 
-              {/* Form */}
               <form className="space-y-5" onSubmit={handleSubmit}>
                 <div className="space-y-2">
-                  <label htmlFor="email" className="text-sm font-medium text-slate-700">
+                  <label htmlFor="email" className="text-sm font-semibold text-foreground">
                     {m.login_email()}
                   </label>
                   <input
@@ -149,44 +124,32 @@ export default function ForgotPasswordPage() {
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
                     placeholder={m.login_emailPlaceholder()}
-                    className="w-full h-11 rounded-lg border border-slate-200 bg-slate-50 px-3 text-sm transition-colors focus:border-slate-900 focus:bg-white focus:outline-none focus:ring-1 focus:ring-slate-900"
+                    className="input h-11"
                   />
                 </div>
 
                 <button
                   type="submit"
                   disabled={isLoading}
-                  className="w-full h-11 rounded-lg bg-slate-900 text-white text-sm font-medium transition-colors hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                  className="btn-primary h-11 w-full gap-2 disabled:cursor-not-allowed disabled:opacity-50"
                 >
-                  {isLoading ? (
-                    <>
-                      <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24">
-                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
-                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                      </svg>
-                      发送中...
-                    </>
-                  ) : (
-                    "发送重置链接"
-                  )}
+                  <Send className="h-4 w-4" aria-hidden="true" />
+                  {isLoading ? "发送中..." : "发送重置链接"}
                 </button>
               </form>
 
-              {/* Back to login */}
-              <div className="mt-8 pt-6 border-t border-slate-100">
-                <p className="text-center text-slate-500">
-                  <a
-                    href={localizeHref("/login")}
-                    className="font-medium text-slate-900 hover:text-slate-700 transition-colors"
-                  >
-                    返回登录
-                  </a>
-                </p>
+              <div className="mt-8 border-t border-[hsl(var(--border))] pt-6 text-center">
+                <a
+                  href={localizeHref("/login")}
+                  className="text-sm font-semibold text-[hsl(var(--primary))] transition-colors hover:text-[hsl(var(--primary-hover))]"
+                >
+                  返回登录
+                </a>
               </div>
             </>
           )}
         </div>
-      </div>
+      </main>
     </div>
   );
 }

--- a/frontend/src/components/GeneratePage.tsx
+++ b/frontend/src/components/GeneratePage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback, useRef, useEffect } from "react";
-import { Sparkles, Upload, Settings, Eye, Check } from "lucide-react";
+import { Check, ClipboardCheck, Eye, Settings, Sparkles, Upload } from "lucide-react";
 import * as m from "@/paraglide/messages.js";
 import { getLocale } from "@/paraglide/runtime.js";
 import { localeToGenerationLanguage, type GenerationLanguage, type Locale } from "@oura-pix/i18n";
@@ -225,21 +225,41 @@ export default function GeneratePage() {
     <div className="flex min-h-screen flex-col">
       <main className="flex-1 bg-[hsl(var(--background))]">
         {/* Header */}
-        <div className="border-b border-[hsl(var(--border))] bg-[hsl(var(--background-secondary))]">
-          <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-            <h1 className="text-2xl font-bold text-foreground">{m.generation_title()}</h1>
-            <p className="mt-1 text-sm text-foreground-muted">
-              {m.generation_subtitle()}
-            </p>
+        <div className="border-b border-[hsl(var(--border))] bg-[hsl(var(--card))]">
+          <div className="proof-strip h-2" />
+          <div className="mx-auto grid max-w-7xl gap-5 px-4 py-7 sm:px-6 lg:grid-cols-[1fr_auto] lg:items-end lg:px-8">
+            <div>
+              <p className="font-utility text-xs font-semibold uppercase text-[hsl(var(--accent))]">
+                Generation bench
+              </p>
+              <h1 className="font-display mt-2 text-4xl font-semibold text-foreground">
+                {m.generation_title()}
+              </h1>
+              <p className="mt-2 max-w-2xl text-sm text-foreground-muted">
+                {m.generation_subtitle()}
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {["Upload", "Specify", "Review"].map((step) => (
+                <span
+                  key={step}
+                  className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--background)/0.55)] px-3 py-1 text-xs font-semibold text-foreground-muted"
+                >
+                  {step}
+                </span>
+              ))}
+            </div>
           </div>
         </div>
 
         {/* Main Content */}
         <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-          <div className="grid gap-8 lg:grid-cols-3">
+          <div className="grid items-start gap-6 lg:grid-cols-[0.9fr_1fr_1.08fr]">
             {/* Left: Upload Area */}
             <div className="space-y-6">
-              <div className="card p-6">
+              <div className="card overflow-hidden">
+                <div className="proof-strip h-1.5" />
+                <div className="p-5 sm:p-6">
                 <div className="flex items-center gap-2 mb-4">
                   <Upload className="h-5 w-5 text-[hsl(var(--primary))]" />
                   <h2 className="text-lg font-semibold text-foreground">{m.generation_uploadSection()}</h2>
@@ -266,12 +286,13 @@ export default function GeneratePage() {
                     onFilesSelected={handleStyleImagesSelect}
                   />
                 </div>
+                </div>
               </div>
 
               {/* Tips */}
-              <div className="card p-4 border-[hsl(var(--primary)/0.2)]">
+              <div className="card border-[hsl(var(--primary)/0.2)] bg-[hsl(var(--primary)/0.06)] p-4">
                 <div className="flex gap-3">
-                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-[hsl(var(--primary)/0.1)]">
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[hsl(var(--primary)/0.1)]">
                     <Sparkles className="h-5 w-5 text-[hsl(var(--primary))]" />
                   </div>
                   <div>
@@ -287,7 +308,9 @@ export default function GeneratePage() {
             </div>
 
             {/* Middle: Settings Panel */}
-            <div className="card p-6">
+            <div className="card overflow-hidden">
+              <div className="proof-strip h-1.5" />
+              <div className="p-5 sm:p-6">
               <div className="flex items-center gap-2 mb-6">
                 <Settings className="h-5 w-5 text-[hsl(var(--primary))]" />
                 <h2 className="text-lg font-semibold text-foreground">{m.generation_settings()}</h2>
@@ -305,14 +328,17 @@ export default function GeneratePage() {
                       type="button"
                       onClick={() => setSettings({ ...settings, platform: platform.value })}
                       className={`
-                        flex flex-col items-center justify-center rounded-xl border-2 p-4 transition-all duration-200
+                        flex flex-col items-center justify-center rounded-lg border-2 p-4 transition-all duration-200
                         ${settings.platform === platform.value
                           ? "border-[hsl(var(--primary))] bg-[hsl(var(--primary)/0.1)]"
                           : "border-[hsl(var(--border))] hover:border-[hsl(var(--foreground-muted)/0.3)]"
                         }
                       `}
                     >
-                      <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-[hsl(var(--primary))] to-violet-500 text-sm font-bold text-white">
+                      <span
+                        className="flex h-8 w-8 items-center justify-center rounded-md bg-[hsl(var(--foreground))] text-sm font-bold text-[hsl(var(--background))]"
+                        aria-hidden="true"
+                      >
                         {platform.icon}
                       </span>
                       <span className="mt-2 text-sm font-medium text-foreground">
@@ -331,6 +357,7 @@ export default function GeneratePage() {
                 <div className="flex items-center gap-4">
                   <input
                     type="range"
+                    aria-label={m.generation_count()}
                     min={5}
                     max={10}
                     step={1}
@@ -357,7 +384,7 @@ export default function GeneratePage() {
                       type="button"
                       onClick={() => setSettings({ ...settings, style: style.value })}
                       className={`
-                        w-full flex items-center justify-between rounded-xl border-2 p-3 text-left transition-all duration-200
+                        w-full flex items-center justify-between rounded-lg border-2 p-3 text-left transition-all duration-200
                         ${settings.style === style.value
                           ? "border-[hsl(var(--primary))] bg-[hsl(var(--primary)/0.1)]"
                           : "border-[hsl(var(--border))] hover:border-[hsl(var(--foreground-muted)/0.3)]"
@@ -397,7 +424,7 @@ export default function GeneratePage() {
               </div>
 
               {/* Image Generation Toggle */}
-              <div className="mb-6 rounded-xl border border-[hsl(var(--border))] p-4">
+              <div className="mb-6 rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--background)/0.42)] p-4">
                 <div className="flex items-center justify-between mb-4">
                   <div>
                     <h3 className="text-sm font-semibold text-foreground">
@@ -410,6 +437,8 @@ export default function GeneratePage() {
                   <button
                     type="button"
                     onClick={() => setSettings({ ...settings, generateImages: !settings.generateImages })}
+                    aria-label={m.generation_imageGen_title()}
+                    aria-pressed={settings.generateImages}
                     className={`
                       relative inline-flex h-6 w-11 items-center rounded-full transition-colors duration-200
                       ${settings.generateImages ? "bg-[hsl(var(--primary))]" : "bg-[hsl(var(--secondary))]"}
@@ -433,6 +462,7 @@ export default function GeneratePage() {
                       <div className="flex items-center gap-3">
                         <input
                           type="range"
+                          aria-label={m.generation_imageGen_count()}
                           min={3}
                           max={10}
                           step={1}
@@ -468,7 +498,7 @@ export default function GeneratePage() {
 
               {/* Error Message */}
               {error && (
-                <div className="mb-4 rounded-xl bg-[hsl(var(--color-error-light))] p-3 text-sm text-[hsl(var(--color-error))]">
+                <div className="mb-4 rounded-lg bg-[hsl(var(--color-error-light))] p-3 text-sm font-medium text-[hsl(var(--color-error))]">
                   {error}
                 </div>
               )}
@@ -479,7 +509,7 @@ export default function GeneratePage() {
                 onClick={handleGenerate}
                 disabled={!canGenerate}
                 className={`
-                  btn-primary w-full h-12 rounded-xl text-base font-medium flex items-center justify-center gap-2
+                  btn-primary w-full h-12 text-base flex items-center justify-center gap-2
                   ${canGenerate
                     ? ""
                     : "opacity-50 cursor-not-allowed"
@@ -506,10 +536,13 @@ export default function GeneratePage() {
                   </>
                 )}
               </button>
+              </div>
             </div>
 
             {/* Right: Preview Area */}
-            <div className="card p-6">
+            <div className="card overflow-hidden">
+              <div className="proof-strip h-1.5" />
+              <div className="p-5 sm:p-6">
               <div className="flex items-center gap-2 mb-4">
                 <Eye className="h-5 w-5 text-[hsl(var(--primary))]" />
                 <h2 className="text-lg font-semibold text-foreground">{m.generation_preview()}</h2>
@@ -532,7 +565,7 @@ export default function GeneratePage() {
                 <div className="space-y-6">
                   {/* Demo Mode Banner */}
                   {generatedResults.some((r) => r.metadata?.mock) && (
-                    <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-400 flex items-center gap-2">
+                    <div className="flex items-center gap-2 rounded-lg border border-[hsl(var(--accent)/0.32)] bg-[hsl(var(--accent)/0.1)] p-3 text-sm font-medium text-[hsl(var(--accent))]">
                       <Sparkles className="w-4 h-4 flex-shrink-0" />
                       {m.generation_demoMode()}
                     </div>
@@ -542,7 +575,7 @@ export default function GeneratePage() {
                     <button
                       type="button"
                       onClick={() => setShowCompare(true)}
-                      className="w-full flex items-center justify-center gap-2 rounded-xl border-2 border-dashed border-[hsl(var(--border))] p-3 text-sm font-medium text-foreground-muted hover:border-[hsl(var(--primary))] hover:text-[hsl(var(--primary))] transition-colors"
+                      className="flex w-full items-center justify-center gap-2 rounded-lg border-2 border-dashed border-[hsl(var(--border))] p-3 text-sm font-semibold text-foreground-muted transition-colors hover:border-[hsl(var(--primary))] hover:text-[hsl(var(--primary))]"
                     >
                       <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 5a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM14 5a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1V5zM4 15a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1H5a1 1 0 01-1-1v-4zM14 15a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1v-4z" />
@@ -551,7 +584,7 @@ export default function GeneratePage() {
                     </button>
                   )}
                   {generatedResults.map((result, resultIndex) => (
-                    <div key={result.id || resultIndex} className="rounded-xl border border-[hsl(var(--border))] p-4">
+                    <div key={result.id || resultIndex} className="rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--background)/0.38)] p-4">
                       <div className="mb-4">
                         <h3 className="text-base font-semibold text-foreground mb-2">
                           {result.title}
@@ -564,7 +597,7 @@ export default function GeneratePage() {
                             {result.tags.slice(0, 5).map((tag: string, tagIndex: number) => (
                               <span
                                 key={tagIndex}
-                                className="inline-flex items-center rounded-full bg-[hsl(var(--primary)/0.1)] px-2.5 py-0.5 text-xs text-[hsl(var(--primary))]"
+                                className="inline-flex items-center rounded-full bg-[hsl(var(--primary)/0.1)] px-2.5 py-0.5 text-xs font-semibold text-[hsl(var(--primary))]"
                               >
                                 {tag}
                               </span>
@@ -582,7 +615,7 @@ export default function GeneratePage() {
                             {result.sceneImages.map((img: SceneImage, imgIndex: number) => (
                               <div
                                 key={img.imageId || imgIndex}
-                                className="group relative aspect-square rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--secondary))] overflow-hidden"
+                                className="group relative aspect-square overflow-hidden rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--secondary))]"
                               >
                                 <img
                                   src={img.url}
@@ -595,14 +628,14 @@ export default function GeneratePage() {
                                   <button
                                     type="button"
                                     onClick={() => window.open(img.url, "_blank")}
-                                    className="rounded-lg bg-[hsl(var(--primary))] px-3 py-1.5 text-xs font-medium text-white hover:bg-[hsl(var(--primary-hover))]"
+                                    className="rounded-md bg-[hsl(var(--primary))] px-3 py-1.5 text-xs font-semibold text-white hover:bg-[hsl(var(--primary-hover))]"
                                   >
                                     {m.generation_viewLarge()}
                                   </button>
                                   <a
                                     href={img.url}
                                     download
-                                    className="rounded-lg bg-[hsl(var(--secondary))] px-3 py-1.5 text-xs font-medium text-foreground hover:bg-[hsl(var(--secondary-hover))]"
+                                    className="rounded-md bg-[hsl(var(--secondary))] px-3 py-1.5 text-xs font-semibold text-foreground hover:bg-[hsl(var(--secondary-hover))]"
                                   >
                                     {m.generation_downloadImage()}
                                   </a>
@@ -620,14 +653,13 @@ export default function GeneratePage() {
                 </div>
               ) : !isGenerating ? (
                 <div className="flex flex-col items-center justify-center py-12 text-center">
-                  <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-[hsl(var(--primary)/0.1)] mb-4">
-                    <svg className="h-8 w-8 text-[hsl(var(--primary))]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                    </svg>
+                  <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-lg bg-[hsl(var(--primary)/0.1)]">
+                    <ClipboardCheck className="h-8 w-8 text-[hsl(var(--primary))]" aria-hidden="true" />
                   </div>
                   <p className="text-sm text-foreground-muted">{m.generation_previewDesc()}</p>
                 </div>
               ) : null}
+              </div>
             </div>
           </div>
         </div>

--- a/frontend/src/components/GenerationCard.tsx
+++ b/frontend/src/components/GenerationCard.tsx
@@ -5,6 +5,7 @@
  */
 
 import { useState } from "react";
+import { Eye, ImageIcon, Pencil, RotateCw, Trash2 } from "lucide-react";
 import * as m from "@/paraglide/messages.js";
 import type { GenerationRecord } from "@/hooks/useGenerations";
 
@@ -31,34 +32,34 @@ function formatTime(dateString: string): string {
   return date.toLocaleDateString("zh-CN");
 }
 
-function getStatusInfo(status: string): { label: string; color: string; bg: string } {
+function getStatusInfo(status: string): { label: string; badge: string } {
   switch (status) {
     case "success":
     case "completed":
-      return { label: m.profile_history_status_completed(), color: "text-green-700", bg: "bg-green-100" };
+      return { label: m.profile_history_status_completed(), badge: "status-badge-success" };
     case "processing":
     case "pending":
-      return { label: m.profile_history_status_processing(), color: "text-yellow-700", bg: "bg-yellow-100" };
+      return { label: m.profile_history_status_processing(), badge: "status-badge-warning" };
     case "failed":
     case "error":
-      return { label: m.profile_history_status_failed(), color: "text-red-700", bg: "bg-red-100" };
+      return { label: m.profile_history_status_failed(), badge: "status-badge-error" };
     default:
-      return { label: status, color: "text-gray-700", bg: "bg-gray-100" };
+      return { label: status, badge: "status-badge-neutral" };
   }
 }
 
-function getPlatformIcon(platform: string): string {
+function getPlatformLabel(platform: string): string {
   switch (platform) {
     case "amazon":
-      return "🅰️";
+      return "Amazon";
     case "shopify":
-      return "🛍️";
+      return "Shopify";
     case "ebay":
-      return "🏷️";
+      return "eBay";
     case "etsy":
-      return "🎨";
+      return "Etsy";
     default:
-      return "📦";
+      return platform || m.common_custom();
   }
 }
 
@@ -73,7 +74,7 @@ export default function GenerationCard({
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   const statusInfo = getStatusInfo(generation.status);
-  const platformIcon = getPlatformIcon(generation.platform);
+  const platformLabel = getPlatformLabel(generation.platform);
   const thumbnail = generation.productImageUrl || generation.generatedImages[0] || null;
 
   const handleDelete = () => {
@@ -88,15 +89,14 @@ export default function GenerationCard({
 
   return (
     <div
-      className="group relative bg-white dark:bg-stone-800 rounded-xl overflow-hidden shadow-sm hover:shadow-md transition-all duration-200 border border-stone-200 dark:border-stone-700"
+      className="card card-hover group relative overflow-hidden"
       onMouseEnter={() => setShowActions(true)}
       onMouseLeave={() => {
         setShowActions(false);
         setShowDeleteConfirm(false);
       }}
     >
-      {/* Thumbnail */}
-      <div className="relative aspect-video bg-stone-100 dark:bg-stone-900 overflow-hidden">
+      <div className="relative aspect-video overflow-hidden bg-[hsl(var(--secondary))]">
         {thumbnail ? (
           <img
             src={thumbnail}
@@ -106,104 +106,89 @@ export default function GenerationCard({
             decoding="async"
           />
         ) : (
-          <div className="w-full h-full flex items-center justify-center text-stone-400">
-            <svg className="w-12 h-12" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-            </svg>
+          <div className="flex h-full w-full items-center justify-center text-foreground-muted">
+            <ImageIcon className="h-12 w-12" aria-hidden="true" />
           </div>
         )}
 
-        {/* Status Badge */}
-        <div className={`absolute top-2 left-2 px-2 py-0.5 rounded-full text-xs font-medium ${statusInfo.bg} ${statusInfo.color}`}>
+        <div className={`status-badge absolute left-2 top-2 ${statusInfo.badge}`}>
           {statusInfo.label}
         </div>
 
-        {/* Image Count Badge */}
         {generation.generatedImages.length > 0 && (
-          <div className="absolute top-2 right-2 px-2 py-0.5 rounded-full text-xs font-medium bg-black/60 text-white">
+          <div className="status-badge absolute right-2 top-2 bg-[hsl(var(--foreground)/0.78)] text-[hsl(var(--background))]">
             {m.generation_imageCount({ count: generation.generatedImages.length.toString() })}
           </div>
         )}
 
-        {/* Quick Actions Overlay */}
         <div
-          className={`absolute inset-0 bg-black/40 flex items-center justify-center gap-2 transition-opacity duration-200 ${
+          className={`absolute inset-0 flex items-center justify-center gap-2 bg-[hsl(var(--foreground)/0.42)] transition-opacity duration-200 ${
             showActions ? "opacity-100" : "opacity-0"
           }`}
         >
           <button
             onClick={() => onViewDetail(generation.id)}
-            className="p-2 rounded-full bg-white/90 hover:bg-white transition-colors"
+            className="icon-button h-10 w-10 bg-[hsl(var(--card)/0.92)] text-foreground hover:bg-[hsl(var(--card))]"
             title={m.profile_history_viewDetail()}
+            aria-label={m.profile_history_viewDetail()}
           >
-            <svg className="w-5 h-5 text-stone-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-            </svg>
+            <Eye className="h-5 w-5" aria-hidden="true" />
           </button>
           <button
             onClick={() => onRegenerate(generation.id)}
-            className="p-2 rounded-full bg-white/90 hover:bg-white transition-colors"
+            className="icon-button h-10 w-10 bg-[hsl(var(--card)/0.92)] text-foreground hover:bg-[hsl(var(--card))]"
             title={m.history_regenerate()}
+            aria-label={m.history_regenerate()}
           >
-            <svg className="w-5 h-5 text-stone-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-            </svg>
+            <RotateCw className="h-5 w-5" aria-hidden="true" />
           </button>
           <button
             onClick={() => {
               const imageUrl = generation.generatedImages[0] || generation.productImageUrl;
               if (imageUrl) onEdit(imageUrl);
             }}
-            className="p-2 rounded-full bg-white/90 hover:bg-white transition-colors"
+            className="icon-button h-10 w-10 bg-[hsl(var(--card)/0.92)] text-foreground hover:bg-[hsl(var(--card))]"
             title={m.editor_editImage()}
+            aria-label={m.editor_editImage()}
           >
-            <svg className="w-5 h-5 text-stone-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-            </svg>
+            <Pencil className="h-5 w-5" aria-hidden="true" />
           </button>
           <button
             onClick={handleDelete}
-            className={`p-2 rounded-full transition-colors ${
+            className={`icon-button h-10 w-10 ${
               showDeleteConfirm
-                ? "bg-red-500 hover:bg-red-600 text-white"
-                : "bg-white/90 hover:bg-white text-stone-700"
+                ? "bg-[hsl(var(--color-error))] text-white hover:bg-[hsl(var(--color-error))]"
+                : "bg-[hsl(var(--card)/0.92)] text-foreground hover:bg-[hsl(var(--card))]"
             }`}
             title={showDeleteConfirm ? m.history_deleteConfirm() : m.common_delete()}
+            aria-label={showDeleteConfirm ? m.history_deleteConfirm() : m.common_delete()}
           >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-            </svg>
+            <Trash2 className="h-5 w-5" aria-hidden="true" />
           </button>
         </div>
       </div>
 
-      {/* Content */}
       <div className="p-3">
-        {/* Title / Prompt */}
-        <h3 className="text-sm font-medium text-stone-900 dark:text-stone-100 line-clamp-2 mb-2">
+        <h3 className="mb-2 line-clamp-2 text-sm font-semibold text-foreground">
           {generation.prompt || m.generation_taskTitle({ id: generation.id.slice(0, 8) })}
         </h3>
 
-        {/* Meta Info */}
-        <div className="flex items-center justify-between text-xs text-stone-500 dark:text-stone-400">
-          <div className="flex items-center gap-1">
-            <span>{platformIcon}</span>
-            <span className="capitalize">{generation.platform}</span>
+        <div className="flex items-center justify-between text-xs text-foreground-muted">
+          <div className="font-utility capitalize">
+            {platformLabel}
           </div>
           <div>{formatTime(generation.createdAt)}</div>
         </div>
 
-        {/* Style Tags */}
         <div className="flex flex-wrap gap-1 mt-2">
-          <span className="px-1.5 py-0.5 text-xs bg-stone-100 dark:bg-stone-700 text-stone-600 dark:text-stone-300 rounded">
+          <span className="status-badge status-badge-neutral">
             {generation.style}
           </span>
-          <span className="px-1.5 py-0.5 text-xs bg-stone-100 dark:bg-stone-700 text-stone-600 dark:text-stone-300 rounded">
+          <span className="status-badge status-badge-neutral">
             {generation.language}
           </span>
           {generation.count > 0 && (
-            <span className="px-1.5 py-0.5 text-xs bg-stone-100 dark:bg-stone-700 text-stone-600 dark:text-stone-300 rounded">
+            <span className="status-badge status-badge-neutral">
               ×{generation.count}
             </span>
           )}

--- a/frontend/src/components/GenerationProgress.tsx
+++ b/frontend/src/components/GenerationProgress.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Check, Loader2 } from "lucide-react";
 import * as m from "@/paraglide/messages.js";
 
 export type GenerationStage = "analyzing" | "generating_text" | "generating_images" | "uploading" | "completed";
@@ -48,7 +49,6 @@ export default function GenerationProgress({
 
   return (
     <div className="space-y-4">
-      {/* Stage Indicators */}
       <div className="flex items-center justify-between">
         {stages.map((stageItem, index) => {
           const isActive = index === currentStageIndex;
@@ -62,26 +62,20 @@ export default function GenerationProgress({
                   className={`
                     flex h-8 w-8 items-center justify-center rounded-full border-2 transition-all
                     ${isCompleted
-                      ? "border-slate-900 bg-slate-900"
+                      ? "border-[hsl(var(--primary))] bg-[hsl(var(--primary))]"
                       : isActive
-                      ? "border-slate-900 bg-white"
-                      : "border-slate-300 bg-white"
+                      ? "border-[hsl(var(--primary))] bg-[hsl(var(--card))]"
+                      : "border-[hsl(var(--border))] bg-[hsl(var(--card))]"
                     }
                   `}
                 >
                   {isCompleted ? (
-                    <svg className="h-4 w-4 text-white" fill="currentColor" viewBox="0 0 20 20">
-                      <path
-                        fillRule="evenodd"
-                        d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
+                    <Check className="h-4 w-4 text-white" aria-hidden="true" />
                   ) : (
                     <span
                       className={`
                         text-xs font-semibold
-                        ${isActive ? "text-slate-900" : "text-slate-400"}
+                        ${isActive ? "text-[hsl(var(--primary))]" : "text-foreground-muted"}
                       `}
                     >
                       {index + 1}
@@ -92,7 +86,7 @@ export default function GenerationProgress({
                 <span
                   className={`
                     mt-2 text-xs text-center
-                    ${isActive || isCompleted ? "text-slate-900 font-medium" : "text-slate-500"}
+                    ${isActive || isCompleted ? "font-semibold text-foreground" : "text-foreground-muted"}
                   `}
                 >
                   {stageItem.label}
@@ -103,7 +97,7 @@ export default function GenerationProgress({
                 <div
                   className={`
                     h-0.5 flex-1 -mt-6 transition-colors
-                    ${isCompleted ? "bg-slate-900" : "bg-slate-300"}
+                    ${isCompleted ? "bg-[hsl(var(--primary))]" : "bg-[hsl(var(--border))]"}
                   `}
                 />
               )}
@@ -115,43 +109,24 @@ export default function GenerationProgress({
       {/* Progress Bar */}
       <div>
         <div className="flex items-center justify-between mb-2">
-          <span className="text-sm text-slate-600">{getStageText()}</span>
-          <span className="text-sm font-medium text-slate-900">{Math.round(progress)}%</span>
+          <span className="text-sm text-foreground-muted">{getStageText()}</span>
+          <span className="font-utility text-sm font-semibold text-foreground">{Math.round(progress)}%</span>
         </div>
-        <div className="h-2 w-full rounded-full bg-slate-100 overflow-hidden">
+        <div className="h-2 w-full overflow-hidden rounded-full bg-[hsl(var(--secondary))]">
           <div
-            className="h-2 rounded-full bg-slate-900 transition-all duration-500 ease-out"
+            className="h-2 rounded-full bg-[hsl(var(--primary))] transition-all duration-500 ease-out"
             style={{ width: `${progress}%` }}
           />
         </div>
       </div>
 
-      {/* Current Stage Description */}
       {stage === "generating_images" && totalImageCount > 0 && (
-        <div className="rounded-lg bg-blue-50 p-3">
+        <div className="info-banner">
           <div className="flex items-start gap-2">
-            <svg
-              className="h-5 w-5 text-blue-600 mt-0.5 shrink-0 animate-spin"
-              fill="none"
-              viewBox="0 0 24 24"
-            >
-              <circle
-                className="opacity-25"
-                cx="12"
-                cy="12"
-                r="10"
-                stroke="currentColor"
-                strokeWidth="4"
-              />
-              <path
-                className="opacity-75"
-                fill="currentColor"
-                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-              />
-            </svg>
+            <Loader2 className="mt-0.5 h-5 w-5 shrink-0 animate-spin" aria-hidden="true" />
             <div className="flex-1">
-              <p className="text-sm font-medium text-blue-900">{m.generation_generatingSceneImages()}</p>
-              <p className="text-xs text-blue-700 mt-1">
+              <p className="text-sm font-semibold">{m.generation_generatingSceneImages()}</p>
+              <p className="mt-1 text-xs">
                 {m.generation_aiCreatingImages()}
               </p>
             </div>

--- a/frontend/src/components/HistoryPage.tsx
+++ b/frontend/src/components/HistoryPage.tsx
@@ -5,6 +5,7 @@
  */
 
 import { useCallback, useState } from "react";
+import { PackageOpen, Plus } from "lucide-react";
 import * as m from "@/paraglide/messages.js";
 import { localizeHref } from "@/paraglide/runtime.js";
 import { useGenerations } from "@/hooks/useGenerations";
@@ -15,17 +16,17 @@ import { deleteGeneration } from "@/lib/api";
 
 function SkeletonCard() {
   return (
-    <div className="bg-white dark:bg-stone-800 rounded-xl overflow-hidden shadow-sm border border-stone-200 dark:border-stone-700 animate-pulse">
-      <div className="aspect-video bg-stone-200 dark:bg-stone-700" />
+    <div className="card animate-pulse overflow-hidden">
+      <div className="aspect-video bg-[hsl(var(--secondary))]" />
       <div className="p-3 space-y-2">
-        <div className="h-4 bg-stone-200 dark:bg-stone-700 rounded w-3/4" />
+        <div className="h-4 w-3/4 rounded bg-[hsl(var(--secondary))]" />
         <div className="flex justify-between">
-          <div className="h-3 bg-stone-200 dark:bg-stone-700 rounded w-1/4" />
-          <div className="h-3 bg-stone-200 dark:bg-stone-700 rounded w-1/4" />
+          <div className="h-3 w-1/4 rounded bg-[hsl(var(--secondary))]" />
+          <div className="h-3 w-1/4 rounded bg-[hsl(var(--secondary))]" />
         </div>
         <div className="flex gap-1">
-          <div className="h-5 bg-stone-200 dark:bg-stone-700 rounded w-12" />
-          <div className="h-5 bg-stone-200 dark:bg-stone-700 rounded w-12" />
+          <div className="h-5 w-12 rounded bg-[hsl(var(--secondary))]" />
+          <div className="h-5 w-12 rounded bg-[hsl(var(--secondary))]" />
         </div>
       </div>
     </div>
@@ -34,27 +35,19 @@ function SkeletonCard() {
 
 function EmptyState({ onGenerate }: { onGenerate: () => void }) {
   return (
-    <div className="flex flex-col items-center justify-center py-16 px-4">
-      <div className="w-24 h-24 mb-6 text-stone-300 dark:text-stone-600">
-        <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" className="w-full h-full">
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={1}
-            d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
-          />
-        </svg>
-      </div>
-      <h3 className="text-lg font-medium text-stone-900 dark:text-stone-100 mb-2">
+    <div className="panel-muted flex flex-col items-center justify-center px-4 py-16">
+      <PackageOpen className="mb-6 h-16 w-16 text-foreground-muted" aria-hidden="true" />
+      <h2 className="mb-2 text-lg font-semibold text-foreground">
         {m.history_empty()}
-      </h3>
-      <p className="text-stone-500 dark:text-stone-400 text-center mb-6 max-w-sm">
+      </h2>
+      <p className="mb-6 max-w-sm text-center text-sm text-foreground-muted">
         {m.history_emptyDescription()}
       </p>
       <button
         onClick={onGenerate}
-        className="px-6 py-2.5 bg-amber-600 hover:bg-amber-700 text-white rounded-lg font-medium transition-colors"
+        className="btn-primary h-10 gap-2 px-6"
       >
+        <Plus className="h-4 w-4" aria-hidden="true" />
         {m.history_startGenerate()}
       </button>
     </div>
@@ -109,30 +102,27 @@ export default function HistoryPage() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-stone-100 dark:bg-stone-950">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {/* Header */}
-        <div className="flex items-center justify-between mb-6">
+    <div className="workbench-page">
+      <div className="workbench-container">
+        <header className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-stone-900 dark:text-stone-100">
+            <p className="page-kicker">Library / Generation history</p>
+            <h1 className="page-title mt-2">
               {m.history_title()}
             </h1>
-            <p className="text-stone-500 dark:text-stone-400 text-sm mt-1">
+            <p className="page-description mt-2">
               {pagination ? m.history_totalRecords({ count: pagination.total.toString() }) : ""}
             </p>
           </div>
           <button
             onClick={handleGenerate}
-            className="px-4 py-2 bg-amber-600 hover:bg-amber-700 text-white rounded-lg font-medium transition-colors flex items-center gap-2"
+            className="btn-primary h-10 gap-2 px-4"
           >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-            </svg>
+            <Plus className="h-4 w-4" aria-hidden="true" />
             {m.history_newGenerate()}
           </button>
-        </div>
+        </header>
 
-        {/* Filters */}
         <FilterBar
           timeFilter={filter}
           onTimeFilterChange={setFilter}
@@ -142,14 +132,13 @@ export default function HistoryPage() {
           onStatusFilterChange={setStatus}
         />
 
-        {/* Content */}
         <div className="mt-6">
           {error && (
-            <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg mb-4">
-              <p className="text-red-700 dark:text-red-400 text-sm">{error}</p>
+            <div className="error-banner mb-4">
+              <p>{error}</p>
               <button
                 onClick={refresh}
-                className="mt-2 text-sm text-red-600 dark:text-red-400 underline hover:no-underline"
+                className="mt-2 text-sm font-semibold underline hover:no-underline"
               >
                 {m.common_retry()}
               </button>
@@ -179,23 +168,22 @@ export default function HistoryPage() {
                 ))}
               </div>
 
-              {/* Pagination */}
               {pagination && pagination.totalPages > 1 && (
                 <div className="flex items-center justify-center gap-2 mt-8">
                   <button
                     onClick={() => setPage(page - 1)}
                     disabled={page === 1}
-                    className="px-3 py-1.5 text-sm rounded-lg bg-white dark:bg-stone-800 border border-stone-200 dark:border-stone-700 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-stone-50 dark:hover:bg-stone-700 transition-colors"
+                    className="btn-secondary h-9 px-3 disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     {m.common_previousPage()}
                   </button>
-                  <span className="text-sm text-stone-600 dark:text-stone-400">
+                  <span className="font-utility text-sm text-foreground-muted">
                     {page} / {pagination.totalPages}
                   </span>
                   <button
                     onClick={() => setPage(page + 1)}
                     disabled={page === pagination.totalPages}
-                    className="px-3 py-1.5 text-sm rounded-lg bg-white dark:bg-stone-800 border border-stone-200 dark:border-stone-700 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-stone-50 dark:hover:bg-stone-700 transition-colors"
+                    className="btn-secondary h-9 px-3 disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     {m.common_nextPage()}
                   </button>

--- a/frontend/src/components/HomePage.tsx
+++ b/frontend/src/components/HomePage.tsx
@@ -1,148 +1,225 @@
 "use client";
 
-import { ArrowRight, Sparkles, Zap, Globe, Shield } from "lucide-react";
+import {
+  ArrowRight,
+  BadgeCheck,
+  Camera,
+  CheckCircle2,
+  Globe2,
+  PackageCheck,
+  ScanLine,
+  WandSparkles,
+} from "lucide-react";
 import * as m from "@/paraglide/messages.js";
 import { localizeHref } from "@/paraglide/runtime.js";
+
+const proofRows = [
+  { label: "Input", value: "1 product photo", tone: "bg-[hsl(var(--primary)/0.1)] text-[hsl(var(--primary))]" },
+  { label: "Market", value: "Amazon, Shopify, eBay", tone: "bg-[hsl(var(--accent)/0.12)] text-[hsl(var(--accent))]" },
+  { label: "Output", value: "Copy, image scenes, tags", tone: "bg-[hsl(var(--foreground)/0.08)] text-foreground" },
+];
+
+const workflow = [
+  {
+    icon: Camera,
+    title: "Drop in the hero image",
+    copy: "Start with the product photo your team already has. Add reference shots only when the brand direction needs it.",
+  },
+  {
+    icon: ScanLine,
+    title: "Set marketplace constraints",
+    copy: "Choose platform, language, aspect ratio, scene count, and style before a generation starts.",
+  },
+  {
+    icon: PackageCheck,
+    title: "Review listing-ready assets",
+    copy: "Scan the generated title, selling points, tags, and scene images in the same workspace.",
+  },
+];
+
+const platformBadges = ["Amazon", "Shopify", "eBay", "Etsy"];
 
 export default function HomePage() {
   return (
     <div className="flex min-h-screen flex-col">
       <main className="flex-1">
-        {/* Hero Section */}
-        <section className="relative overflow-hidden">
-          {/* Background gradient mesh */}
-          <div className="absolute inset-0 gradient-mesh" />
-          <div className="absolute inset-0 gradient-radial" />
+        <section className="relative overflow-hidden border-b border-[hsl(var(--border))] bg-[hsl(var(--background))]">
+          <div className="proof-strip absolute inset-x-0 top-0 h-2" />
 
-          {/* Floating orbs */}
-          <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-[hsl(var(--primary))]/10 rounded-full blur-3xl animate-float" />
-          <div className="absolute bottom-1/3 right-1/4 w-80 h-80 bg-violet-500/10 rounded-full blur-3xl animate-float" style={{ animationDelay: "1s" }} />
-
-          <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-            <div className="flex flex-col items-center justify-center py-24 text-center lg:py-36">
-              {/* Badge */}
-              <div className="mb-8 inline-flex items-center gap-2 rounded-full border border-[hsl(var(--primary)/0.3)] bg-[hsl(var(--primary)/0.1)] px-4 py-1.5 text-sm animate-fade-in-up">
-                <span className="status-dot status-dot-online" />
-                <span className="text-foreground-muted">AI Powered Product Generation</span>
-              </div>
-
-              {/* Title */}
-              <h1 className="max-w-4xl text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl animate-fade-in-up stagger-1">
-                {m.welcome()}
+          <div className="mx-auto grid max-w-7xl gap-10 px-4 pb-14 pt-16 sm:px-6 lg:grid-cols-[0.9fr_1.1fr] lg:px-8 lg:pb-20 lg:pt-20">
+            <div className="flex flex-col justify-center">
+              <p className="font-utility text-xs font-semibold uppercase text-[hsl(var(--accent))]">
+                Product photo to listing bench
+              </p>
+              <h1 className="font-display mt-5 max-w-3xl text-5xl font-semibold text-foreground sm:text-6xl lg:text-7xl">
+                Turn one product shot into a marketplace-ready detail page.
               </h1>
-
-              {/* Gradient text effect for key word */}
-              <h1 className="max-w-4xl text-4xl font-bold tracking-tight mt-2 sm:text-5xl lg:text-6xl animate-fade-in-up stagger-2">
-                <span className="gradient-text">{m.description()}</span>
-              </h1>
-
-              {/* Subtitle */}
-              <p className="mt-6 max-w-2xl text-lg text-foreground-muted animate-fade-in-up stagger-3">
-                Transform your product images into stunning detail pages with AI.
-                Generate professional content for Amazon, Shopify, eBay, and more.
+              <p className="mt-6 max-w-2xl text-lg text-foreground-muted">
+                OuraPix helps cross-border teams turn product imagery into copy, visual scenes,
+                tags, and exportable detail-page material without leaving the browser.
               </p>
 
-              {/* CTA Buttons */}
-              <div className="mt-10 flex flex-col gap-4 sm:flex-row animate-fade-in-up stagger-4">
+              <div className="mt-8 flex flex-col gap-3 sm:flex-row">
                 <a
                   href={localizeHref("/generate")}
-                  className="btn-primary inline-flex items-center justify-center gap-2 rounded-xl px-8 py-3.5 text-base font-medium"
+                  className="btn-primary gap-2 px-6 py-3 text-base"
                 >
-                  <Sparkles className="h-5 w-5" />
+                  <WandSparkles className="h-5 w-5" aria-hidden="true" />
                   {m.generate()}
-                  <ArrowRight className="h-4 w-4" />
+                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
                 </a>
                 <a
                   href={localizeHref("/pricing")}
-                  className="btn-secondary inline-flex items-center justify-center gap-2 rounded-xl px-8 py-3.5 text-base font-medium"
+                  className="btn-secondary gap-2 px-6 py-3 text-base"
                 >
                   {m.pricing()}
                 </a>
               </div>
-            </div>
-          </div>
-        </section>
 
-        {/* Features Section */}
-        <section className="relative py-24">
-          <div className="absolute inset-0 gradient-mesh opacity-50" />
-          <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-            <div className="text-center">
-              <h2 className="text-3xl font-bold text-foreground sm:text-4xl animate-fade-in-up">
-                Everything you need
-              </h2>
-              <p className="mt-4 text-lg text-foreground-muted">
-                Create stunning product pages in minutes
-              </p>
-            </div>
-
-            <div className="mt-16 grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-              {[
-                {
-                  icon: Sparkles,
-                  title: "AI Generation",
-                  desc: "Generate pages with AI",
-                  color: "from-[hsl(var(--primary))] to-violet-500",
-                },
-                {
-                  icon: Globe,
-                  title: "Multi-language",
-                  desc: "Support for multiple languages",
-                  color: "from-cyan-500 to-blue-500",
-                },
-                {
-                  icon: Zap,
-                  title: "Fast Export",
-                  desc: "Export in multiple formats",
-                  color: "from-amber-500 to-orange-500",
-                },
-                {
-                  icon: Shield,
-                  title: "Secure & Private",
-                  desc: "Your data stays protected",
-                  color: "from-emerald-500 to-green-500",
-                },
-              ].map((feature, index) => (
-                <div
-                  key={feature.title}
-                  className="card card-hover p-6 animate-fade-in-up"
-                  style={{ animationDelay: `${index * 0.1}s` }}
-                >
-                  <div className={`mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br ${feature.color} p-2.5`}>
-                    <feature.icon className="h-6 w-6 text-white" />
-                  </div>
-                  <h3 className="text-lg font-semibold text-foreground">{feature.title}</h3>
-                  <p className="mt-2 text-sm text-foreground-muted">{feature.desc}</p>
-                </div>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* CTA Section */}
-        <section className="relative py-24">
-          <div className="relative mx-auto max-w-4xl px-4 text-center sm:px-6 lg:px-8">
-            <div className="card p-12 lg:p-16 glow-sm">
-              <div className="absolute inset-0 gradient-radial opacity-50" />
-              <div className="relative">
-                <h2 className="text-3xl font-bold text-foreground sm:text-4xl">
-                  Ready to get started?
-                </h2>
-                <p className="mt-4 text-lg text-foreground-muted">
-                  Create your first product page in minutes
-                </p>
-                <div className="mt-10">
-                  <a
-                    href={localizeHref("/generate")}
-                    className="btn-primary inline-flex items-center justify-center gap-2 rounded-xl px-8 py-3.5 text-base font-medium"
+              <div className="mt-8 flex flex-wrap gap-2" aria-label="Supported marketplaces">
+                {platformBadges.map((platform) => (
+                  <span
+                    key={platform}
+                    className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--card)/0.8)] px-3 py-1 text-sm font-semibold text-foreground-muted"
                   >
-                    <Sparkles className="h-5 w-5" />
-                    Start Generating
-                    <ArrowRight className="h-4 w-4" />
-                  </a>
-                </div>
+                    {platform}
+                  </span>
+                ))}
               </div>
             </div>
+
+            <aside className="relative" aria-label="OuraPix generation specimen">
+              <div className="card specimen-shadow overflow-hidden border-2 border-[hsl(var(--foreground)/0.14)]">
+                <div className="proof-strip h-3" />
+                <div className="grid gap-5 p-4 sm:p-5 lg:grid-cols-[1fr_0.88fr]">
+                  <div className="rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--background-secondary))] p-4">
+                    <div className="flex items-center justify-between gap-3">
+                      <div>
+                        <p className="font-utility text-xs font-semibold uppercase text-foreground-muted">
+                          Source image
+                        </p>
+                        <h2 className="mt-1 text-xl font-semibold text-foreground">
+                          Travel mug set
+                        </h2>
+                      </div>
+                      <BadgeCheck className="h-5 w-5 text-[hsl(var(--primary))]" aria-hidden="true" />
+                    </div>
+
+                    <div className="mt-4 aspect-[4/3] overflow-hidden rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--card))]">
+                      <div className="bench-grid flex h-full items-center justify-center p-8">
+                        <img
+                          src="/logo.png"
+                          alt="OuraPix product preview placeholder"
+                          className="h-full max-h-48 w-full object-contain"
+                          loading="eager"
+                        />
+                      </div>
+                    </div>
+
+                    <div className="mt-4 grid gap-2">
+                      {proofRows.map((row) => (
+                        <div
+                          key={row.label}
+                          className="flex items-center justify-between gap-3 rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 py-2"
+                        >
+                          <span className="font-utility text-[11px] font-semibold uppercase text-foreground-muted">
+                            {row.label}
+                          </span>
+                          <span className={`rounded-full px-2.5 py-1 text-xs font-semibold ${row.tone}`}>
+                            {row.value}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="flex flex-col gap-3">
+                    <div className="rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-4">
+                      <p className="font-utility text-xs font-semibold uppercase text-foreground-muted">
+                        Generated listing
+                      </p>
+                      <h3 className="mt-3 text-2xl font-semibold text-foreground">
+                        Leakproof mug for daily carry
+                      </h3>
+                      <p className="mt-3 text-sm text-foreground-muted">
+                        Compact silhouette, textured grip, and insulated body described for marketplace search.
+                      </p>
+                      <div className="mt-4 flex flex-wrap gap-2">
+                        {["BPA free", "commute", "giftable"].map((tag) => (
+                          <span key={tag} className="badge">
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+
+                    <div className="rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--foreground))] p-4 text-[hsl(var(--background))]">
+                      <div className="flex items-center justify-between gap-3">
+                        <p className="font-utility text-xs font-semibold uppercase text-[hsl(var(--background)/0.68)]">
+                          Export check
+                        </p>
+                        <Globe2 className="h-5 w-5 text-[hsl(var(--background))]" aria-hidden="true" />
+                      </div>
+                      <div className="mt-5 space-y-3">
+                        {["Localized copy", "Scene ratios", "SEO tags"].map((item) => (
+                          <div key={item} className="flex items-center gap-2 text-sm font-semibold">
+                            <CheckCircle2 className="h-4 w-4 text-[hsl(var(--accent))]" aria-hidden="true" />
+                            {item}
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </aside>
+          </div>
+        </section>
+
+        <section className="bg-[hsl(var(--card))] py-16">
+          <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+            <div className="grid gap-8 lg:grid-cols-[0.7fr_1.3fr]">
+              <div>
+                <p className="font-utility text-xs font-semibold uppercase text-[hsl(var(--primary))]">
+                  Operating line
+                </p>
+                <h2 className="font-display mt-3 text-4xl font-semibold text-foreground">
+                  Built around the actual listing workflow.
+                </h2>
+              </div>
+              <div className="grid gap-3 md:grid-cols-3">
+                {workflow.map((item) => (
+                  <div
+                    key={item.title}
+                    className="border-l-2 border-[hsl(var(--border))] bg-[hsl(var(--background)/0.5)] p-5"
+                  >
+                    <item.icon className="h-5 w-5 text-[hsl(var(--primary))]" aria-hidden="true" />
+                    <h3 className="mt-5 text-lg font-semibold text-foreground">{item.title}</h3>
+                    <p className="mt-3 text-sm text-foreground-muted">{item.copy}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="border-t border-[hsl(var(--border))] bg-[hsl(var(--foreground))] py-14 text-[hsl(var(--background))]">
+          <div className="mx-auto flex max-w-7xl flex-col items-start justify-between gap-6 px-4 sm:px-6 lg:flex-row lg:items-center lg:px-8">
+            <div>
+              <p className="font-utility text-xs font-semibold uppercase text-[hsl(var(--background)/0.62)]">
+                Ready at the bench
+              </p>
+              <h2 className="font-display mt-3 text-4xl font-semibold">
+                Start with the product image you already have.
+              </h2>
+            </div>
+            <a
+              href={localizeHref("/generate")}
+              className="inline-flex items-center justify-center rounded-md bg-[hsl(var(--background))] px-6 py-3 text-base font-semibold text-foreground transition hover:bg-[hsl(var(--background-secondary))]"
+            >
+              {m.generate()}
+              <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+            </a>
           </div>
         </section>
       </main>

--- a/frontend/src/components/LanguageSelector.tsx
+++ b/frontend/src/components/LanguageSelector.tsx
@@ -43,9 +43,11 @@ export default function LanguageSelector() {
   return (
     <div className="relative" ref={dropdownRef}>
       <button
+        type="button"
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium text-slate-600 hover:bg-slate-100 transition-colors"
+        className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-semibold text-foreground-muted transition-colors hover:bg-[hsl(var(--foreground)/0.06)] hover:text-foreground"
         aria-label={m.language_selector()}
+        aria-expanded={isOpen}
       >
         <span>{currentLanguage.flag}</span>
         <span className="hidden sm:inline">{currentLanguage.label}</span>
@@ -60,24 +62,25 @@ export default function LanguageSelector() {
       </button>
 
       {isOpen && (
-        <div className="absolute right-0 mt-2 w-40 rounded-lg bg-white shadow-lg border border-slate-200 py-1 z-50">
+        <div className="absolute right-0 z-50 mt-2 w-40 rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--popover))] py-1 shadow-lg">
           {languages.map((lang) => (
             <button
               key={lang.tag}
+              type="button"
               onClick={() => {
                 handleLanguageChange(lang.tag);
                 setIsOpen(false);
               }}
               className={`w-full flex items-center gap-2 px-4 py-2 text-sm transition-colors ${
                 currentLang === lang.tag
-                  ? "bg-slate-100 text-slate-900"
-                  : "text-slate-600 hover:bg-slate-50"
+                  ? "bg-[hsl(var(--primary)/0.1)] text-foreground"
+                  : "text-foreground-muted hover:bg-[hsl(var(--foreground)/0.06)] hover:text-foreground"
               }`}
             >
               <span>{lang.flag}</span>
               <span>{lang.label}</span>
               {currentLang === lang.tag && (
-                <svg className="h-4 w-4 ml-auto text-amber-600" fill="currentColor" viewBox="0 0 20 20">
+                <svg className="ml-auto h-4 w-4 text-[hsl(var(--accent))]" fill="currentColor" viewBox="0 0 20 20">
                   <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
                 </svg>
               )}

--- a/frontend/src/components/LoginPage.tsx
+++ b/frontend/src/components/LoginPage.tsx
@@ -1,15 +1,14 @@
 "use client";
 
 import { useState } from "react";
-import { Eye, EyeOff, Sparkles } from "lucide-react";
+import { CheckCircle2, Eye, EyeOff, PackageCheck } from "lucide-react";
 import * as m from "@/paraglide/messages.js";
 import { localizeHref } from "@/paraglide/runtime.js";
 import { useAuth } from "@/hooks/use-auth";
 import { signInSocial } from "@/lib/auth";
 
-// PasswordInput sub-component
 function PasswordInput({
-  className,
+  className = "",
   ...props
 }: React.InputHTMLAttributes<HTMLInputElement>) {
   const [showPassword, setShowPassword] = useState(false);
@@ -18,26 +17,25 @@ function PasswordInput({
     <div className="relative">
       <input
         type={showPassword ? "text" : "password"}
-        className={`input pr-10 ${className}`}
+        className={`input h-11 pr-10 ${className}`}
         {...props}
       />
       <button
         type="button"
-        className="absolute right-0 top-0 h-full px-3 text-foreground-muted hover:text-foreground transition-colors"
+        className="absolute right-0 top-0 flex h-full items-center px-3 text-foreground-muted transition-colors hover:text-foreground"
         onClick={() => setShowPassword(!showPassword)}
-        tabIndex={-1}
+        aria-label={showPassword ? "Hide password" : "Show password"}
       >
         {showPassword ? (
-          <EyeOff className="h-4 w-4" />
+          <EyeOff className="h-4 w-4" aria-hidden="true" />
         ) : (
-          <Eye className="h-4 w-4" />
+          <Eye className="h-4 w-4" aria-hidden="true" />
         )}
       </button>
     </div>
   );
 }
 
-// Social login buttons
 function SocialLoginButtons() {
   const handleGoogleLogin = () => {
     signInSocial("google", localizeHref("/"));
@@ -64,9 +62,9 @@ function SocialLoginButtons() {
         <button
           type="button"
           onClick={handleGoogleLogin}
-          className="btn-secondary inline-flex h-11 items-center justify-center gap-2 rounded-xl px-4 text-sm"
+          className="btn-secondary h-11 gap-2 px-4 text-sm"
         >
-          <svg className="h-4 w-4" viewBox="0 0 24 24">
+          <svg className="h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
             <path
               d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
               fill="#4285F4"
@@ -89,9 +87,9 @@ function SocialLoginButtons() {
         <button
           type="button"
           onClick={handleGitHubLogin}
-          className="btn-secondary inline-flex h-11 items-center justify-center gap-2 rounded-xl px-4 text-sm"
+          className="btn-secondary h-11 gap-2 px-4 text-sm"
         >
-          <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
+          <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
             <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
           </svg>
           GitHub
@@ -125,111 +123,83 @@ export default function LoginPage() {
     setIsLoading(false);
   };
 
+  const checklist = [
+    m.loginMarketing_featureFree(),
+    m.loginMarketing_featureFast(),
+    m.loginMarketing_featureQuality(),
+  ];
+
   return (
-    <div className="flex min-h-screen">
-      {/* Left side - Marketing */}
-      <div className="hidden lg:flex lg:w-1/2 relative overflow-hidden bg-[hsl(var(--background-secondary))]">
-        {/* Background decorations */}
-        <div className="absolute inset-0">
-          <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-[hsl(var(--primary))]/20 rounded-full blur-3xl" />
-          <div className="absolute bottom-1/4 right-1/4 w-96 h-96 bg-violet-500/15 rounded-full blur-3xl" />
-          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-64 h-64 bg-[hsl(var(--primary))]/10 rounded-full blur-2xl" />
-        </div>
+    <div className="grid min-h-screen lg:grid-cols-[0.95fr_1.05fr]">
+      <aside className="relative hidden overflow-hidden border-r border-[hsl(var(--border))] bg-[hsl(var(--card))] lg:block">
+        <div className="proof-strip absolute inset-x-0 top-0 h-2" />
+        <div className="bench-grid absolute inset-0 opacity-40" />
 
-        {/* Grid pattern */}
-        <div
-          className="absolute inset-0 opacity-10"
-          style={{
-            backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.15'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
-          }}
-        />
+        <div className="relative z-10 flex min-h-screen flex-col justify-center px-12 xl:px-20">
+          <a href={localizeHref("/")} className="flex items-center gap-3">
+            <div className="flex h-12 w-12 items-center justify-center rounded-md bg-[hsl(var(--foreground))] text-[hsl(var(--background))]">
+              <PackageCheck className="h-6 w-6" aria-hidden="true" />
+            </div>
+            <span className="font-display text-3xl font-semibold text-foreground">OuraPix</span>
+          </a>
 
-        {/* Content */}
-        <div className="relative z-10 flex flex-col justify-center px-12 xl:px-20">
-          <div className="mb-8">
-            <a href={localizeHref("/")} className="flex items-center gap-3 group">
-              <div className="relative flex h-12 w-12 items-center justify-center rounded-xl overflow-hidden">
-                <div className="absolute inset-0 bg-gradient-to-br from-[hsl(var(--primary))] to-violet-500 opacity-80" />
-                <div className="absolute inset-0 bg-gradient-to-br from-[hsl(var(--primary))] to-violet-500 opacity-80 blur-xl" />
-                <span className="relative text-2xl font-bold text-white">
-                  <Sparkles className="h-6 w-6" />
-                </span>
-              </div>
-              <span className="text-3xl font-bold text-foreground">OuraPix</span>
-            </a>
-          </div>
-
-          <h1 className="text-4xl xl:text-5xl font-bold text-foreground leading-tight mb-6">
-            {m.loginMarketing_headline()}<br />
-            <span className="gradient-text">
+          <p className="font-utility mt-12 text-xs font-semibold uppercase text-[hsl(var(--accent))]">
+            Returning bench
+          </p>
+          <h2 className="font-display mt-4 max-w-xl text-5xl font-semibold leading-none text-foreground">
+            {m.loginMarketing_headline()}
+            <span className="block text-[hsl(var(--primary))]">
               {m.loginMarketing_headlineHighlight()}
             </span>
-          </h1>
-
-          <p className="text-lg text-foreground-muted mb-8 max-w-md">
+          </h2>
+          <p className="mt-6 max-w-md text-lg text-foreground-muted">
             {m.loginMarketing_description()}
           </p>
 
-          <div className="flex items-center gap-6 text-sm text-foreground-muted">
-            <div className="flex items-center gap-2">
-              <svg className="w-5 h-5 text-[hsl(var(--primary))]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-              </svg>
-              <span>{m.loginMarketing_featureFree()}</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <svg className="w-5 h-5 text-[hsl(var(--primary))]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-              </svg>
-              <span>{m.loginMarketing_featureFast()}</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <svg className="w-5 h-5 text-[hsl(var(--primary))]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-              </svg>
-              <span>{m.loginMarketing_featureQuality()}</span>
+          <div className="card mt-10 overflow-hidden">
+            <div className="proof-strip h-2" />
+            <div className="space-y-4 p-5">
+              {checklist.map((item) => (
+                <div key={item} className="flex items-center gap-3 text-sm font-semibold text-foreground">
+                  <CheckCircle2 className="h-5 w-5 text-[hsl(var(--primary))]" aria-hidden="true" />
+                  {item}
+                </div>
+              ))}
             </div>
           </div>
         </div>
-      </div>
+      </aside>
 
-      {/* Right side - Login Form */}
-      <div className="w-full lg:w-1/2 flex flex-col justify-center px-6 py-12 sm:px-8 lg:px-12 xl:px-16 bg-[hsl(var(--background))]">
-        <div className="w-full max-w-md mx-auto">
-          {/* Mobile Logo */}
-          <div className="lg:hidden flex justify-center mb-8">
+      <main className="flex min-h-screen flex-col justify-center bg-[hsl(var(--background))] px-6 py-12 sm:px-8 lg:px-12 xl:px-16">
+        <div className="mx-auto w-full max-w-md">
+          <div className="mb-8 flex justify-center lg:hidden">
             <a href={localizeHref("/")} className="flex items-center gap-2">
-              <div className="relative flex h-10 w-10 items-center justify-center rounded-xl overflow-hidden">
-                <div className="absolute inset-0 bg-gradient-to-br from-[hsl(var(--primary))] to-violet-500 opacity-80" />
-                <span className="relative text-xl font-bold text-white">
-                  <Sparkles className="h-5 w-5" />
-                </span>
+              <div className="flex h-10 w-10 items-center justify-center rounded-md bg-[hsl(var(--foreground))] text-[hsl(var(--background))]">
+                <PackageCheck className="h-5 w-5" aria-hidden="true" />
               </div>
-              <span className="text-2xl font-bold text-foreground">OuraPix</span>
+              <span className="font-display text-2xl font-semibold text-foreground">OuraPix</span>
             </a>
           </div>
 
-          {/* Title */}
           <div className="mb-8">
-            <h2 className="text-2xl font-bold text-foreground mb-2">
-              {m.login_title()}
-            </h2>
-            <p className="text-foreground-muted">
-              {m.login_subtitle()}
+            <p className="font-utility text-xs font-semibold uppercase text-[hsl(var(--accent))]">
+              Sign in
             </p>
+            <h1 className="font-display mt-2 text-4xl font-semibold text-foreground">
+              {m.login_title()}
+            </h1>
+            <p className="mt-2 text-foreground-muted">{m.login_subtitle()}</p>
           </div>
 
-          {/* Error message */}
           {error && (
-            <div className="mb-6 p-4 rounded-xl bg-[hsl(var(--color-error-light))] border border-[hsl(var(--color-error)/0.3)]">
-              <p className="text-sm text-[hsl(var(--color-error))]">{error}</p>
+            <div className="mb-6 rounded-lg border border-[hsl(var(--color-error)/0.3)] bg-[hsl(var(--color-error-light))] p-4">
+              <p className="text-sm font-medium text-[hsl(var(--color-error))]">{error}</p>
             </div>
           )}
 
-          {/* Login Form */}
           <form className="space-y-5" onSubmit={handleSubmit}>
             <div className="space-y-2">
-              <label htmlFor="email" className="text-sm font-medium text-foreground">
+              <label htmlFor="email" className="text-sm font-semibold text-foreground">
                 {m.login_email()}
               </label>
               <input
@@ -246,7 +216,7 @@ export default function LoginPage() {
             </div>
 
             <div className="space-y-2">
-              <label htmlFor="password" className="text-sm font-medium text-foreground">
+              <label htmlFor="password" className="text-sm font-semibold text-foreground">
                 {m.login_password()}
               </label>
               <PasswordInput
@@ -260,8 +230,8 @@ export default function LoginPage() {
               />
             </div>
 
-            <div className="flex items-center justify-between">
-              <div className="flex items-center space-x-2">
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex items-center gap-2">
                 <input
                   id="remember"
                   type="checkbox"
@@ -271,14 +241,14 @@ export default function LoginPage() {
                 />
                 <label
                   htmlFor="remember"
-                  className="text-sm text-foreground-muted cursor-pointer select-none"
+                  className="cursor-pointer select-none text-sm text-foreground-muted"
                 >
                   {m.login_rememberMe()}
                 </label>
               </div>
               <a
                 href={localizeHref("/forgot-password")}
-                className="text-sm font-medium text-[hsl(var(--primary))] hover:text-[hsl(var(--primary-hover))] transition-colors"
+                className="text-sm font-semibold text-[hsl(var(--primary))] transition-colors hover:text-[hsl(var(--primary-hover))]"
               >
                 {m.login_forgotPassword()}
               </a>
@@ -287,11 +257,11 @@ export default function LoginPage() {
             <button
               type="submit"
               disabled={isLoading}
-              className="btn-primary w-full h-11 rounded-xl text-sm flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="btn-primary h-11 w-full gap-2 text-sm disabled:cursor-not-allowed disabled:opacity-50"
             >
               {isLoading ? (
                 <>
-                  <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24">
+                  <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" aria-hidden="true">
                     <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
                     <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
                   </svg>
@@ -305,20 +275,19 @@ export default function LoginPage() {
             <SocialLoginButtons />
           </form>
 
-          {/* Register link */}
-          <div className="mt-8 pt-6 border-t border-[hsl(var(--border))]">
-            <p className="text-center text-foreground-muted text-sm">
+          <div className="mt-8 border-t border-[hsl(var(--border))] pt-6">
+            <p className="text-center text-sm text-foreground-muted">
               {m.login_noAccount()}{" "}
               <a
                 href={localizeHref("/register")}
-                className="font-medium text-[hsl(var(--primary))] hover:text-[hsl(var(--primary-hover))] transition-colors"
+                className="font-semibold text-[hsl(var(--primary))] transition-colors hover:text-[hsl(var(--primary-hover))]"
               >
                 {m.login_signUp()}
               </a>
             </p>
           </div>
         </div>
-      </div>
+      </main>
     </div>
   );
 }

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { Menu, X, ChevronDown, Sparkles } from "lucide-react";
+import { Menu, X, ChevronDown, PackageCheck } from "lucide-react";
 import * as m from "@/paraglide/messages.js";
 import { localizeHref } from "@/paraglide/runtime.js";
 import LanguageSelector from "./LanguageSelector";
@@ -86,23 +86,17 @@ export default function Navbar() {
     <header
       className={`sticky top-0 z-50 w-full transition-all duration-300 ${
         isScrolled
-          ? "glass border-b border-[hsl(var(--border))] shadow-lg"
-          : "bg-transparent"
+          ? "glass border-b border-[hsl(var(--border))] shadow-sm"
+          : "bg-[hsl(var(--background)/0.86)] backdrop-blur-md"
       }`}
     >
       <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
         {/* Logo */}
         <a href={localizeHref("/")} className="flex items-center gap-3 group">
-          <div className="relative flex h-9 w-9 items-center justify-center rounded-xl overflow-hidden">
-            {/* Glow effect */}
-            <div className="absolute inset-0 bg-gradient-to-br from-[hsl(var(--primary))] to-violet-500 opacity-80" />
-            <div className="absolute inset-0 bg-gradient-to-br from-[hsl(var(--primary))] to-violet-500 opacity-80 blur-xl" />
-            {/* Icon */}
-            <span className="relative text-lg font-bold text-white">
-              <Sparkles className="h-4 w-4" />
-            </span>
+          <div className="flex h-9 w-9 items-center justify-center rounded-md bg-[hsl(var(--foreground))] text-[hsl(var(--background))] shadow-sm">
+            <PackageCheck className="h-5 w-5" aria-hidden="true" />
           </div>
-          <span className="text-lg font-semibold text-foreground tracking-tight">OuraPix</span>
+          <span className="font-display text-xl font-semibold text-foreground">OuraPix</span>
         </a>
 
         {/* Desktop Navigation */}
@@ -112,7 +106,7 @@ export default function Navbar() {
               <a
                 key={item.href}
                 href={localizeHref(item.href)}
-                className="px-4 py-2 rounded-lg text-sm font-medium text-foreground-muted transition-all duration-200 hover:text-foreground hover:bg-[hsl(var(--foreground)/0.05)]"
+                className="rounded-md px-3 py-2 text-sm font-semibold text-foreground-muted transition-all duration-200 hover:bg-[hsl(var(--foreground)/0.06)] hover:text-foreground"
               >
                 {item.label}
               </a>
@@ -124,11 +118,13 @@ export default function Navbar() {
                 onMouseLeave={handleMouseLeave}
               >
                 <button
+                  type="button"
                   onClick={(e) => {
                     e.stopPropagation();
                     setOpenDropdown(openDropdown === item.label ? null : item.label);
                   }}
-                  className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium text-foreground-muted transition-all duration-200 hover:text-foreground hover:bg-[hsl(var(--foreground)/0.05)]"
+                  className="flex items-center gap-1.5 rounded-md px-3 py-2 text-sm font-semibold text-foreground-muted transition-all duration-200 hover:bg-[hsl(var(--foreground)/0.06)] hover:text-foreground"
+                  aria-expanded={openDropdown === item.label}
                 >
                   {item.label}
                   <ChevronDown
@@ -139,12 +135,12 @@ export default function Navbar() {
                 </button>
                 {openDropdown === item.label && (
                   <div className="absolute left-0 top-full pt-2 animate-scale-in origin-top-left">
-                    <div className="min-w-[160px] rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--popover))] p-1.5 shadow-xl">
+                    <div className="min-w-[180px] rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--popover))] p-1.5 shadow-xl">
                       {item.children.map((child) => (
                         <a
                           key={child.href}
                           href={localizeHref(child.href)}
-                          className="flex items-center px-3 py-2 rounded-lg text-sm text-foreground-muted transition-colors hover:text-foreground hover:bg-[hsl(var(--foreground)/0.05)]"
+                          className="flex items-center rounded-md px-3 py-2 text-sm font-medium text-foreground-muted transition-colors hover:bg-[hsl(var(--foreground)/0.06)] hover:text-foreground"
                         >
                           {child.label}
                         </a>
@@ -165,14 +161,14 @@ export default function Navbar() {
             <>
               <a
                 href={localizeHref("/profile")}
-                className="px-4 py-2 rounded-lg text-sm font-medium text-foreground-muted transition-all duration-200 hover:text-foreground hover:bg-[hsl(var(--foreground)/0.05)]"
+                className="rounded-md px-3 py-2 text-sm font-semibold text-foreground-muted transition-all duration-200 hover:bg-[hsl(var(--foreground)/0.06)] hover:text-foreground"
               >
                 {m.profile()}
               </a>
               <button
                 type="button"
                 onClick={handleLogout}
-                className="btn-primary text-sm font-medium px-4 py-2 rounded-lg"
+                className="btn-primary px-4 py-2 text-sm"
               >
                 {m.logout()}
               </button>
@@ -182,13 +178,13 @@ export default function Navbar() {
               <>
                 <a
                   href={localizeHref("/login")}
-                  className="px-4 py-2 rounded-lg text-sm font-medium text-foreground-muted transition-all duration-200 hover:text-foreground hover:bg-[hsl(var(--foreground)/0.05)]"
+                  className="rounded-md px-3 py-2 text-sm font-semibold text-foreground-muted transition-all duration-200 hover:bg-[hsl(var(--foreground)/0.06)] hover:text-foreground"
                 >
                   {m.login()}
                 </a>
                 <a
                   href={localizeHref("/register")}
-                  className="btn-primary text-sm font-medium px-4 py-2 rounded-lg"
+                  className="btn-primary px-4 py-2 text-sm"
                 >
                   {m.register()}
                 </a>
@@ -199,8 +195,9 @@ export default function Navbar() {
 
         {/* Mobile Menu Button */}
         <button
+          type="button"
           onClick={() => setIsMenuOpen(!isMenuOpen)}
-          className="md:hidden p-2 rounded-lg text-foreground-muted hover:bg-[hsl(var(--foreground)/0.05)] transition-colors"
+          className="rounded-md p-2 text-foreground-muted transition-colors hover:bg-[hsl(var(--foreground)/0.06)] md:hidden"
           aria-label={isMenuOpen ? m.nav_closeMenu() : m.nav_openMenu()}
           aria-expanded={isMenuOpen}
         >
@@ -210,26 +207,28 @@ export default function Navbar() {
 
       {/* Mobile Menu */}
       {isMenuOpen && (
-        <div className="md:hidden border-t border-[hsl(var(--border))] bg-[hsl(var(--background))]/95 backdrop-blur-xl px-4 py-4 animate-fade-in">
+        <div className="animate-fade-in border-t border-[hsl(var(--border))] bg-[hsl(var(--background))]/96 px-4 py-4 backdrop-blur-xl md:hidden">
           <nav className="flex flex-col gap-1">
             {navItems.map((item) =>
               item.type === "link" ? (
                 <a
                   key={item.href}
                   href={localizeHref(item.href)}
-                  className="px-3 py-2.5 rounded-lg text-sm font-medium text-foreground-muted transition-colors hover:text-foreground hover:bg-[hsl(var(--foreground)/0.05)]"
+                  className="rounded-md px-3 py-2.5 text-sm font-semibold text-foreground-muted transition-colors hover:bg-[hsl(var(--foreground)/0.06)] hover:text-foreground"
                 >
                   {item.label}
                 </a>
               ) : (
                 <div key={item.label}>
                   <button
+                    type="button"
                     onClick={() =>
                       setExpandedMobileGroup(
                         expandedMobileGroup === item.label ? null : item.label
                       )
                     }
-                    className="flex w-full items-center justify-between px-3 py-2.5 rounded-lg text-sm font-medium text-foreground-muted transition-colors hover:text-foreground hover:bg-[hsl(var(--foreground)/0.05)]"
+                    className="flex w-full items-center justify-between rounded-md px-3 py-2.5 text-sm font-semibold text-foreground-muted transition-colors hover:bg-[hsl(var(--foreground)/0.06)] hover:text-foreground"
+                    aria-expanded={expandedMobileGroup === item.label}
                   >
                     {item.label}
                     <ChevronDown
@@ -244,7 +243,7 @@ export default function Navbar() {
                         <a
                           key={child.href}
                           href={localizeHref(child.href)}
-                          className="px-3 py-2 rounded-lg text-sm text-foreground-muted transition-colors hover:text-foreground hover:bg-[hsl(var(--foreground)/0.05)]"
+                          className="rounded-md px-3 py-2 text-sm text-foreground-muted transition-colors hover:bg-[hsl(var(--foreground)/0.06)] hover:text-foreground"
                         >
                           {child.label}
                         </a>
@@ -259,14 +258,14 @@ export default function Navbar() {
               <>
                 <a
                   href={localizeHref("/profile")}
-                  className="px-3 py-2.5 rounded-lg text-sm font-medium text-foreground-muted transition-colors hover:text-foreground hover:bg-[hsl(var(--foreground)/0.05)]"
+                  className="rounded-md px-3 py-2.5 text-sm font-semibold text-foreground-muted transition-colors hover:bg-[hsl(var(--foreground)/0.06)] hover:text-foreground"
                 >
                   {m.profile()}
                 </a>
                 <button
                   type="button"
                   onClick={handleLogout}
-                  className="btn-primary text-sm font-medium px-4 py-2.5 rounded-lg text-center mt-1"
+                  className="btn-primary mt-1 px-4 py-2.5 text-center text-sm"
                 >
                   {m.logout()}
                 </button>
@@ -276,13 +275,13 @@ export default function Navbar() {
                 <>
                   <a
                     href={localizeHref("/login")}
-                    className="px-3 py-2.5 rounded-lg text-sm font-medium text-foreground-muted transition-colors hover:text-foreground hover:bg-[hsl(var(--foreground)/0.05)]"
+                    className="rounded-md px-3 py-2.5 text-sm font-semibold text-foreground-muted transition-colors hover:bg-[hsl(var(--foreground)/0.06)] hover:text-foreground"
                   >
                     {m.login()}
                   </a>
                   <a
                     href={localizeHref("/register")}
-                    className="btn-primary text-sm font-medium px-4 py-2.5 rounded-lg text-center mt-1"
+                    className="btn-primary mt-1 px-4 py-2.5 text-center text-sm"
                   >
                     {m.register()}
                   </a>

--- a/frontend/src/components/PricingPage.tsx
+++ b/frontend/src/components/PricingPage.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ArrowRight, CheckCircle2, CircleMinus, PackageCheck } from "lucide-react";
 import * as m from "@/paraglide/messages.js";
 import { localizeHref } from "@/paraglide/runtime.js";
 
@@ -73,196 +74,201 @@ export default function PricingPage() {
     { feature: m.pricingFeatures_templates(), free: m.pricingFeatures_basicTemplates(), pro: m.pricingFeatures_allTemplates(), enterprise: m.pricingFeatures_customTemplates() },
     { feature: m.pricingFeatures_platforms(), free: m.pricingFeatures_amazon(), pro: m.pricingFeatures_multiPlatform(), enterprise: m.pricingFeatures_allPlatforms() },
     { feature: m.pricingFeatures_batchGeneration(), free: m.pricingFeatures_notAvailable(), pro: m.pricingFeatures_batch10(), enterprise: m.pricingFeatures_unlimited() },
-    { feature: m.pricingFeatures_apiAccess(), free: m.pricingFeatures_notAvailable(), pro: "✓", enterprise: "✓" },
+    { feature: m.pricingFeatures_apiAccess(), free: m.pricingFeatures_notAvailable(), pro: "Yes", enterprise: "Yes" },
     { feature: m.pricingFeatures_generationSpeed(), free: m.pricingFeatures_standardSpeed(), pro: m.pricingFeatures_priority(), enterprise: m.pricingFeatures_highestPriority() },
     { feature: m.pricingFeatures_support(), free: m.pricingFeatures_community(), pro: m.pricingFeatures_prioritySupport(), enterprise: m.pricingFeatures_dedicatedManager() },
   ];
 
   const faqs = [
-    {
-      question: m.pricing_faq1_question(),
-      answer: m.pricing_faq1_answer(),
-    },
-    {
-      question: m.pricing_faq2_question(),
-      answer: m.pricing_faq2_answer(),
-    },
-    {
-      question: m.pricing_faq3_question(),
-      answer: m.pricing_faq3_answer(),
-    },
-    {
-      question: m.pricing_faq4_question(),
-      answer: m.pricing_faq4_answer(),
-    },
+    { question: m.pricing_faq1_question(), answer: m.pricing_faq1_answer() },
+    { question: m.pricing_faq2_question(), answer: m.pricing_faq2_answer() },
+    { question: m.pricing_faq3_question(), answer: m.pricing_faq3_answer() },
+    { question: m.pricing_faq4_question(), answer: m.pricing_faq4_answer() },
   ];
 
   return (
     <div className="flex min-h-screen flex-col">
       <main className="flex-1">
-        {/* Header */}
-        <div className="bg-white">
-          <div className="mx-auto max-w-7xl px-4 py-16 text-center sm:px-6 lg:px-8">
-            <h1 className="text-4xl font-bold text-slate-900 sm:text-5xl">
-              {m.pricing_title()}
-            </h1>
-            <p className="mx-auto mt-4 max-w-2xl text-lg text-slate-600">
-              {m.pricing_subtitle()}
-            </p>
-          </div>
-        </div>
-
-        {/* Pricing Cards */}
-        <div className="bg-slate-50 py-12">
-          <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-            <div className="grid gap-8 lg:grid-cols-3">
-              {plans.map((plan) => (
-                <div
-                  key={plan.key}
-                  className={`
-                    relative flex flex-col rounded-2xl bg-white p-8 shadow-sm
-                    ${plan.popular ? "ring-2 ring-slate-900" : "border border-slate-200"}
-                  `}
-                >
-                  {/* Popular Badge */}
-                  {plan.popular && (
-                    <div className="absolute -top-4 left-1/2 -translate-x-1/2">
-                      <span className="inline-flex items-center rounded-full bg-slate-900 px-3 py-1 text-xs font-medium text-white">
-                        {m.pricing_mostPopular()}
-                      </span>
-                    </div>
-                  )}
-
-                  {/* Plan Info */}
-                  <div className="mb-6">
-                    <h3 className="text-xl font-semibold text-slate-900">{plan.name}</h3>
-                    <p className="mt-1 text-sm text-slate-500">{plan.description}</p>
+        <section className="border-b border-[hsl(var(--border))] bg-[hsl(var(--background))]">
+          <div className="proof-strip h-2" />
+          <div className="mx-auto grid max-w-7xl gap-8 px-4 py-14 sm:px-6 lg:grid-cols-[0.9fr_1.1fr] lg:items-end lg:px-8">
+            <div>
+              <p className="font-utility text-xs font-semibold uppercase text-[hsl(var(--accent))]">
+                Listing capacity rate card
+              </p>
+              <h1 className="font-display mt-3 max-w-3xl text-5xl font-semibold text-foreground sm:text-6xl">
+                {m.pricing_title()}
+              </h1>
+              <p className="mt-5 max-w-2xl text-lg text-foreground-muted">
+                {m.pricing_subtitle()}
+              </p>
+            </div>
+            <div className="card overflow-hidden">
+              <div className="proof-strip h-2" />
+              <div className="p-5">
+                <div className="flex items-center gap-3">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-md bg-[hsl(var(--foreground))] text-[hsl(var(--background))]">
+                    <PackageCheck className="h-5 w-5" aria-hidden="true" />
                   </div>
-
-                  {/* Price */}
-                  <div className="mb-6">
-                    <div className="flex items-baseline">
-                      <span className="text-3xl font-bold text-slate-900">¥</span>
-                      <span className="text-5xl font-bold text-slate-900">{plan.price}</span>
-                      <span className="ml-1 text-slate-500">{plan.period}</span>
-                    </div>
+                  <div>
+                    <p className="font-utility text-xs font-semibold uppercase text-foreground-muted">
+                      Best fit
+                    </p>
+                    <p className="text-lg font-semibold text-foreground">{m.pricing_pro_name()}</p>
                   </div>
-
-                  {/* Features */}
-                  <ul className="mb-8 flex-1 space-y-3">
-                    {plan.features.map((feature, index) => (
-                      <li key={index} className="flex items-start gap-3">
-                        {feature.included ? (
-                          <svg className="h-5 w-5 shrink-0 text-green-500" fill="currentColor" viewBox="0 0 20 20">
-                            <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-                          </svg>
-                        ) : (
-                          <svg className="h-5 w-5 shrink-0 text-slate-300" fill="currentColor" viewBox="0 0 20 20">
-                            <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
-                          </svg>
-                        )}
-                        <span className={feature.included ? "text-slate-700" : "text-slate-400"}>
-                          {feature.text}
-                        </span>
-                      </li>
-                    ))}
-                  </ul>
-
-                  {/* CTA Button */}
-                  <a
-                    href={plan.ctaLink.startsWith("/") ? localizeHref(plan.ctaLink) : plan.ctaLink}
-                    className={`
-                      block w-full rounded-lg px-4 py-3 text-center text-sm font-medium transition-all
-                      ${plan.popular
-                        ? "bg-slate-900 text-white hover:bg-slate-800"
-                        : "bg-slate-100 text-slate-900 hover:bg-slate-200"
-                      }
-                    `}
-                  >
-                    {plan.cta}
-                  </a>
                 </div>
+                <p className="mt-4 text-sm text-foreground-muted">
+                  200 monthly generations with batch support and priority output speed for active shops.
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-12">
+          <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+            <div className="grid items-stretch gap-5 lg:grid-cols-3">
+              {plans.map((plan) => (
+                <article
+                  key={plan.key}
+                  className={`card flex flex-col overflow-hidden ${
+                    plan.popular ? "border-[hsl(var(--primary))] shadow-lg" : ""
+                  }`}
+                >
+                  <div className={plan.popular ? "proof-strip h-2" : "h-2 bg-[hsl(var(--background-secondary))]"} />
+                  <div className="flex flex-1 flex-col p-6">
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <h2 className="text-2xl font-semibold text-foreground">{plan.name}</h2>
+                        <p className="mt-2 text-sm text-foreground-muted">{plan.description}</p>
+                      </div>
+                      {plan.popular && (
+                        <span className="badge shrink-0">{m.pricing_mostPopular()}</span>
+                      )}
+                    </div>
+
+                    <div className="mt-7 flex items-end gap-1 border-b border-[hsl(var(--border))] pb-6">
+                      <span className="pb-2 text-2xl font-semibold text-foreground">¥</span>
+                      <span className="font-display text-6xl font-semibold leading-none text-foreground">
+                        {plan.price}
+                      </span>
+                      <span className="pb-2 text-sm font-medium text-foreground-muted">{plan.period}</span>
+                    </div>
+
+                    <ul className="mt-6 flex-1 space-y-3">
+                      {plan.features.map((feature) => (
+                        <li key={feature.text} className="flex items-start gap-3 text-sm">
+                          {feature.included ? (
+                            <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-[hsl(var(--primary))]" aria-hidden="true" />
+                          ) : (
+                            <CircleMinus className="mt-0.5 h-4 w-4 shrink-0 text-foreground-muted" aria-hidden="true" />
+                          )}
+                          <span className={feature.included ? "text-foreground" : "text-foreground-muted"}>
+                            {feature.text}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+
+                    <a
+                      href={plan.ctaLink.startsWith("/") ? localizeHref(plan.ctaLink) : plan.ctaLink}
+                      className={`${plan.popular ? "btn-primary" : "btn-secondary"} mt-8 w-full gap-2 px-4 py-3 text-center`}
+                    >
+                      {plan.cta}
+                      <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                    </a>
+                  </div>
+                </article>
               ))}
             </div>
           </div>
-        </div>
+        </section>
 
-        {/* Feature Comparison */}
-        <div className="bg-white py-16">
+        <section className="border-y border-[hsl(var(--border))] bg-[hsl(var(--card))] py-16">
           <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-            <div className="text-center">
-              <h2 className="text-2xl font-bold text-slate-900">{m.pricing_comparison()}</h2>
-              <p className="mt-2 text-slate-600">{m.pricing_comparisonSubtitle()}</p>
+            <div className="max-w-3xl">
+              <p className="font-utility text-xs font-semibold uppercase text-[hsl(var(--primary))]">
+                Comparison sheet
+              </p>
+              <h2 className="font-display mt-3 text-4xl font-semibold text-foreground">
+                {m.pricing_comparison()}
+              </h2>
+              <p className="mt-3 text-foreground-muted">{m.pricing_comparisonSubtitle()}</p>
             </div>
 
-            <div className="mt-10 overflow-x-auto rounded-xl border border-slate-200">
-              <table className="w-full">
-                <thead className="bg-slate-50">
-                  <tr>
-                    <th className="px-6 py-4 text-left text-sm font-semibold text-slate-900">{m.pricingFeatures_feature()}</th>
-                    <th className="px-6 py-4 text-center text-sm font-semibold text-slate-900">{m.pricing_free_name()}</th>
-                    <th className="px-6 py-4 text-center text-sm font-semibold text-slate-900 bg-slate-100">{m.pricing_pro_name()}</th>
-                    <th className="px-6 py-4 text-center text-sm font-semibold text-slate-900">{m.pricing_enterprise_name()}</th>
+            <div className="card mt-8 overflow-x-auto">
+              <table className="w-full min-w-[760px]">
+                <thead>
+                  <tr className="border-b border-[hsl(var(--border))] bg-[hsl(var(--background-secondary)/0.52)]">
+                    <th className="px-5 py-4 text-left text-sm font-semibold text-foreground">{m.pricingFeatures_feature()}</th>
+                    <th className="px-5 py-4 text-center text-sm font-semibold text-foreground">{m.pricing_free_name()}</th>
+                    <th className="px-5 py-4 text-center text-sm font-semibold text-[hsl(var(--primary))]">{m.pricing_pro_name()}</th>
+                    <th className="px-5 py-4 text-center text-sm font-semibold text-foreground">{m.pricing_enterprise_name()}</th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-slate-200">
-                  {comparisons.map((row, index) => (
-                    <tr key={index} className={index % 2 === 0 ? "bg-white" : "bg-slate-50/50"}>
-                      <td className="px-6 py-4 text-sm text-slate-700">{row.feature}</td>
-                      <td className="px-6 py-4 text-center text-sm text-slate-600">{row.free}</td>
-                      <td className="px-6 py-4 text-center text-sm font-medium text-slate-900 bg-slate-50">{row.pro}</td>
-                      <td className="px-6 py-4 text-center text-sm text-slate-600">{row.enterprise}</td>
+                <tbody className="divide-y divide-[hsl(var(--border))]">
+                  {comparisons.map((row) => (
+                    <tr key={row.feature}>
+                      <td className="px-5 py-4 text-sm font-medium text-foreground">{row.feature}</td>
+                      <td className="px-5 py-4 text-center text-sm text-foreground-muted">{row.free}</td>
+                      <td className="bg-[hsl(var(--primary)/0.06)] px-5 py-4 text-center text-sm font-semibold text-foreground">
+                        {row.pro}
+                      </td>
+                      <td className="px-5 py-4 text-center text-sm text-foreground-muted">{row.enterprise}</td>
                     </tr>
                   ))}
                 </tbody>
               </table>
             </div>
           </div>
-        </div>
+        </section>
 
-        {/* FAQ */}
-        <div className="bg-slate-50 py-16">
-          <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
-            <div className="text-center">
-              <h2 className="text-2xl font-bold text-slate-900">{m.pricing_faq()}</h2>
+        <section className="py-16">
+          <div className="mx-auto grid max-w-7xl gap-8 px-4 sm:px-6 lg:grid-cols-[0.7fr_1.3fr] lg:px-8">
+            <div>
+              <p className="font-utility text-xs font-semibold uppercase text-[hsl(var(--accent))]">
+                Notes
+              </p>
+              <h2 className="font-display mt-3 text-4xl font-semibold text-foreground">
+                {m.pricing_faq()}
+              </h2>
             </div>
-
-            <div className="mt-10 space-y-4">
-              {faqs.map((faq, index) => (
-                <div key={index} className="rounded-xl bg-white p-6 shadow-sm">
-                  <h3 className="text-base font-semibold text-slate-900">{faq.question}</h3>
-                  <p className="mt-2 text-sm text-slate-600">{faq.answer}</p>
-                </div>
+            <div className="grid gap-3 md:grid-cols-2">
+              {faqs.map((faq) => (
+                <article key={faq.question} className="card p-5">
+                  <h3 className="text-base font-semibold text-foreground">{faq.question}</h3>
+                  <p className="mt-3 text-sm text-foreground-muted">{faq.answer}</p>
+                </article>
               ))}
             </div>
           </div>
-        </div>
+        </section>
 
-        {/* CTA Section */}
-        <div className="bg-slate-900 py-16">
-          <div className="mx-auto max-w-4xl px-4 text-center sm:px-6 lg:px-8">
-            <h2 className="text-3xl font-bold text-white">
-              {m.pricing_ctaTitle()}
-            </h2>
-            <p className="mt-4 text-lg text-slate-300">
-              {m.pricing_ctaSubtitle()}
-            </p>
-            <div className="mt-8 flex flex-col justify-center gap-4 sm:flex-row">
+        <section className="bg-[hsl(var(--foreground))] py-14 text-[hsl(var(--background))]">
+          <div className="mx-auto flex max-w-7xl flex-col items-start justify-between gap-6 px-4 sm:px-6 lg:flex-row lg:items-center lg:px-8">
+            <div>
+              <p className="font-utility text-xs font-semibold uppercase text-[hsl(var(--background)/0.62)]">
+                Start the bench
+              </p>
+              <h2 className="font-display mt-3 text-4xl font-semibold">{m.pricing_ctaTitle()}</h2>
+              <p className="mt-3 max-w-2xl text-[hsl(var(--background)/0.72)]">{m.pricing_ctaSubtitle()}</p>
+            </div>
+            <div className="flex flex-col gap-3 sm:flex-row">
               <a
                 href={localizeHref("/generate")}
-                className="inline-flex items-center justify-center rounded-lg bg-white px-6 py-3 text-base font-medium text-slate-900 transition-all hover:bg-slate-100"
+                className="inline-flex items-center justify-center rounded-md bg-[hsl(var(--background))] px-6 py-3 text-base font-semibold text-foreground transition hover:bg-[hsl(var(--background-secondary))]"
               >
                 {m.pricing_ctaFree()}
               </a>
               <a
                 href="mailto:sales@ourapix.com"
-                className="inline-flex items-center justify-center rounded-lg border border-slate-600 bg-transparent px-6 py-3 text-base font-medium text-white transition-all hover:bg-slate-800"
+                className="inline-flex items-center justify-center rounded-md border border-[hsl(var(--background)/0.32)] px-6 py-3 text-base font-semibold text-[hsl(var(--background))] transition hover:bg-[hsl(var(--background)/0.08)]"
               >
                 {m.pricing_ctaContact()}
               </a>
             </div>
           </div>
-        </div>
+        </section>
       </main>
     </div>
   );

--- a/frontend/src/components/ProfilePage.tsx
+++ b/frontend/src/components/ProfilePage.tsx
@@ -1,11 +1,25 @@
 "use client";
 
 import { useState } from "react";
+import {
+  Bell,
+  CalendarDays,
+  Coins,
+  Eye,
+  FolderOpen,
+  ImageIcon,
+  Loader2,
+  Palette,
+  Save,
+  ShieldCheck,
+  Trash2,
+  User,
+  Zap,
+} from "lucide-react";
 import * as m from "@/paraglide/messages.js";
 import { localizeHref } from "@/paraglide/runtime.js";
 import { useAuth } from "@/hooks/use-auth";
 
-// Mock data for development
 type ProfileTab = "overview" | "history" | "settings";
 
 interface GenerationRecord {
@@ -39,185 +53,154 @@ const mockHistory: GenerationRecord[] = [
   },
 ];
 
-// Stats Cards Component
+function statusClass(status: GenerationRecord["status"]) {
+  if (status === "completed") return "status-badge-success";
+  if (status === "processing") return "status-badge-info";
+  return "status-badge-error";
+}
+
+function statusLabel(status: GenerationRecord["status"]) {
+  if (status === "completed") return m.profile_history_status_completed();
+  if (status === "processing") return m.profile_history_status_processing();
+  return m.profile_history_status_failed();
+}
+
 function StatsCards() {
   const stats = [
     {
       label: m.profile_stats_totalGenerations(),
       value: 12,
-      icon: (
-        <svg className="h-6 w-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-        </svg>
-      ),
-      bgColor: "bg-blue-100",
+      icon: ImageIcon,
+      tone: "text-[hsl(var(--primary))] bg-[hsl(var(--color-info-light))]",
     },
     {
       label: m.profile_stats_thisMonth(),
       value: 5,
-      icon: (
-        <svg className="h-6 w-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-        </svg>
-      ),
-      bgColor: "bg-green-100",
+      icon: CalendarDays,
+      tone: "text-[hsl(var(--color-success))] bg-[hsl(var(--color-success-light))]",
     },
     {
       label: m.profile_stats_remainingCredits(),
       value: 195,
-      icon: (
-        <svg className="h-6 w-6 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-        </svg>
-      ),
-      bgColor: "bg-purple-100",
+      icon: Coins,
+      tone: "text-[hsl(var(--accent))] bg-[hsl(var(--color-warning-light))]",
     },
     {
       label: m.profile_stats_favoriteStyle(),
       value: "简约现代",
-      icon: (
-        <svg className="h-6 w-6 text-orange-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01" />
-        </svg>
-      ),
-      bgColor: "bg-orange-100",
+      icon: Palette,
+      tone: "text-foreground bg-[hsl(var(--secondary))]",
     },
   ];
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-      {stats.map((item, index) => (
-        <div key={index} className="bg-white rounded-xl shadow-sm border border-slate-200">
-          <div className="p-6">
-            <div className="flex items-center">
-              <div className={`flex-shrink-0 p-3 ${item.bgColor} rounded-lg`}>
-                {item.icon}
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+      {stats.map((item) => {
+        const Icon = item.icon;
+        return (
+          <div key={item.label} className="panel p-5">
+            <div className="flex items-center gap-4">
+              <div className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-md ${item.tone}`}>
+                <Icon className="h-6 w-6" aria-hidden="true" />
               </div>
-              <div className="ml-4">
-                <p className="text-sm font-medium text-slate-500">{item.label}</p>
-                <p className="text-2xl font-bold text-slate-900">{item.value}</p>
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-foreground-muted">{item.label}</p>
+                <p className="truncate text-2xl font-semibold text-foreground">{item.value}</p>
               </div>
             </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }
 
-// User Info Card Component
 function UserInfoCard() {
   const { user } = useAuth();
+  const rows = [
+    [m.profile_userInfo_username(), user?.name || "User"],
+    [m.profile_userInfo_email(), user?.email || "user@example.com"],
+    [m.profile_userInfo_memberSince(), "2024-01-01"],
+    [m.profile_userInfo_plan(), m.profile_userInfo_proPlan()],
+  ];
 
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-slate-200">
-      <div className="p-6 border-b border-slate-200">
-        <h3 className="text-lg font-semibold text-slate-900">{m.profile_userInfo_title()}</h3>
+    <section className="panel overflow-hidden">
+      <div className="border-b border-[hsl(var(--border))] p-5">
+        <h2 className="panel-title">{m.profile_userInfo_title()}</h2>
       </div>
-      <div className="p-6">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div>
-            <p className="text-sm text-slate-500">{m.profile_userInfo_username()}</p>
-            <p className="text-base font-medium text-slate-900">{user?.name || "User"}</p>
+      <div className="grid grid-cols-1 gap-4 p-5 md:grid-cols-2">
+        {rows.map(([label, value]) => (
+          <div key={label} className="panel-muted p-4">
+            <p className="panel-label">{label}</p>
+            <p className="mt-1 text-base font-semibold text-foreground">{value}</p>
           </div>
-          <div>
-            <p className="text-sm text-slate-500">{m.profile_userInfo_email()}</p>
-            <p className="text-base font-medium text-slate-900">{user?.email || "user@example.com"}</p>
-          </div>
-          <div>
-            <p className="text-sm text-slate-500">{m.profile_userInfo_memberSince()}</p>
-            <p className="text-base font-medium text-slate-900">2024-01-01</p>
-          </div>
-          <div>
-            <p className="text-sm text-slate-500">{m.profile_userInfo_plan()}</p>
-            <p className="text-base font-medium text-slate-900">{m.profile_userInfo_proPlan()}</p>
-          </div>
-        </div>
+        ))}
       </div>
-    </div>
+    </section>
   );
 }
 
-// Generation History Component
 function GenerationHistory() {
   const handleDelete = (_id: string) => {
     // TODO: Implement delete functionality
   };
 
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-slate-200">
-      <div className="p-6 border-b border-slate-200">
-        <h3 className="text-lg font-semibold text-slate-900">{m.profile_history_title()}</h3>
-        <p className="mt-1 text-sm text-slate-500">{m.profile_history_subtitle()}</p>
+    <section className="panel overflow-hidden">
+      <div className="border-b border-[hsl(var(--border))] p-5">
+        <h2 className="panel-title">{m.profile_history_title()}</h2>
+        <p className="mt-1 text-sm text-foreground-muted">{m.profile_history_subtitle()}</p>
       </div>
-      <div className="p-0">
-        {mockHistory.length === 0 ? (
-          <div className="p-12 text-center">
-            <div className="mx-auto h-16 w-16 rounded-full bg-slate-100 flex items-center justify-center mb-4">
-              <svg className="h-8 w-8 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 13h6m-3-3v6m-9 1V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z" />
-              </svg>
-            </div>
-            <h3 className="text-lg font-semibold text-slate-900">{m.profile_history_empty()}</h3>
-            <p className="mt-2 text-slate-500">{m.profile_history_emptyDesc()}</p>
-            <a
-              href={localizeHref("/generate")}
-              className="mt-4 inline-flex items-center justify-center rounded-lg bg-slate-900 px-4 py-2 text-sm font-medium text-white hover:bg-slate-800 transition-colors"
-            >
-              {m.profile_history_startGenerating()}
-            </a>
-          </div>
-        ) : (
-          <div className="divide-y divide-slate-200">
-            {mockHistory.map((item) => (
-              <div key={item.id} className="p-6 hover:bg-slate-50 transition-colors">
-                <div className="flex items-start justify-between">
-                  <div className="flex-1">
-                    <div className="flex items-center gap-2">
-                      <h4 className="text-base font-medium text-slate-900">{item.prompt}</h4>
-                      <span
-                        className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
-                          item.status === "completed"
-                            ? "bg-green-100 text-green-700"
-                            : item.status === "processing"
-                            ? "bg-blue-100 text-blue-700"
-                            : "bg-red-100 text-red-700"
-                        }`}
-                      >
-                        {item.status === "completed"
-                          ? m.profile_history_status_completed()
-                          : item.status === "processing"
-                          ? m.profile_history_status_processing()
-                          : m.profile_history_status_failed()}
-                      </span>
-                    </div>
-                    <p className="mt-1 text-sm text-slate-500">
-                      {item.platform} · {item.style} · {item.language}
-                    </p>
-                    <p className="mt-1 text-xs text-slate-400">{item.createdAt}</p>
+
+      {mockHistory.length === 0 ? (
+        <div className="flex flex-col items-center justify-center p-12 text-center">
+          <FolderOpen className="mb-4 h-12 w-12 text-foreground-muted" aria-hidden="true" />
+          <h3 className="text-lg font-semibold text-foreground">{m.profile_history_empty()}</h3>
+          <p className="mt-2 text-sm text-foreground-muted">{m.profile_history_emptyDesc()}</p>
+          <a href={localizeHref("/generate")} className="btn-primary mt-5 h-10 px-4">
+            {m.profile_history_startGenerating()}
+          </a>
+        </div>
+      ) : (
+        <div>
+          {mockHistory.map((item) => (
+            <div key={item.id} className="data-row p-5">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3 className="text-base font-semibold text-foreground">{item.prompt}</h3>
+                    <span className={`status-badge ${statusClass(item.status)}`}>
+                      {statusLabel(item.status)}
+                    </span>
                   </div>
-                  <div className="flex gap-2">
-                    <button className="text-sm text-slate-600 hover:text-slate-900 px-3 py-1 rounded-md hover:bg-slate-100 transition-colors">
-                      {m.profile_history_viewDetail()}
-                    </button>
-                    <button
-                      onClick={() => handleDelete(item.id)}
-                      className="text-sm text-red-600 hover:text-red-700 px-3 py-1 rounded-md hover:bg-red-50 transition-colors"
-                    >
-                      {m.profile_history_delete()}
-                    </button>
-                  </div>
+                  <p className="mt-1 text-sm text-foreground-muted">
+                    {item.platform} · {item.style} · {item.language}
+                  </p>
+                  <p className="font-utility mt-1 text-xs text-foreground-muted">{item.createdAt}</p>
+                </div>
+                <div className="flex gap-2">
+                  <button className="btn-secondary h-9 gap-2 px-3">
+                    <Eye className="h-4 w-4" aria-hidden="true" />
+                    {m.profile_history_viewDetail()}
+                  </button>
+                  <button
+                    onClick={() => handleDelete(item.id)}
+                    className="btn-secondary h-9 gap-2 px-3 text-[hsl(var(--color-error))]"
+                  >
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
+                    {m.profile_history_delete()}
+                  </button>
                 </div>
               </div>
-            ))}
-          </div>
-        )}
-      </div>
-    </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
   );
 }
 
-// Settings Form Component
 function SettingsForm() {
   const [isLoading, setIsLoading] = useState(false);
   const { user } = useAuth();
@@ -229,117 +212,105 @@ function SettingsForm() {
   };
 
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-slate-200">
-      <div className="p-6 border-b border-slate-200">
-        <h3 className="text-lg font-semibold text-slate-900">{m.profile_settings_title()}</h3>
+    <section className="panel overflow-hidden">
+      <div className="border-b border-[hsl(var(--border))] p-5">
+        <h2 className="panel-title">{m.profile_settings_title()}</h2>
       </div>
-      <form onSubmit={handleSubmit} className="p-6 space-y-6">
-        {/* Profile Section */}
-        <div>
-          <h4 className="text-sm font-medium text-slate-900 mb-4">{m.profile_settings_profile()}</h4>
+      <form onSubmit={handleSubmit} className="space-y-6 p-5">
+        <section>
+          <h3 className="mb-4 flex items-center gap-2 text-sm font-semibold text-foreground">
+            <User className="h-4 w-4 text-[hsl(var(--primary))]" aria-hidden="true" />
+            {m.profile_settings_profile()}
+          </h3>
           <div className="space-y-4">
             <div>
-              <label className="block text-sm font-medium text-slate-700 mb-1">
-                {m.profile_userInfo_username()}
-              </label>
-              <input
-                type="text"
-                defaultValue={user?.name || ""}
-                className="w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm transition-colors focus:border-slate-900 focus:bg-white focus:outline-none focus:ring-1 focus:ring-slate-900"
-              />
+              <label className="panel-label mb-1 block">{m.profile_userInfo_username()}</label>
+              <input type="text" defaultValue={user?.name || ""} className="input" />
             </div>
             <div>
-              <label className="block text-sm font-medium text-slate-700 mb-1">
-                {m.profile_userInfo_email()}
-              </label>
-              <input
-                type="email"
-                defaultValue={user?.email || ""}
-                className="w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm transition-colors focus:border-slate-900 focus:bg-white focus:outline-none focus:ring-1 focus:ring-slate-900"
-              />
+              <label className="panel-label mb-1 block">{m.profile_userInfo_email()}</label>
+              <input type="email" defaultValue={user?.email || ""} className="input" />
             </div>
           </div>
-        </div>
+        </section>
 
-        {/* Password Section */}
-        <div className="pt-6 border-t border-slate-200">
-          <h4 className="text-sm font-medium text-slate-900 mb-4">{m.profile_settings_password()}</h4>
+        <section className="border-t border-[hsl(var(--border))] pt-6">
+          <h3 className="mb-4 flex items-center gap-2 text-sm font-semibold text-foreground">
+            <ShieldCheck className="h-4 w-4 text-[hsl(var(--primary))]" aria-hidden="true" />
+            {m.profile_settings_password()}
+          </h3>
           <div className="space-y-4">
             <div>
-              <label className="block text-sm font-medium text-slate-700 mb-1">
-                {m.profile_settings_currentPassword()}
-              </label>
+              <label className="panel-label mb-1 block">{m.profile_settings_currentPassword()}</label>
               <input
                 type="password"
                 placeholder={m.profile_settings_enterCurrentPassword()}
-                className="w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm transition-colors focus:border-slate-900 focus:bg-white focus:outline-none focus:ring-1 focus:ring-slate-900"
+                className="input"
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-slate-700 mb-1">
-                {m.profile_settings_newPassword()}
-              </label>
+              <label className="panel-label mb-1 block">{m.profile_settings_newPassword()}</label>
               <input
                 type="password"
                 placeholder={m.profile_settings_enterNewPassword()}
-                className="w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm transition-colors focus:border-slate-900 focus:bg-white focus:outline-none focus:ring-1 focus:ring-slate-900"
+                className="input"
               />
             </div>
           </div>
-        </div>
+        </section>
 
-        {/* Notifications Section */}
-        <div className="pt-6 border-t border-slate-200">
-          <h4 className="text-sm font-medium text-slate-900 mb-4">{m.profile_settings_notifications()}</h4>
+        <section className="border-t border-[hsl(var(--border))] pt-6">
+          <h3 className="mb-4 flex items-center gap-2 text-sm font-semibold text-foreground">
+            <Bell className="h-4 w-4 text-[hsl(var(--primary))]" aria-hidden="true" />
+            {m.profile_settings_notifications()}
+          </h3>
           <div className="space-y-3">
-            <div className="flex items-center">
+            <label className="flex items-center gap-2 text-sm text-foreground">
               <input
                 type="checkbox"
                 id="notify-generation"
                 defaultChecked
-                className="h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-900"
+                className="h-4 w-4 rounded border-[hsl(var(--border))] text-[hsl(var(--primary))] focus:ring-[hsl(var(--primary)/0.28)]"
               />
-              <label htmlFor="notify-generation" className="ml-2 text-sm text-slate-700">
-                {m.profile_settings_notifyOnComplete()}
-              </label>
-            </div>
-            <div className="flex items-center">
+              {m.profile_settings_notifyOnComplete()}
+            </label>
+            <label className="flex items-center gap-2 text-sm text-foreground">
               <input
                 type="checkbox"
                 id="notify-marketing"
-                className="h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-900"
+                className="h-4 w-4 rounded border-[hsl(var(--border))] text-[hsl(var(--primary))] focus:ring-[hsl(var(--primary)/0.28)]"
               />
-              <label htmlFor="notify-marketing" className="ml-2 text-sm text-slate-700">
-                {m.profile_settings_receiveMarketing()}
-              </label>
-            </div>
+              {m.profile_settings_receiveMarketing()}
+            </label>
           </div>
-        </div>
+        </section>
 
-        {/* Submit */}
-        <div className="pt-6 border-t border-slate-200">
+        <div className="border-t border-[hsl(var(--border))] pt-6">
           <button
             type="submit"
             disabled={isLoading}
-            className="inline-flex items-center justify-center rounded-lg bg-slate-900 px-6 py-2 text-sm font-medium text-white transition-colors hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="btn-primary h-10 gap-2 px-6 disabled:cursor-not-allowed disabled:opacity-50"
           >
+            <Save className="h-4 w-4" aria-hidden="true" />
             {isLoading ? m.profile_settings_saving() : m.profile_settings_save()}
           </button>
         </div>
       </form>
-    </div>
+    </section>
   );
 }
 
-// Main Profile Page Component
 export default function ProfilePage() {
   const [activeTab, setActiveTab] = useState<ProfileTab>("overview");
   const { user, isLoading: isAuthLoading } = useAuth();
 
   if (isAuthLoading) {
     return (
-      <div className="min-h-screen bg-slate-50 flex items-center justify-center">
-        <div className="text-slate-500">{m.profile_loading()}</div>
+      <div className="workbench-page flex items-center justify-center">
+        <div className="flex items-center gap-2 text-foreground-muted">
+          <Loader2 className="h-5 w-5 animate-spin" aria-hidden="true" />
+          {m.profile_loading()}
+        </div>
       </div>
     );
   }
@@ -351,88 +322,61 @@ export default function ProfilePage() {
   ];
 
   return (
-    <div className="min-h-screen bg-slate-50">
-      {/* Header */}
-      <div className="bg-white border-b border-slate-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="text-3xl font-bold text-slate-900">{m.profile_title()}</h1>
-              <p className="mt-2 text-slate-600">{m.profile_subtitle()}</p>
-            </div>
-            <div className="flex items-center gap-3">
-              <div className="h-16 w-16 rounded-full bg-slate-900 flex items-center justify-center">
-                <span className="text-2xl font-bold text-white">
-                  {user?.name?.charAt(0).toUpperCase() || "U"}
-                </span>
-              </div>
-            </div>
+    <div className="workbench-page">
+      <div className="workbench-container">
+        <header className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="page-kicker">Account / Seller bench</p>
+            <h1 className="page-title mt-2">{m.profile_title()}</h1>
+            <p className="page-description mt-2">{m.profile_subtitle()}</p>
           </div>
-        </div>
-      </div>
-
-      {/* Tabs */}
-      <div className="bg-white border-b border-slate-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex space-x-1">
-            {tabs.map((tab) => (
-              <button
-                key={tab.id}
-                onClick={() => setActiveTab(tab.id)}
-                className={`py-4 px-4 text-sm font-medium border-b-2 transition-colors ${
-                  activeTab === tab.id
-                    ? "border-slate-900 text-slate-900"
-                    : "border-transparent text-slate-500 hover:text-slate-700"
-                }`}
-              >
-                {tab.label}
-              </button>
-            ))}
+          <div className="flex h-16 w-16 items-center justify-center rounded-md bg-[hsl(var(--foreground))] text-[hsl(var(--background))]">
+            <span className="text-2xl font-semibold">
+              {user?.name?.charAt(0).toUpperCase() || "U"}
+            </span>
           </div>
-        </div>
-      </div>
+        </header>
 
-      {/* Content */}
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="panel mb-6 flex flex-wrap gap-1 p-2">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`segmented-option ${activeTab === tab.id ? "segmented-option-active" : ""}`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
         {activeTab === "overview" && (
           <div className="space-y-6">
             <StatsCards />
             <UserInfoCard />
-            <div className="bg-white rounded-xl shadow-sm border border-slate-200">
-              <div className="p-6 border-b border-slate-200">
-                <h3 className="text-lg font-semibold text-slate-900">{m.profile_overview_recentActivity()}</h3>
+            <section className="panel overflow-hidden">
+              <div className="border-b border-[hsl(var(--border))] p-5">
+                <h2 className="panel-title">{m.profile_overview_recentActivity()}</h2>
               </div>
-              <div className="p-6">
+              <div>
                 {mockHistory.slice(0, 3).map((item) => (
-                  <div key={item.id} className="flex items-center gap-4 py-3">
-                    <div className="h-10 w-10 rounded-full bg-slate-100 flex items-center justify-center">
-                      <svg className="h-5 w-5 text-slate-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
-                      </svg>
+                  <div key={item.id} className="data-row flex items-center gap-4 p-4">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-md bg-[hsl(var(--color-info-light))] text-[hsl(var(--primary))]">
+                      <Zap className="h-5 w-5" aria-hidden="true" />
                     </div>
-                    <div className="flex-1">
-                      <p className="text-sm font-medium text-slate-900">{item.prompt}</p>
-                      <p className="text-xs text-slate-500">{item.createdAt}</p>
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-semibold text-foreground">{item.prompt}</p>
+                      <p className="font-utility text-xs text-foreground-muted">{item.createdAt}</p>
                     </div>
-                    <span className="text-xs text-slate-400">{item.platform}</span>
+                    <span className="status-badge status-badge-neutral">{item.platform}</span>
                   </div>
                 ))}
               </div>
-            </div>
+            </section>
           </div>
         )}
 
-        {activeTab === "history" && (
-          <div className="space-y-6">
-            <GenerationHistory />
-          </div>
-        )}
-
-        {activeTab === "settings" && (
-          <div className="space-y-6">
-            <SettingsForm />
-          </div>
-        )}
+        {activeTab === "history" && <GenerationHistory />}
+        {activeTab === "settings" && <SettingsForm />}
       </div>
     </div>
   );

--- a/frontend/src/components/RegisterPage.tsx
+++ b/frontend/src/components/RegisterPage.tsx
@@ -1,15 +1,14 @@
 "use client";
 
 import { useState } from "react";
-import { Eye, EyeOff } from "lucide-react";
+import { CheckCircle2, Eye, EyeOff, PackageCheck } from "lucide-react";
 import * as m from "@/paraglide/messages.js";
 import { localizeHref } from "@/paraglide/runtime.js";
 import { useAuth } from "@/hooks/use-auth";
 import { signInSocial } from "@/lib/auth";
 
-// PasswordInput sub-component
 function PasswordInput({
-  className,
+  className = "",
   ...props
 }: React.InputHTMLAttributes<HTMLInputElement>) {
   const [showPassword, setShowPassword] = useState(false);
@@ -18,26 +17,25 @@ function PasswordInput({
     <div className="relative">
       <input
         type={showPassword ? "text" : "password"}
-        className={`w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5 pr-10 text-sm transition-colors focus:border-slate-900 focus:bg-white focus:outline-none focus:ring-1 focus:ring-slate-900 ${className}`}
+        className={`input h-11 pr-10 ${className}`}
         {...props}
       />
       <button
         type="button"
-        className="absolute right-0 top-0 h-full px-3 text-slate-400 hover:text-slate-600"
+        className="absolute right-0 top-0 flex h-full items-center px-3 text-foreground-muted transition-colors hover:text-foreground"
         onClick={() => setShowPassword(!showPassword)}
-        tabIndex={-1}
+        aria-label={showPassword ? "Hide password" : "Show password"}
       >
         {showPassword ? (
-          <EyeOff className="h-4 w-4" />
+          <EyeOff className="h-4 w-4" aria-hidden="true" />
         ) : (
-          <Eye className="h-4 w-4" />
+          <Eye className="h-4 w-4" aria-hidden="true" />
         )}
       </button>
     </div>
   );
 }
 
-// Social login buttons
 function SocialLoginButtons() {
   const handleGoogleLogin = () => {
     signInSocial("google", localizeHref("/"));
@@ -51,10 +49,10 @@ function SocialLoginButtons() {
     <>
       <div className="relative my-6">
         <div className="absolute inset-0 flex items-center">
-          <span className="w-full border-t border-slate-200" />
+          <span className="w-full border-t border-[hsl(var(--border))]" />
         </div>
         <div className="relative flex justify-center text-xs uppercase">
-          <span className="bg-white px-3 text-slate-400">
+          <span className="bg-[hsl(var(--background))] px-3 text-foreground-muted">
             or continue with
           </span>
         </div>
@@ -64,9 +62,9 @@ function SocialLoginButtons() {
         <button
           type="button"
           onClick={handleGoogleLogin}
-          className="inline-flex h-11 items-center justify-center rounded-lg border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition-colors hover:border-slate-300 hover:bg-slate-50"
+          className="btn-secondary h-11 gap-2 px-4 text-sm"
         >
-          <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
+          <svg className="h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
             <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4" />
             <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
             <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
@@ -77,9 +75,9 @@ function SocialLoginButtons() {
         <button
           type="button"
           onClick={handleGitHubLogin}
-          className="inline-flex h-11 items-center justify-center rounded-lg border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition-colors hover:border-slate-300 hover:bg-slate-50"
+          className="btn-secondary h-11 gap-2 px-4 text-sm"
         >
-          <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
+          <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
             <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
           </svg>
           GitHub
@@ -121,110 +119,83 @@ export default function RegisterPage() {
     setIsLoading(false);
   };
 
+  const checklist = [
+    m.registerMarketing_feature1(),
+    m.registerMarketing_feature2(),
+    m.registerMarketing_feature3(),
+  ];
+
   return (
-    <div className="flex min-h-screen">
-      {/* Left side - Marketing */}
-      <div className="hidden lg:flex lg:w-1/2 relative overflow-hidden bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">
-        {/* Background decorations */}
-        <div className="absolute inset-0">
-          <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-purple-500/20 rounded-full blur-3xl" />
-          <div className="absolute bottom-1/4 right-1/4 w-96 h-96 bg-blue-500/20 rounded-full blur-3xl" />
-          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-64 h-64 bg-pink-500/10 rounded-full blur-2xl" />
-        </div>
+    <div className="grid min-h-screen lg:grid-cols-[0.95fr_1.05fr]">
+      <aside className="relative hidden overflow-hidden border-r border-[hsl(var(--border))] bg-[hsl(var(--card))] lg:block">
+        <div className="proof-strip absolute inset-x-0 top-0 h-2" />
+        <div className="bench-grid absolute inset-0 opacity-40" />
 
-        {/* Grid pattern */}
-        <div
-          className="absolute inset-0 opacity-20"
-          style={{
-            backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.1'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
-          }}
-        />
+        <div className="relative z-10 flex min-h-screen flex-col justify-center px-12 xl:px-20">
+          <a href={localizeHref("/")} className="flex items-center gap-3">
+            <div className="flex h-12 w-12 items-center justify-center rounded-md bg-[hsl(var(--foreground))] text-[hsl(var(--background))]">
+              <PackageCheck className="h-6 w-6" aria-hidden="true" />
+            </div>
+            <span className="font-display text-3xl font-semibold text-foreground">OuraPix</span>
+          </a>
 
-        {/* Content */}
-        <div className="relative z-10 flex flex-col justify-center px-12 xl:px-20">
-          <div className="mb-8">
-            <a href={localizeHref("/")} className="flex items-center gap-3 group">
-              <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-white/10 backdrop-blur-sm border border-white/20 group-hover:bg-white/20 transition-colors">
-                <span className="text-2xl font-bold text-white">O</span>
-              </div>
-              <span className="text-3xl font-bold text-white">OuraPix</span>
-            </a>
-          </div>
-
-          <h1 className="text-4xl xl:text-5xl font-bold text-white leading-tight mb-6">
-            {m.registerMarketing_headline()}<br />
-            <span className="bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent">
+          <p className="font-utility mt-12 text-xs font-semibold uppercase text-[hsl(var(--accent))]">
+            New seller bench
+          </p>
+          <h2 className="font-display mt-4 max-w-xl text-5xl font-semibold leading-none text-foreground">
+            {m.registerMarketing_headline()}
+            <span className="block text-[hsl(var(--primary))]">
               {m.registerMarketing_headlineHighlight()}
             </span>
-          </h1>
-
-          <p className="text-lg text-slate-300 mb-8 max-w-md">
+          </h2>
+          <p className="mt-6 max-w-md text-lg text-foreground-muted">
             {m.registerMarketing_description()}
           </p>
 
-          <div className="space-y-4">
-            <div className="flex items-center gap-3 text-slate-300">
-              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-white/10">
-                <svg className="w-5 h-5 text-purple-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
-                </svg>
-              </div>
-              <span>{m.registerMarketing_feature1()}</span>
-            </div>
-            <div className="flex items-center gap-3 text-slate-300">
-              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-white/10">
-                <svg className="w-5 h-5 text-pink-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                </svg>
-              </div>
-              <span>{m.registerMarketing_feature2()}</span>
-            </div>
-            <div className="flex items-center gap-3 text-slate-300">
-              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-white/10">
-                <svg className="w-5 h-5 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-                </svg>
-              </div>
-              <span>{m.registerMarketing_feature3()}</span>
+          <div className="card mt-10 overflow-hidden">
+            <div className="proof-strip h-2" />
+            <div className="space-y-4 p-5">
+              {checklist.map((item) => (
+                <div key={item} className="flex items-center gap-3 text-sm font-semibold text-foreground">
+                  <CheckCircle2 className="h-5 w-5 text-[hsl(var(--primary))]" aria-hidden="true" />
+                  {item}
+                </div>
+              ))}
             </div>
           </div>
         </div>
-      </div>
+      </aside>
 
-      {/* Right side - Register Form */}
-      <div className="w-full lg:w-1/2 flex flex-col justify-center px-6 py-12 sm:px-8 lg:px-12 xl:px-16 bg-white">
-        <div className="w-full max-w-md mx-auto">
-          {/* Mobile Logo */}
-          <div className="lg:hidden flex justify-center mb-8">
+      <main className="flex min-h-screen flex-col justify-center bg-[hsl(var(--background))] px-6 py-12 sm:px-8 lg:px-12 xl:px-16">
+        <div className="mx-auto w-full max-w-md">
+          <div className="mb-8 flex justify-center lg:hidden">
             <a href={localizeHref("/")} className="flex items-center gap-2">
-              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-slate-900">
-                <span className="text-xl font-bold text-white">O</span>
+              <div className="flex h-10 w-10 items-center justify-center rounded-md bg-[hsl(var(--foreground))] text-[hsl(var(--background))]">
+                <PackageCheck className="h-5 w-5" aria-hidden="true" />
               </div>
-              <span className="text-2xl font-bold text-slate-900">OuraPix</span>
+              <span className="font-display text-2xl font-semibold text-foreground">OuraPix</span>
             </a>
           </div>
 
-          {/* Title */}
           <div className="mb-8">
-            <h2 className="text-2xl font-bold text-slate-900 mb-2">
-              {m.register_title()}
-            </h2>
-            <p className="text-slate-500">
-              {m.register_subtitle()}
+            <p className="font-utility text-xs font-semibold uppercase text-[hsl(var(--accent))]">
+              Create account
             </p>
+            <h1 className="font-display mt-2 text-4xl font-semibold text-foreground">
+              {m.register_title()}
+            </h1>
+            <p className="mt-2 text-foreground-muted">{m.register_subtitle()}</p>
           </div>
 
-          {/* Error message */}
           {error && (
-            <div className="mb-6 p-4 rounded-lg bg-red-50 border border-red-100">
-              <p className="text-sm text-red-600">{error}</p>
+            <div className="mb-6 rounded-lg border border-[hsl(var(--color-error)/0.3)] bg-[hsl(var(--color-error-light))] p-4">
+              <p className="text-sm font-medium text-[hsl(var(--color-error))]">{error}</p>
             </div>
           )}
 
-          {/* Register Form */}
           <form className="space-y-5" onSubmit={handleSubmit}>
             <div className="space-y-2">
-              <label htmlFor="name" className="text-sm font-medium text-slate-700">
+              <label htmlFor="name" className="text-sm font-semibold text-foreground">
                 {m.register_name()}
               </label>
               <input
@@ -236,12 +207,12 @@ export default function RegisterPage() {
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder={m.register_namePlaceholder()}
-                className="w-full h-11 rounded-lg border border-slate-200 bg-slate-50 px-3 text-sm transition-colors focus:border-slate-900 focus:bg-white focus:outline-none focus:ring-1 focus:ring-slate-900"
+                className="input h-11"
               />
             </div>
 
             <div className="space-y-2">
-              <label htmlFor="email" className="text-sm font-medium text-slate-700">
+              <label htmlFor="email" className="text-sm font-semibold text-foreground">
                 {m.login_email()}
               </label>
               <input
@@ -253,12 +224,12 @@ export default function RegisterPage() {
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 placeholder={m.login_emailPlaceholder()}
-                className="w-full h-11 rounded-lg border border-slate-200 bg-slate-50 px-3 text-sm transition-colors focus:border-slate-900 focus:bg-white focus:outline-none focus:ring-1 focus:ring-slate-900"
+                className="input h-11"
               />
             </div>
 
             <div className="space-y-2">
-              <label htmlFor="password" className="text-sm font-medium text-slate-700">
+              <label htmlFor="password" className="text-sm font-semibold text-foreground">
                 {m.login_password()}
               </label>
               <PasswordInput
@@ -273,7 +244,7 @@ export default function RegisterPage() {
             </div>
 
             <div className="space-y-2">
-              <label htmlFor="confirmPassword" className="text-sm font-medium text-slate-700">
+              <label htmlFor="confirmPassword" className="text-sm font-semibold text-foreground">
                 {m.register_confirmPassword()}
               </label>
               <PasswordInput
@@ -295,15 +266,15 @@ export default function RegisterPage() {
                 required
                 checked={agreeTerms}
                 onChange={(e) => setAgreeTerms(e.target.checked)}
-                className="mt-1 h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-900 cursor-pointer"
+                className="mt-1 h-4 w-4 cursor-pointer rounded border-[hsl(var(--border))] bg-[hsl(var(--input))] text-[hsl(var(--primary))] focus:ring-[hsl(var(--primary)/0.3)]"
               />
-              <label htmlFor="agree-terms" className="text-sm text-slate-600 cursor-pointer select-none">
+              <label htmlFor="agree-terms" className="cursor-pointer select-none text-sm text-foreground-muted">
                 {m.register_agreeToTerms()}{" "}
-                <a href={localizeHref("/docs/terms")} className="text-slate-900 font-medium hover:underline">
+                <a href={localizeHref("/docs/terms")} className="font-semibold text-[hsl(var(--primary))] hover:text-[hsl(var(--primary-hover))]">
                   {m.register_termsOfService()}
                 </a>{" "}
                 {m.register_and()}{" "}
-                <a href={localizeHref("/docs/privacy")} className="text-slate-900 font-medium hover:underline">
+                <a href={localizeHref("/docs/privacy")} className="font-semibold text-[hsl(var(--primary))] hover:text-[hsl(var(--primary-hover))]">
                   {m.register_privacyPolicy()}
                 </a>
               </label>
@@ -312,11 +283,11 @@ export default function RegisterPage() {
             <button
               type="submit"
               disabled={isLoading || !agreeTerms}
-              className="w-full h-11 rounded-lg bg-slate-900 text-white text-sm font-medium transition-colors hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+              className="btn-primary h-11 w-full gap-2 text-sm disabled:cursor-not-allowed disabled:opacity-50"
             >
               {isLoading ? (
                 <>
-                  <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24">
+                  <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" aria-hidden="true">
                     <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
                     <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
                   </svg>
@@ -330,20 +301,19 @@ export default function RegisterPage() {
             <SocialLoginButtons />
           </form>
 
-          {/* Login link */}
-          <div className="mt-8 pt-6 border-t border-slate-100">
-            <p className="text-center text-slate-500 text-sm">
+          <div className="mt-8 border-t border-[hsl(var(--border))] pt-6">
+            <p className="text-center text-sm text-foreground-muted">
               {m.register_hasAccount()}{" "}
               <a
                 href={localizeHref("/login")}
-                className="font-medium text-slate-900 hover:text-slate-700 transition-colors"
+                className="font-semibold text-[hsl(var(--primary))] transition-colors hover:text-[hsl(var(--primary-hover))]"
               >
                 {m.register_signIn()}
               </a>
             </p>
           </div>
         </div>
-      </div>
+      </main>
     </div>
   );
 }

--- a/frontend/src/components/ResetPasswordPage.tsx
+++ b/frontend/src/components/ResetPasswordPage.tsx
@@ -1,13 +1,64 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { Eye, EyeOff } from "lucide-react";
+import { useEffect, useState } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Eye,
+  EyeOff,
+  LockKeyhole,
+  PackageCheck,
+} from "lucide-react";
 import { localizeHref } from "@/paraglide/runtime.js";
 import { resetPassword } from "@/lib/auth";
 
-// PasswordInput sub-component
+function BrandLink() {
+  return (
+    <a href={localizeHref("/")} className="flex items-center gap-3">
+      <div className="flex h-11 w-11 items-center justify-center rounded-md bg-[hsl(var(--foreground))] text-[hsl(var(--background))]">
+        <PackageCheck className="h-5 w-5" aria-hidden="true" />
+      </div>
+      <span className="font-display text-2xl font-semibold text-foreground">OuraPix</span>
+    </a>
+  );
+}
+
+function RecoveryAside({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <aside className="relative hidden overflow-hidden border-r border-[hsl(var(--border))] bg-[hsl(var(--card))] lg:block">
+      <div className="proof-strip absolute inset-x-0 top-0 h-2" />
+      <div className="bench-grid absolute inset-0 opacity-40" />
+      <div className="relative z-10 flex min-h-screen flex-col justify-center px-12 xl:px-20">
+        <BrandLink />
+        <p className="page-kicker mt-12">Credential proof</p>
+        <h2 className="font-display mt-4 max-w-xl text-5xl font-semibold leading-none text-foreground">
+          {title}
+        </h2>
+        <p className="mt-6 max-w-md text-lg text-foreground-muted">{description}</p>
+        <div className="card mt-10 overflow-hidden">
+          <div className="proof-strip h-2" />
+          <div className="space-y-4 p-5">
+            {["新密码至少 8 位", "重置完成后回到登录台", "商品与团队数据保持不变"].map((item) => (
+              <div key={item} className="flex items-center gap-3 text-sm font-semibold text-foreground">
+                <CheckCircle2 className="h-5 w-5 text-[hsl(var(--primary))]" aria-hidden="true" />
+                {item}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </aside>
+  );
+}
+
 function PasswordInput({
-  className,
+  className = "",
   ...props
 }: React.InputHTMLAttributes<HTMLInputElement>) {
   const [showPassword, setShowPassword] = useState(false);
@@ -16,19 +67,19 @@ function PasswordInput({
     <div className="relative">
       <input
         type={showPassword ? "text" : "password"}
-        className={`w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5 pr-10 text-sm transition-colors focus:border-slate-900 focus:bg-white focus:outline-none focus:ring-1 focus:ring-slate-900 ${className}`}
+        className={`input h-11 pr-10 ${className}`}
         {...props}
       />
       <button
         type="button"
-        className="absolute right-0 top-0 h-full px-3 text-slate-400 hover:text-slate-600"
+        className="absolute right-0 top-0 flex h-full items-center px-3 text-foreground-muted transition-colors hover:text-foreground"
         onClick={() => setShowPassword(!showPassword)}
-        tabIndex={-1}
+        aria-label={showPassword ? "Hide password" : "Show password"}
       >
         {showPassword ? (
-          <EyeOff className="h-4 w-4" />
+          <EyeOff className="h-4 w-4" aria-hidden="true" />
         ) : (
-          <Eye className="h-4 w-4" />
+          <Eye className="h-4 w-4" aria-hidden="true" />
         )}
       </button>
     </div>
@@ -48,11 +99,7 @@ export default function ResetPasswordPage({ token }: Props) {
   const [isValidToken, setIsValidToken] = useState<boolean | null>(null);
 
   useEffect(() => {
-    if (!token) {
-      setIsValidToken(false);
-      return;
-    }
-    setIsValidToken(true);
+    setIsValidToken(Boolean(token));
   }, [token]);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -93,230 +140,94 @@ export default function ResetPasswordPage({ token }: Props) {
     }
   };
 
-  // Invalid token state
   if (isValidToken === false) {
     return (
-      <div className="flex min-h-screen">
-        <div className="hidden lg:flex lg:w-1/2 relative overflow-hidden bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">
-          <div className="absolute inset-0">
-            <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-red-500/20 rounded-full blur-3xl" />
-            <div className="absolute bottom-1/4 right-1/4 w-96 h-96 bg-orange-500/20 rounded-full blur-3xl" />
-          </div>
-          <div
-            className="absolute inset-0 opacity-20"
-            style={{
-              backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.1'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
-            }}
-          />
-          <div className="relative z-10 flex flex-col justify-center px-12 xl:px-20">
-            <div className="mb-8">
-              <a href={localizeHref("/")} className="flex items-center gap-3 group">
-                <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-white/10 backdrop-blur-sm border border-white/20 group-hover:bg-white/20 transition-colors">
-                  <span className="text-2xl font-bold text-white">O</span>
-                </div>
-                <span className="text-3xl font-bold text-white">OuraPix</span>
-              </a>
+      <div className="grid min-h-screen lg:grid-cols-[0.95fr_1.05fr]">
+        <RecoveryAside
+          title="Expired links stay outside the listing bench."
+          description="链接失效时不再接受密码改写，避免过期邮件继续打开账户入口。"
+        />
+        <main className="flex min-h-screen flex-col justify-center bg-[hsl(var(--background))] px-6 py-12 sm:px-8 lg:px-12 xl:px-16">
+          <div className="mx-auto w-full max-w-md text-center">
+            <div className="mb-8 flex justify-center lg:hidden">
+              <BrandLink />
             </div>
-            <h1 className="text-4xl xl:text-5xl font-bold text-white leading-tight mb-6">
-              链接已失效<br />
-              <span className="bg-gradient-to-r from-red-400 to-orange-400 bg-clip-text text-transparent">
-                请重新申请
-              </span>
+            <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-md bg-[hsl(var(--color-error-light))] text-[hsl(var(--color-error))]">
+              <AlertTriangle className="h-8 w-8" aria-hidden="true" />
+            </div>
+            <p className="page-kicker">Invalid reset link</p>
+            <h1 className="font-display mt-2 text-4xl font-semibold text-foreground">
+              链接已失效
             </h1>
+            <p className="mt-3 text-foreground-muted">该密码重置链接已过期或无效。</p>
+            <a href={localizeHref("/forgot-password")} className="btn-primary mt-8 h-11 px-6">
+              重新申请
+            </a>
           </div>
-        </div>
-
-        <div className="w-full lg:w-1/2 flex flex-col justify-center px-6 py-12 sm:px-8 lg:px-12 xl:px-16 bg-white">
-          <div className="w-full max-w-md mx-auto">
-            <div className="lg:hidden flex justify-center mb-8">
-              <a href={localizeHref("/")} className="flex items-center gap-2">
-                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-slate-900">
-                  <span className="text-xl font-bold text-white">O</span>
-                </div>
-                <span className="text-2xl font-bold text-slate-900">OuraPix</span>
-              </a>
-            </div>
-
-            <div className="text-center">
-              <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-red-100 mb-6">
-                <svg className="h-8 w-8 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-                </svg>
-              </div>
-              <h2 className="text-2xl font-bold text-slate-900 mb-3">
-                链接已失效
-              </h2>
-              <p className="text-slate-500 mb-8">
-                该密码重置链接已过期或无效。
-              </p>
-              <a
-                href={localizeHref("/forgot-password")}
-                className="inline-flex items-center justify-center h-11 px-6 rounded-md bg-slate-900 hover:bg-slate-800 text-white font-medium transition-colors"
-              >
-                重新申请
-              </a>
-            </div>
-          </div>
-        </div>
+        </main>
       </div>
     );
   }
 
-  // Success state
   if (isSuccess) {
     return (
-      <div className="flex min-h-screen">
-        <div className="hidden lg:flex lg:w-1/2 relative overflow-hidden bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">
-          <div className="absolute inset-0">
-            <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-green-500/20 rounded-full blur-3xl" />
-            <div className="absolute bottom-1/4 right-1/4 w-96 h-96 bg-emerald-500/20 rounded-full blur-3xl" />
-          </div>
-          <div
-            className="absolute inset-0 opacity-20"
-            style={{
-              backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.1'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
-            }}
-          />
-          <div className="relative z-10 flex flex-col justify-center px-12 xl:px-20">
-            <div className="mb-8">
-              <a href={localizeHref("/")} className="flex items-center gap-3 group">
-                <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-white/10 backdrop-blur-sm border border-white/20 group-hover:bg-white/20 transition-colors">
-                  <span className="text-2xl font-bold text-white">O</span>
-                </div>
-                <span className="text-3xl font-bold text-white">OuraPix</span>
-              </a>
+      <div className="grid min-h-screen lg:grid-cols-[0.95fr_1.05fr]">
+        <RecoveryAside
+          title="The account is cleared back onto the workbench."
+          description="新密码已生效，几秒后会带您回到登录入口继续处理商品图。"
+        />
+        <main className="flex min-h-screen flex-col justify-center bg-[hsl(var(--background))] px-6 py-12 sm:px-8 lg:px-12 xl:px-16">
+          <div className="mx-auto w-full max-w-md text-center">
+            <div className="mb-8 flex justify-center lg:hidden">
+              <BrandLink />
             </div>
-            <h1 className="text-4xl xl:text-5xl font-bold text-white leading-tight mb-6">
-              密码重置成功！<br />
-              <span className="bg-gradient-to-r from-green-400 to-emerald-400 bg-clip-text text-transparent">
-                即将跳转登录
-              </span>
+            <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-md bg-[hsl(var(--color-success-light))] text-[hsl(var(--color-success))]">
+              <CheckCircle2 className="h-8 w-8" aria-hidden="true" />
+            </div>
+            <p className="page-kicker">Password updated</p>
+            <h1 className="font-display mt-2 text-4xl font-semibold text-foreground">
+              重置成功
             </h1>
+            <p className="mt-3 text-foreground-muted">您的密码已重置，即将跳转到登录页面。</p>
+            <a href={localizeHref("/login")} className="btn-primary mt-8 h-11 px-6">
+              立即登录
+            </a>
           </div>
-        </div>
-
-        <div className="w-full lg:w-1/2 flex flex-col justify-center px-6 py-12 sm:px-8 lg:px-12 xl:px-16 bg-white">
-          <div className="w-full max-w-md mx-auto">
-            <div className="lg:hidden flex justify-center mb-8">
-              <a href={localizeHref("/")} className="flex items-center gap-2">
-                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-slate-900">
-                  <span className="text-xl font-bold text-white">O</span>
-                </div>
-                <span className="text-2xl font-bold text-slate-900">OuraPix</span>
-              </a>
-            </div>
-
-            <div className="text-center">
-              <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-green-100 mb-6">
-                <svg className="h-8 w-8 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                </svg>
-              </div>
-              <h2 className="text-2xl font-bold text-slate-900 mb-3">
-                重置成功
-              </h2>
-              <p className="text-slate-500 mb-8">
-                您的密码已重置，即将跳转到登录页面。
-              </p>
-              <a
-                href={localizeHref("/login")}
-                className="inline-flex items-center justify-center h-11 px-6 rounded-md bg-slate-900 hover:bg-slate-800 text-white font-medium transition-colors"
-              >
-                立即登录
-              </a>
-            </div>
-          </div>
-        </div>
+        </main>
       </div>
     );
   }
 
   return (
-    <div className="flex min-h-screen">
-      {/* Left side - Marketing */}
-      <div className="hidden lg:flex lg:w-1/2 relative overflow-hidden bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">
-        {/* Background decorations */}
-        <div className="absolute inset-0">
-          <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-amber-500/20 rounded-full blur-3xl" />
-          <div className="absolute bottom-1/4 right-1/4 w-96 h-96 bg-orange-500/20 rounded-full blur-3xl" />
-          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-64 h-64 bg-yellow-500/10 rounded-full blur-2xl" />
-        </div>
+    <div className="grid min-h-screen lg:grid-cols-[0.95fr_1.05fr]">
+      <RecoveryAside
+        title="Set a fresh key before returning to production work."
+        description="用新密码恢复账户访问，再继续生成、导出和复用商品详情页素材。"
+      />
 
-        {/* Grid pattern */}
-        <div
-          className="absolute inset-0 opacity-20"
-          style={{
-            backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.1'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
-          }}
-        />
+      <main className="flex min-h-screen flex-col justify-center bg-[hsl(var(--background))] px-6 py-12 sm:px-8 lg:px-12 xl:px-16">
+        <div className="mx-auto w-full max-w-md">
+          <div className="mb-8 flex justify-center lg:hidden">
+            <BrandLink />
+          </div>
 
-        {/* Content */}
-        <div className="relative z-10 flex flex-col justify-center px-12 xl:px-20">
           <div className="mb-8">
-            <a href={localizeHref("/")} className="flex items-center gap-3 group">
-              <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-white/10 backdrop-blur-sm border border-white/20 group-hover:bg-white/20 transition-colors">
-                <span className="text-2xl font-bold text-white">O</span>
-              </div>
-              <span className="text-3xl font-bold text-white">OuraPix</span>
-            </a>
-          </div>
-
-          <h1 className="text-4xl xl:text-5xl font-bold text-white leading-tight mb-6">
-            设置新密码<br />
-            <span className="bg-gradient-to-r from-amber-400 to-orange-400 bg-clip-text text-transparent">
-              保护您的账户
-            </span>
-          </h1>
-
-          <p className="text-lg text-slate-300 mb-8 max-w-md">
-            请输入您的新密码，确保密码长度至少8位，包含字母和数字。
-          </p>
-
-          <div className="flex items-center gap-3 text-slate-300">
-            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-white/10">
-              <svg className="w-5 h-5 text-amber-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-              </svg>
-            </div>
-            <span>安全加密，保护您的隐私</span>
-          </div>
-        </div>
-      </div>
-
-      {/* Right side - Form */}
-      <div className="w-full lg:w-1/2 flex flex-col justify-center px-6 py-12 sm:px-8 lg:px-12 xl:px-16 bg-white">
-        <div className="w-full max-w-md mx-auto">
-          {/* Mobile Logo */}
-          <div className="lg:hidden flex justify-center mb-8">
-            <a href={localizeHref("/")} className="flex items-center gap-2">
-              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-slate-900">
-                <span className="text-xl font-bold text-white">O</span>
-              </div>
-              <span className="text-2xl font-bold text-slate-900">OuraPix</span>
-            </a>
-          </div>
-
-          {/* Title */}
-          <div className="mb-8">
-            <h2 className="text-2xl font-bold text-slate-900 mb-2">
+            <p className="page-kicker">Set password</p>
+            <h1 className="font-display mt-2 text-4xl font-semibold text-foreground">
               设置新密码
-            </h2>
-            <p className="text-slate-500">
-              请输入您的新密码。
-            </p>
+            </h1>
+            <p className="mt-2 text-foreground-muted">请输入您的新密码。</p>
           </div>
 
-          {/* Error message */}
           {error && (
-            <div className="mb-6 p-4 rounded-lg bg-red-50 border border-red-100">
-              <p className="text-sm text-red-600">{error}</p>
+            <div className="error-banner mb-6">
+              <p>{error}</p>
             </div>
           )}
 
-          {/* Form */}
           <form className="space-y-5" onSubmit={handleSubmit}>
             <div className="space-y-2">
-              <label htmlFor="password" className="text-sm font-medium text-slate-700">
+              <label htmlFor="password" className="text-sm font-semibold text-foreground">
                 新密码
               </label>
               <PasswordInput
@@ -331,7 +242,7 @@ export default function ResetPasswordPage({ token }: Props) {
             </div>
 
             <div className="space-y-2">
-              <label htmlFor="confirmPassword" className="text-sm font-medium text-slate-700">
+              <label htmlFor="confirmPassword" className="text-sm font-semibold text-foreground">
                 确认密码
               </label>
               <PasswordInput
@@ -348,35 +259,23 @@ export default function ResetPasswordPage({ token }: Props) {
             <button
               type="submit"
               disabled={isLoading}
-              className="w-full h-11 rounded-lg bg-slate-900 text-white text-sm font-medium transition-colors hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+              className="btn-primary h-11 w-full gap-2 disabled:cursor-not-allowed disabled:opacity-50"
             >
-              {isLoading ? (
-                <>
-                  <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24">
-                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
-                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                  </svg>
-                  重置中...
-                </>
-              ) : (
-                "重置密码"
-              )}
+              <LockKeyhole className="h-4 w-4" aria-hidden="true" />
+              {isLoading ? "重置中..." : "重置密码"}
             </button>
           </form>
 
-          {/* Back to login */}
-          <div className="mt-8 pt-6 border-t border-slate-100">
-            <p className="text-center text-slate-500">
-              <a
-                href={localizeHref("/login")}
-                className="font-medium text-slate-900 hover:text-slate-700 transition-colors"
-              >
-                返回登录
-              </a>
-            </p>
+          <div className="mt-8 border-t border-[hsl(var(--border))] pt-6 text-center">
+            <a
+              href={localizeHref("/login")}
+              className="text-sm font-semibold text-[hsl(var(--primary))] transition-colors hover:text-[hsl(var(--primary-hover))]"
+            >
+              返回登录
+            </a>
           </div>
         </div>
-      </div>
+      </main>
     </div>
   );
 }

--- a/frontend/src/components/StateMessage.tsx
+++ b/frontend/src/components/StateMessage.tsx
@@ -56,9 +56,9 @@ function LoadingMessage({ message, className }: LoadingState) {
     <div
       className={`flex flex-col items-center justify-center py-12 ${className ?? ""}`}
     >
-      <Loader2 className="h-8 w-8 animate-spin text-slate-400 dark:text-slate-500" />
+      <Loader2 className="h-8 w-8 animate-spin text-[hsl(var(--primary))]" />
       {message && (
-        <p className="mt-3 text-sm text-slate-500 dark:text-slate-400">
+        <p className="mt-3 text-sm font-medium text-foreground-muted">
           {message}
         </p>
       )}
@@ -68,17 +68,15 @@ function LoadingMessage({ message, className }: LoadingState) {
 
 function ErrorMessage({ message, onRetry, className }: ErrorState) {
   return (
-    <div
-      className={`rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20 ${className ?? ""}`}
-    >
+    <div className={`error-banner ${className ?? ""}`}>
       <div className="flex items-start gap-3">
-        <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-600 dark:text-red-400" />
+        <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
         <div className="min-w-0 flex-1">
-          <p className="text-sm text-red-700 dark:text-red-300">{message}</p>
+          <p>{message}</p>
           {onRetry && (
             <button
               onClick={onRetry}
-              className="mt-2 text-sm font-medium text-red-600 underline hover:no-underline dark:text-red-400"
+              className="mt-2 text-sm font-semibold underline hover:no-underline"
             >
               {m.common_retry()}
             </button>
@@ -98,23 +96,23 @@ function EmptyMessage({
 }: EmptyState) {
   return (
     <div
-      className={`flex flex-col items-center justify-center px-4 py-16 ${className ?? ""}`}
+      className={`panel-muted flex flex-col items-center justify-center px-4 py-16 ${className ?? ""}`}
     >
-      <div className="mb-6 text-slate-300 dark:text-slate-600">
+      <div className="mb-6 text-foreground-muted">
         {icon ?? <Inbox className="h-16 w-16" />}
       </div>
-      <h3 className="text-lg font-medium text-slate-900 dark:text-slate-100">
+      <h3 className="text-lg font-semibold text-foreground">
         {title}
       </h3>
       {description && (
-        <p className="mt-2 max-w-sm text-center text-sm text-slate-500 dark:text-slate-400">
+        <p className="mt-2 max-w-sm text-center text-sm text-foreground-muted">
           {description}
         </p>
       )}
       {action && (
         <button
           onClick={action.onClick}
-          className="mt-6 rounded-lg bg-amber-600 px-6 py-2.5 font-medium text-white transition-colors hover:bg-amber-700"
+          className="btn-primary mt-6 h-10 px-6"
         >
           {action.label}
         </button>

--- a/frontend/src/components/UploadDropzone.tsx
+++ b/frontend/src/components/UploadDropzone.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useId, useState } from "react";
+import { ImageIcon, UploadCloud, X } from "lucide-react";
 import * as m from "@/paraglide/messages.js";
 
 interface UploadDropzoneProps {
@@ -27,6 +28,7 @@ export default function UploadDropzone({
   const [isDragOver, setIsDragOver] = useState(false);
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const inputId = useId();
 
   const formatFileSize = (bytes: number): string => {
     if (bytes === 0) return "0 B";
@@ -134,9 +136,9 @@ export default function UploadDropzone({
 
   return (
     <div className="space-y-3">
-      <label className="block text-sm font-medium text-slate-700">
+      <label htmlFor={inputId} className="block text-sm font-semibold text-foreground">
         {label}
-        {required && <span className="ml-1 text-red-500">*</span>}
+        {required && <span className="ml-1 text-[hsl(var(--color-error))]">*</span>}
       </label>
 
       {/* Dropzone */}
@@ -147,14 +149,15 @@ export default function UploadDropzone({
         className={`
           relative rounded-lg border-2 border-dashed p-6 text-center transition-all
           ${isDragOver
-            ? "border-slate-900 bg-slate-50"
+            ? "border-[hsl(var(--primary))] bg-[hsl(var(--primary)/0.08)]"
             : selectedFiles.length > 0
-            ? "border-slate-900 bg-slate-50"
-            : "border-slate-300 hover:border-slate-400"
+            ? "border-[hsl(var(--primary))] bg-[hsl(var(--primary)/0.08)]"
+            : "border-[hsl(var(--border))] bg-[hsl(var(--card))] hover:border-[hsl(var(--foreground)/0.28)]"
           }
         `}
       >
         <input
+          id={inputId}
           type="file"
           accept={accept}
           multiple={multiple}
@@ -163,25 +166,16 @@ export default function UploadDropzone({
         />
 
         <div className="pointer-events-none">
-          <svg
-            className={`mx-auto h-10 w-10 ${selectedFiles.length > 0 ? "text-slate-900" : "text-slate-400"}`}
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={1.5}
-              d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
-            />
-          </svg>
-          <p className="mt-2 text-sm text-slate-600">
+          <UploadCloud
+            className={`mx-auto h-10 w-10 ${selectedFiles.length > 0 ? "text-[hsl(var(--primary))]" : "text-foreground-muted"}`}
+            aria-hidden="true"
+          />
+          <p className="mt-2 text-sm font-medium text-foreground">
             {selectedFiles.length > 0
               ? m.upload_filesSelected({ count: selectedFiles.length.toString() })
               : m.upload_clickOrDrag()}
           </p>
-          <p className="mt-1 text-xs text-slate-500">
+          <p className="mt-1 text-xs text-foreground-muted">
             {description || m.upload_supportedFormats({ type: accept, size: formatFileSize(maxSize) })}
           </p>
         </div>
@@ -189,7 +183,7 @@ export default function UploadDropzone({
 
       {/* Error Message */}
       {error && (
-        <p className="text-sm text-red-600">{error}</p>
+        <p className="text-sm font-medium text-[hsl(var(--color-error))]">{error}</p>
       )}
 
       {/* Selected Files */}
@@ -198,40 +192,22 @@ export default function UploadDropzone({
           {selectedFiles.map((file, index) => (
             <div
               key={`${file.name}-${index}`}
-              className="flex items-center justify-between rounded-lg border border-slate-200 bg-slate-50 px-3 py-2"
+              className="flex items-center justify-between rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--background-secondary)/0.55)] px-3 py-2"
             >
               <div className="flex items-center gap-2 min-w-0">
-                <svg
-                  className="h-5 w-5 shrink-0 text-slate-400"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={1.5}
-                    d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
-                  />
-                </svg>
-                <span className="text-sm text-slate-700 truncate">{file.name}</span>
-                <span className="text-xs text-slate-500 shrink-0">
+                <ImageIcon className="h-5 w-5 shrink-0 text-[hsl(var(--primary))]" aria-hidden="true" />
+                <span className="truncate text-sm text-foreground">{file.name}</span>
+                <span className="shrink-0 text-xs text-foreground-muted">
                   ({formatFileSize(file.size)})
                 </span>
               </div>
               <button
                 type="button"
                 onClick={() => removeFile(index)}
-                className="ml-2 shrink-0 text-slate-400 hover:text-red-500 transition-colors"
+                className="ml-2 shrink-0 rounded-md p-1 text-foreground-muted transition-colors hover:bg-[hsl(var(--color-error-light))] hover:text-[hsl(var(--color-error))]"
+                aria-label={`Remove ${file.name}`}
               >
-                <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                </svg>
+                <X className="h-4 w-4" aria-hidden="true" />
               </button>
             </div>
           ))}

--- a/frontend/src/components/categories/CategoriesPage.tsx
+++ b/frontend/src/components/categories/CategoriesPage.tsx
@@ -4,36 +4,46 @@
 
 "use client";
 
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
+import { Sparkles, X } from "lucide-react";
+import { localizeHref } from "@/paraglide/runtime.js";
 import { useCategories, useCategoryTemplates, type Category, type Template } from "@/hooks/useCategories";
 
-function TemplateCard({ template, isSelected, onClick }: { template: Template; isSelected: boolean; onClick: () => void }) {
+function TemplateCard({
+  template,
+  isSelected,
+  onClick,
+}: {
+  template: Template;
+  isSelected: boolean;
+  onClick: () => void;
+}) {
   return (
     <button
       onClick={onClick}
-      className={`text-left p-4 rounded-lg border w-full transition-colors ${
-        isSelected
-          ? "border-slate-900 dark:border-slate-100 bg-slate-50 dark:bg-slate-800"
-          : "border-slate-200 dark:border-slate-700 hover:border-slate-400 dark:hover:border-slate-500"
+      className={`panel w-full p-4 text-left transition-colors ${
+        isSelected ? "border-[hsl(var(--primary))] bg-[hsl(var(--primary)/0.08)]" : "hover:border-[hsl(var(--primary)/0.5)]"
       }`}
     >
-      <div className="flex items-start justify-between mb-1">
-        <h4 className="font-medium text-slate-900 dark:text-slate-100">{template.name}</h4>
-        {template.isPreset ? (
-          <span className="px-1.5 py-0.5 text-xs rounded bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">预设</span>
-        ) : (
-          <span className="px-1.5 py-0.5 text-xs rounded bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300">自定义</span>
-        )}
+      <div className="mb-2 flex items-start justify-between gap-3">
+        <h3 className="font-semibold text-foreground">{template.name}</h3>
+        <span className={`status-badge ${template.isPreset ? "status-badge-info" : "status-badge-neutral"}`}>
+          {template.isPreset ? "预设" : "自定义"}
+        </span>
       </div>
-      {template.description && <p className="text-xs text-slate-500 mb-2">{template.description}</p>}
+      {template.description && (
+        <p className="mb-3 text-xs text-foreground-muted">{template.description}</p>
+      )}
       <div className="flex flex-wrap gap-1.5">
         {Object.entries(template.settings).map(([k, v]) => (
-          <span key={k} className="text-xs px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400">
+          <span key={k} className="status-badge status-badge-neutral">
             {k}: {String(v)}
           </span>
         ))}
       </div>
-      {template.usageCount > 0 && <p className="text-xs text-slate-400 mt-2">使用 {template.usageCount} 次</p>}
+      {template.usageCount > 0 && (
+        <p className="font-utility mt-3 text-xs text-foreground-muted">使用 {template.usageCount} 次</p>
+      )}
     </button>
   );
 }
@@ -45,87 +55,140 @@ export default function CategoriesPage() {
   const selected = categories.find((c) => c.id === selectedId) ?? null;
 
   if (loading && categories.length === 0) {
-    return <div className="max-w-6xl mx-auto p-6 text-center text-slate-500">加载中...</div>;
+    return (
+      <CategoriesShell>
+        <div className="panel-muted flex min-h-[320px] items-center justify-center p-12 text-center text-foreground-muted" aria-busy="true">
+          加载商品类目...
+        </div>
+      </CategoriesShell>
+    );
   }
 
-  if (error) {
+  if (error && categories.length === 0) {
     return (
-      <div className="max-w-6xl mx-auto p-6">
-        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-3 rounded">
-          <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
+      <CategoriesShell>
+        <div className="error-banner" role="alert">
+          <p className="font-semibold">无法加载商品类目</p>
+          <p className="mt-1 text-sm">{error}</p>
         </div>
-      </div>
+        <div className="panel-muted mt-4 flex min-h-[240px] flex-col items-center justify-center p-8 text-center">
+          <h2 className="text-lg font-semibold text-foreground">类目模板暂时不可用</h2>
+          <p className="mt-2 max-w-md text-sm text-foreground-muted">
+            确认 API 服务可访问后刷新页面，已保存的导航和页面上下文不会丢失。
+          </p>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            className="btn-secondary mt-6 h-10 px-5"
+          >
+            重新加载
+          </button>
+        </div>
+      </CategoriesShell>
     );
   }
 
   return (
-    <div className="max-w-6xl mx-auto p-6">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">商品类目与模板</h1>
-        <p className="text-sm text-slate-500 mt-1">选择类目，使用预设模板快速生成</p>
-      </div>
+    <CategoriesShell>
+      {error && (
+        <div className="error-banner mb-4" role="alert">
+          <p className="font-semibold">部分类目信息未更新</p>
+          <p className="mt-1 text-sm">{error}</p>
+        </div>
+      )}
 
-      <div className="grid grid-cols-1 lg:grid-cols-12 gap-4">
-        <aside className="lg:col-span-3">
-          <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 overflow-hidden">
-            {categories.map((cat) => (
-              <button
-                key={cat.id}
-                onClick={() => { setSelectedId(cat.id); setTab("templates"); }}
-                className={`w-full text-left px-4 py-3 border-b border-slate-100 dark:border-slate-800 last:border-b-0 transition-colors ${
-                  selectedId === cat.id ? "bg-slate-100 dark:bg-slate-800" : "hover:bg-slate-50 dark:hover:bg-slate-800/50"
-                }`}
-              >
-                <div className="flex items-center gap-2">
-                  <span className="text-2xl">{cat.icon}</span>
-                  <div className="flex-1 min-w-0">
-                    <div className="font-medium text-slate-900 dark:text-slate-100">{cat.name}</div>
-                    <div className="text-xs text-slate-500">{cat.templateCount ?? 0} 模板</div>
-                  </div>
-                </div>
-              </button>
-            ))}
-          </div>
-        </aside>
-
-        <main className="lg:col-span-9">
-          {selected ? (
-            <CategoryDetail key={selected.id} category={selected} tab={tab} setTab={setTab} />
-          ) : (
-            <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-12 text-center text-slate-500">
-              ← 选择一个类目查看模板和最佳实践
+      {categories.length === 0 ? (
+        <div className="panel-muted flex min-h-[320px] items-center justify-center p-12 text-center text-foreground-muted">
+          暂无类目模板
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-12">
+          <aside className="lg:col-span-3">
+            <div className="panel overflow-hidden">
+              {categories.map((cat) => (
+                <button
+                  key={cat.id}
+                  onClick={() => {
+                    setSelectedId(cat.id);
+                    setTab("templates");
+                  }}
+                  className={`data-row flex w-full items-center gap-3 px-4 py-3 text-left first:border-t-0 ${
+                    selectedId === cat.id ? "bg-[hsl(var(--primary)/0.08)]" : ""
+                  }`}
+                >
+                  <span className="text-2xl" aria-hidden="true">{cat.icon}</span>
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate font-semibold text-foreground">{cat.name}</span>
+                    <span className="font-utility text-xs text-foreground-muted">{cat.templateCount ?? 0} 模板</span>
+                  </span>
+                </button>
+              ))}
             </div>
-          )}
-        </main>
+          </aside>
+
+          <main className="lg:col-span-9">
+            {selected ? (
+              <CategoryDetail key={selected.id} category={selected} tab={tab} setTab={setTab} />
+            ) : (
+              <div className="panel-muted flex min-h-[320px] items-center justify-center p-12 text-center text-foreground-muted">
+                选择一个类目查看模板和最佳实践
+              </div>
+            )}
+          </main>
+        </div>
+      )}
+    </CategoriesShell>
+  );
+}
+
+function CategoriesShell({ children }: { children: ReactNode }) {
+  return (
+    <div className="workbench-page">
+      <div className="workbench-container">
+        <header className="mb-8 max-w-3xl">
+          <p className="page-kicker">Catalog / Templates</p>
+          <h1 className="page-title mt-2">商品类目与模板</h1>
+          <p className="page-description mt-3">选择类目，使用预设模板快速生成</p>
+        </header>
+
+        {children}
       </div>
     </div>
   );
 }
 
-function CategoryDetail({ category, tab, setTab }: { category: Category; tab: "templates" | "practices"; setTab: (t: "templates" | "practices") => void }) {
+function CategoryDetail({
+  category,
+  tab,
+  setTab,
+}: {
+  category: Category;
+  tab: "templates" | "practices";
+  setTab: (t: "templates" | "practices") => void;
+}) {
   const { templates, loading, error } = useCategoryTemplates(category.id);
   const [selectedTemplate, setSelectedTemplate] = useState<Template | null>(null);
 
   return (
-    <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700">
-      <div className="p-6 border-b border-slate-200 dark:border-slate-700">
-        <div className="flex items-center gap-3 mb-2">
-          <span className="text-4xl">{category.icon}</span>
+    <section className="panel overflow-hidden">
+      <div className="border-b border-[hsl(var(--border))] p-6">
+        <div className="mb-4 flex items-center gap-3">
+          <span className="text-4xl" aria-hidden="true">{category.icon}</span>
           <div>
-            <h2 className="text-xl font-bold text-slate-900 dark:text-slate-100">{category.name}</h2>
-            <p className="text-sm text-slate-500">{category.description}</p>
+            <h2 className="font-display text-2xl font-semibold text-foreground">{category.name}</h2>
+            <p className="text-sm text-foreground-muted">{category.description}</p>
           </div>
         </div>
-        <div className="flex gap-2 mt-4">
+        <div className="flex flex-wrap gap-2">
           <button
             onClick={() => setTab("templates")}
-            className={`px-3 py-1.5 text-sm rounded ${tab === "templates" ? "bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900" : "bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700"}`}
+            className={`segmented-option ${tab === "templates" ? "segmented-option-active" : ""}`}
           >
             模板 ({templates.length})
           </button>
           <button
             onClick={() => setTab("practices")}
-            className={`px-3 py-1.5 text-sm rounded ${tab === "practices" ? "bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900" : "bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700"}`}
+            className={`segmented-option ${tab === "practices" ? "segmented-option-active" : ""}`}
           >
             最佳实践
           </button>
@@ -136,39 +199,51 @@ function CategoryDetail({ category, tab, setTab }: { category: Category; tab: "t
         {tab === "templates" ? (
           <>
             {error && (
-              <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-3 rounded mb-4">
-                <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
+              <div className="error-banner mb-4">
+                <p>{error}</p>
               </div>
             )}
             {loading && templates.length === 0 ? (
-              <p className="text-center text-slate-500 py-8">加载中...</p>
+              <p className="py-8 text-center text-foreground-muted">加载中...</p>
             ) : templates.length === 0 ? (
-              <p className="text-center text-slate-500 py-8">暂无模板</p>
+              <p className="py-8 text-center text-foreground-muted">暂无模板</p>
             ) : (
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
                 {templates.map((t) => (
-                  <TemplateCard key={t.id} template={t} isSelected={selectedTemplate?.id === t.id} onClick={() => setSelectedTemplate(t)} />
+                  <TemplateCard
+                    key={t.id}
+                    template={t}
+                    isSelected={selectedTemplate?.id === t.id}
+                    onClick={() => setSelectedTemplate(t)}
+                  />
                 ))}
               </div>
             )}
             {selectedTemplate && (
-              <div className="mt-6 p-4 bg-slate-50 dark:bg-slate-800 rounded-lg">
-                <div className="flex items-start justify-between mb-2">
-                  <h3 className="font-medium text-slate-900 dark:text-slate-100">使用模板: {selectedTemplate.name}</h3>
-                  <button onClick={() => setSelectedTemplate(null)} className="text-slate-400 hover:text-slate-600" aria-label="Close">✕</button>
+              <div className="panel-muted mt-6 p-4">
+                <div className="mb-3 flex items-start justify-between gap-3">
+                  <h3 className="font-semibold text-foreground">使用模板: {selectedTemplate.name}</h3>
+                  <button
+                    onClick={() => setSelectedTemplate(null)}
+                    className="icon-button h-8 w-8"
+                    aria-label="Close"
+                  >
+                    <X className="h-4 w-4" aria-hidden="true" />
+                  </button>
                 </div>
-                <a href={`/generate?template=${selectedTemplate.id}`} className="inline-block mt-2 px-4 py-2 bg-slate-900 text-white text-sm rounded hover:bg-slate-800">
-                  用此模板生成 →
+                <a href={localizeHref(`/generate?template=${selectedTemplate.id}`)} className="btn-primary h-10 gap-2 px-4">
+                  <Sparkles className="h-4 w-4" aria-hidden="true" />
+                  用此模板生成
                 </a>
               </div>
             )}
           </>
         ) : (
-          <pre className="text-xs whitespace-pre-wrap font-sans bg-slate-50 dark:bg-slate-800 p-3 rounded text-slate-700 dark:text-slate-300">
+          <pre className="panel-muted whitespace-pre-wrap p-4 text-sm text-foreground">
             {category.bestPractices ?? "暂无最佳实践"}
           </pre>
         )}
       </div>
-    </div>
+    </section>
   );
 }

--- a/frontend/src/components/collections/CollectionsPage.tsx
+++ b/frontend/src/components/collections/CollectionsPage.tsx
@@ -7,6 +7,7 @@
 "use client";
 
 import { useState } from "react";
+import { FolderPlus, Pencil, Save, Trash2, X } from "lucide-react";
 import { useCollections, type Collection } from "@/hooks/useCollections";
 import { StateMessage } from "@/components/StateMessage";
 
@@ -21,64 +22,92 @@ export default function CollectionsPage() {
   const [editingId, setEditingId] = useState<string | null>(null);
 
   return (
-    <div className="max-w-4xl mx-auto p-6">
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">收藏夹</h1>
-          <p className="text-sm text-slate-500 mt-1">用收藏夹整理你的图片</p>
-        </div>
-        <button
-          onClick={() => setShowCreate(true)}
-          className="px-4 py-2 bg-slate-900 text-white text-sm rounded hover:bg-slate-800"
-        >
-          + 新建收藏夹
-        </button>
+    <div className="workbench-page">
+      <div className="workbench-container max-w-5xl">
+        <header className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="page-kicker">Library / Collections</p>
+            <h1 className="page-title mt-2">收藏夹</h1>
+            <p className="page-description mt-3">用收藏夹整理你的图片</p>
+          </div>
+          <button onClick={() => setShowCreate(true)} className="btn-primary h-10 gap-2 px-4">
+            <FolderPlus className="h-4 w-4" aria-hidden="true" />
+            新建收藏夹
+          </button>
+        </header>
+
+        {error && <StateMessage variant="error" message={error} className="mb-4" />}
+
+        {loading && collections.length === 0 ? (
+          <StateMessage variant="loading" message="加载收藏夹..." />
+        ) : collections.length === 0 ? (
+          <StateMessage
+            variant="empty"
+            title="还没有收藏夹"
+            description="点击右上角创建第一个收藏夹"
+          />
+        ) : (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {collections.map((c) => (
+              <CollectionCard
+                key={c.id}
+                collection={c}
+                isEditing={editingId === c.id}
+                onEdit={() => setEditingId(c.id)}
+                onCancel={() => setEditingId(null)}
+                onUpdate={async (input) => {
+                  const ok = await updateCollection(c.id, input);
+                  if (ok) setEditingId(null);
+                  return ok;
+                }}
+                onDelete={async () => {
+                  if (confirm(`确定删除收藏夹 "${c.name}"? 其中的图片会变为未分类。`)) {
+                    await deleteCollection(c.id);
+                  }
+                }}
+              />
+            ))}
+          </div>
+        )}
+
+        {showCreate && (
+          <CreateCollectionModal
+            onClose={() => setShowCreate(false)}
+            onCreate={async (input) => {
+              const result = await createCollection(input);
+              if (result) setShowCreate(false);
+              return result !== null;
+            }}
+          />
+        )}
       </div>
+    </div>
+  );
+}
 
-      {error && <StateMessage variant="error" message={error} className="mb-4" />}
-
-      {loading && collections.length === 0 ? (
-        <StateMessage variant="loading" message="加载收藏夹..." />
-      ) : collections.length === 0 ? (
-        <StateMessage
-          variant="empty"
-          title="还没有收藏夹"
-          description="点击右上角创建第一个收藏夹"
+function ColorSwatches({
+  value,
+  onChange,
+  size = "h-7 w-7",
+}: {
+  value: string;
+  onChange: (color: string) => void;
+  size?: string;
+}) {
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {COLORS.map((c) => (
+        <button
+          key={c}
+          type="button"
+          onClick={() => onChange(c)}
+          className={`${size} rounded-full border-2 ${
+            value === c ? "border-[hsl(var(--foreground))]" : "border-transparent"
+          }`}
+          style={{ backgroundColor: c }}
+          aria-label={c}
         />
-      ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {collections.map((c) => (
-            <CollectionCard
-              key={c.id}
-              collection={c}
-              isEditing={editingId === c.id}
-              onEdit={() => setEditingId(c.id)}
-              onCancel={() => setEditingId(null)}
-              onUpdate={async (input) => {
-                const ok = await updateCollection(c.id, input);
-                if (ok) setEditingId(null);
-                return ok;
-              }}
-              onDelete={async () => {
-                if (confirm(`确定删除收藏夹 "${c.name}"? 其中的图片会变为未分类。`)) {
-                  await deleteCollection(c.id);
-                }
-              }}
-            />
-          ))}
-        </div>
-      )}
-
-      {showCreate && (
-        <CreateCollectionModal
-          onClose={() => setShowCreate(false)}
-          onCreate={async (input) => {
-            const result = await createCollection(input);
-            if (result) setShowCreate(false);
-            return result !== null;
-          }}
-        />
-      )}
+      ))}
     </div>
   );
 }
@@ -104,45 +133,33 @@ function CollectionCard({
 
   if (isEditing) {
     return (
-      <div className="bg-white dark:bg-slate-900 rounded-lg border-2 border-slate-300 dark:border-slate-700 p-4 space-y-3">
+      <div className="panel space-y-3 border-[hsl(var(--primary)/0.5)] p-4">
         <input
           type="text"
           value={name}
           onChange={(e) => setName(e.target.value)}
           maxLength={50}
-          className="w-full px-3 py-1.5 text-sm font-medium border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+          className="input font-semibold"
           autoFocus
         />
-        <div className="flex gap-1.5">
-          {COLORS.map((c) => (
-            <button
-              key={c}
-              onClick={() => setColor(c)}
-              className={`w-6 h-6 rounded-full border-2 ${color === c ? "border-slate-900 dark:border-slate-100" : "border-transparent"}`}
-              style={{ backgroundColor: c }}
-              aria-label={c}
-            />
-          ))}
-        </div>
+        <ColorSwatches value={color} onChange={setColor} size="h-6 w-6" />
         <textarea
           value={description}
           onChange={(e) => setDescription(e.target.value)}
           placeholder="描述（可选）"
           rows={2}
           maxLength={200}
-          className="w-full px-3 py-1.5 text-sm border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+          className="input"
         />
-        <div className="flex gap-2 justify-end">
-          <button
-            onClick={onCancel}
-            className="px-3 py-1.5 text-sm border border-slate-200 dark:border-slate-700 rounded"
-          >
+        <div className="flex justify-end gap-2">
+          <button onClick={onCancel} className="btn-secondary h-9 px-3">
             取消
           </button>
           <button
             onClick={() => onUpdate({ name: name.trim(), color, description: description.trim() || undefined })}
-            className="px-3 py-1.5 text-sm bg-slate-900 text-white rounded hover:bg-slate-800"
+            className="btn-primary h-9 gap-2 px-3"
           >
+            <Save className="h-4 w-4" aria-hidden="true" />
             保存
           </button>
         </div>
@@ -151,38 +168,28 @@ function CollectionCard({
   }
 
   return (
-    <div
-      className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-4 hover:border-slate-300 dark:hover:border-slate-600 transition-colors"
-    >
-      <div className="flex items-start justify-between mb-2">
-        <div className="flex items-center gap-2 flex-1 min-w-0">
+    <div className="card card-hover p-4">
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
           <div
-            className="w-4 h-4 rounded-full flex-shrink-0"
+            className="h-4 w-4 flex-shrink-0 rounded-full"
             style={{ backgroundColor: collection.color }}
           />
-          <h3 className="font-semibold text-slate-900 dark:text-slate-100 truncate">
-            {collection.name}
-          </h3>
+          <h2 className="truncate font-semibold text-foreground">{collection.name}</h2>
         </div>
-        <div className="flex gap-1 ml-2 flex-shrink-0">
-          <button
-            onClick={onEdit}
-            className="text-xs text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
-          >
-            编辑
+        <div className="flex flex-shrink-0 gap-1">
+          <button onClick={onEdit} className="icon-button h-8 w-8" aria-label="编辑收藏夹">
+            <Pencil className="h-4 w-4" aria-hidden="true" />
           </button>
-          <button
-            onClick={onDelete}
-            className="text-xs text-slate-500 hover:text-red-500"
-          >
-            删除
+          <button onClick={onDelete} className="icon-button h-8 w-8 hover:text-[hsl(var(--color-error))]" aria-label="删除收藏夹">
+            <Trash2 className="h-4 w-4" aria-hidden="true" />
           </button>
         </div>
       </div>
       {collection.description && (
-        <p className="text-sm text-slate-500 mb-2 line-clamp-2">{collection.description}</p>
+        <p className="mb-3 line-clamp-2 text-sm text-foreground-muted">{collection.description}</p>
       )}
-      <div className="text-xs text-slate-500">
+      <div className="font-utility text-xs text-foreground-muted">
         {collection.itemCount ?? 0} 张图片
       </div>
     </div>
@@ -211,77 +218,64 @@ function CreateCollectionModal({
 
   return (
     <div
-      className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[hsl(var(--foreground)/0.42)] p-4"
       onClick={onClose}
       role="dialog"
       aria-modal="true"
+      aria-labelledby="collection-modal-title"
     >
       <form
         onSubmit={handleSubmit}
-        className="bg-white dark:bg-slate-900 rounded-lg shadow-xl max-w-md w-full p-6 space-y-4"
+        className="panel w-full max-w-md space-y-4 overflow-hidden p-6 shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
-        <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">新建收藏夹</h2>
+        <div className="flex items-start justify-between gap-4">
+          <h2 id="collection-modal-title" className="font-display text-2xl font-semibold text-foreground">
+            新建收藏夹
+          </h2>
+          <button type="button" onClick={onClose} className="icon-button h-9 w-9" aria-label="关闭">
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
 
         <div>
-          <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
-            名称
-          </label>
+          <label className="panel-label mb-1 block">名称</label>
           <input
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="如：白底主图"
             maxLength={50}
-            className="w-full px-3 py-2 border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+            className="input"
             required
             autoFocus
           />
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
-            颜色
-          </label>
-          <div className="flex gap-1.5">
-            {COLORS.map((c) => (
-              <button
-                key={c}
-                type="button"
-                onClick={() => setColor(c)}
-                className={`w-7 h-7 rounded-full border-2 ${color === c ? "border-slate-900 dark:border-slate-100" : "border-transparent"}`}
-                style={{ backgroundColor: c }}
-                aria-label={c}
-              />
-            ))}
-          </div>
+          <label className="panel-label mb-2 block">颜色</label>
+          <ColorSwatches value={color} onChange={setColor} />
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
-            描述（可选）
-          </label>
+          <label className="panel-label mb-1 block">描述（可选）</label>
           <textarea
             value={description}
             onChange={(e) => setDescription(e.target.value)}
             rows={2}
             maxLength={200}
-            className="w-full px-3 py-2 border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+            className="input"
           />
         </div>
 
-        <div className="flex gap-2 justify-end pt-2">
-          <button
-            type="button"
-            onClick={onClose}
-            className="px-4 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded"
-          >
+        <div className="flex justify-end gap-2 pt-2">
+          <button type="button" onClick={onClose} className="btn-secondary h-10 px-4">
             取消
           </button>
           <button
             type="submit"
             disabled={!name.trim() || submitting}
-            className="px-4 py-2 text-sm bg-slate-900 text-white rounded hover:bg-slate-800 disabled:opacity-50"
+            className="btn-primary h-10 px-4 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {submitting ? "创建中..." : "创建"}
           </button>

--- a/frontend/src/components/compare/CompareGrid.tsx
+++ b/frontend/src/components/compare/CompareGrid.tsx
@@ -53,7 +53,7 @@ export default function CompareGrid({
 
   return (
     <div
-      className={`grid ${gridClass} gap-2 w-full h-full bg-stone-900 rounded-lg overflow-hidden`}
+      className={`grid ${gridClass} h-full w-full gap-2 overflow-hidden rounded-md bg-[hsl(var(--foreground))]`}
       onWheel={onWheel}
       onMouseDown={onMouseDown}
       onMouseMove={onMouseMove}
@@ -67,7 +67,7 @@ export default function CompareGrid({
             layout === "single" ? "col-span-1 row-span-1" : ""
           } ${
             layout !== "single" && onSelectImage && idx === currentIndex
-              ? "ring-2 ring-amber-500"
+              ? "ring-2 ring-[hsl(var(--primary))]"
               : ""
           }`}
           onClick={() => onSelectImage?.(idx)}
@@ -85,7 +85,7 @@ export default function CompareGrid({
             draggable={false}
           />
           {/* Image Index Badge */}
-          <div className="absolute top-2 left-2 px-2 py-0.5 bg-black/60 text-white text-xs rounded">
+          <div className="font-utility absolute left-2 top-2 rounded-md bg-[hsl(var(--foreground)/0.7)] px-2 py-0.5 text-xs text-[hsl(var(--background))]">
             {idx + 1}
           </div>
         </div>

--- a/frontend/src/components/compare/CompareToolbar.tsx
+++ b/frontend/src/components/compare/CompareToolbar.tsx
@@ -4,6 +4,21 @@
  * Toolbar for comparison view controls
  */
 
+import {
+  ChevronLeft,
+  ChevronRight,
+  Grid2X2,
+  Maximize2,
+  Minimize2,
+  PanelTop,
+  PanelRight,
+  RotateCcw,
+  Square,
+  X,
+  ZoomIn,
+  ZoomOut,
+} from "lucide-react";
+import type { ComponentType } from "react";
 import type { LayoutMode } from "@/hooks/useCompare";
 
 interface CompareToolbarProps {
@@ -24,11 +39,11 @@ interface CompareToolbarProps {
   onClose: () => void;
 }
 
-const layouts: { value: LayoutMode; label: string; icon: string }[] = [
-  { value: "grid-2x2", label: "2×2", icon: "⊞" },
-  { value: "grid-1x4", label: "1×4", icon: "☰" },
-  { value: "grid-4x1", label: "4×1", icon: "▤" },
-  { value: "single", label: "单图", icon: "□" },
+const layouts: { value: LayoutMode; label: string; icon: ComponentType<{ className?: string }> }[] = [
+  { value: "grid-2x2", label: "2×2", icon: Grid2X2 },
+  { value: "grid-1x4", label: "1×4", icon: PanelTop },
+  { value: "grid-4x1", label: "4×1", icon: PanelRight },
+  { value: "single", label: "单图", icon: Square },
 ];
 
 export default function CompareToolbar({
@@ -49,117 +64,100 @@ export default function CompareToolbar({
   onClose,
 }: CompareToolbarProps) {
   return (
-    <div className="flex items-center justify-between px-4 py-2 bg-stone-800 border-b border-stone-700">
-      {/* Left: Layout Selection */}
+    <div className="flex items-center justify-between border-b border-[hsl(var(--border))] bg-[hsl(var(--card))] px-4 py-2">
       <div className="flex items-center gap-1">
-        {layouts.map((l) => (
-          <button
-            key={l.value}
-            onClick={() => onLayoutChange(l.value)}
-            className={`px-3 py-1.5 text-sm rounded transition-colors ${
-              layout === l.value
-                ? "bg-amber-600 text-white"
-                : "bg-stone-700 text-stone-300 hover:bg-stone-600"
-            }`}
-            title={l.label}
-          >
-            <span className="mr-1">{l.icon}</span>
-            <span className="hidden sm:inline">{l.label}</span>
-          </button>
-        ))}
+        {layouts.map((l) => {
+          const Icon = l.icon;
+          return (
+            <button
+              key={l.value}
+              onClick={() => onLayoutChange(l.value)}
+              className={`segmented-option ${layout === l.value ? "segmented-option-active" : ""}`}
+              title={l.label}
+              aria-label={l.label}
+            >
+              <Icon className="h-4 w-4" />
+              <span className="hidden sm:inline">{l.label}</span>
+            </button>
+          );
+        })}
       </div>
 
-      {/* Center: Zoom Controls */}
       <div className="flex items-center gap-2">
         <button
           onClick={onZoomOut}
           disabled={zoom <= 0.5}
-          className="p-1.5 rounded bg-stone-700 text-stone-300 hover:bg-stone-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          className="icon-button h-8 w-8 disabled:cursor-not-allowed disabled:opacity-50"
           title="缩小"
+          aria-label="缩小"
         >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
-          </svg>
+          <ZoomOut className="h-4 w-4" aria-hidden="true" />
         </button>
-        <span className="text-sm text-stone-300 w-12 text-center">
+        <span className="font-utility w-12 text-center text-sm text-foreground-muted">
           {Math.round(zoom * 100)}%
         </span>
         <button
           onClick={onZoomIn}
           disabled={zoom >= 5}
-          className="p-1.5 rounded bg-stone-700 text-stone-300 hover:bg-stone-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          className="icon-button h-8 w-8 disabled:cursor-not-allowed disabled:opacity-50"
           title="放大"
+          aria-label="放大"
         >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-          </svg>
+          <ZoomIn className="h-4 w-4" aria-hidden="true" />
         </button>
         <button
           onClick={onResetView}
-          className="px-2 py-1 text-xs rounded bg-stone-700 text-stone-300 hover:bg-stone-600 transition-colors"
+          className="btn-secondary h-8 gap-1 px-2 text-xs"
           title="重置视图"
         >
+          <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />
           重置
         </button>
       </div>
 
-      {/* Right: Navigation & Actions */}
       <div className="flex items-center gap-2">
-        {/* Image Navigation (for single view) */}
         {layout === "single" && (
-          <div className="flex items-center gap-1 mr-2">
+          <div className="mr-2 flex items-center gap-1">
             <button
               onClick={onPrev}
               disabled={!canPrev}
-              className="p-1.5 rounded bg-stone-700 text-stone-300 hover:bg-stone-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="icon-button h-8 w-8 disabled:cursor-not-allowed disabled:opacity-50"
               title="上一张"
+              aria-label="上一张"
             >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-              </svg>
+              <ChevronLeft className="h-4 w-4" aria-hidden="true" />
             </button>
-            <span className="text-sm text-stone-300 min-w-[40px] text-center">
+            <span className="font-utility min-w-[40px] text-center text-sm text-foreground-muted">
               {currentIndex + 1}/{totalImages}
             </span>
             <button
               onClick={onNext}
               disabled={!canNext}
-              className="p-1.5 rounded bg-stone-700 text-stone-300 hover:bg-stone-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="icon-button h-8 w-8 disabled:cursor-not-allowed disabled:opacity-50"
               title="下一张"
+              aria-label="下一张"
             >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-              </svg>
+              <ChevronRight className="h-4 w-4" aria-hidden="true" />
             </button>
           </div>
         )}
 
-        {/* Fullscreen */}
         <button
           onClick={onFullscreen}
-          className="p-1.5 rounded bg-stone-700 text-stone-300 hover:bg-stone-600 transition-colors"
+          className="icon-button h-8 w-8"
           title={isFullscreen ? "退出全屏" : "全屏"}
+          aria-label={isFullscreen ? "退出全屏" : "全屏"}
         >
-          {isFullscreen ? (
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 9V4.5M9 9H4.5M9 9L3.75 3.75M9 15v4.5M9 15H4.5M9 15l-5.25 5.25M15 9h4.5M15 9V4.5M15 9l5.25-5.25M15 15h4.5M15 15v4.5m0-4.5l5.25 5.25" />
-            </svg>
-          ) : (
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3.75 3.75v4.5m0-4.5h4.5m-4.5 0L9 9M3.75 20.25v-4.5m0 4.5h4.5m-4.5 0L9 15M20.25 3.75h-4.5m4.5 0v4.5m0-4.5L15 9m5.25 11.25h-4.5m4.5 0v-4.5m0 4.5L15 15" />
-            </svg>
-          )}
+          {isFullscreen ? <Minimize2 className="h-4 w-4" aria-hidden="true" /> : <Maximize2 className="h-4 w-4" aria-hidden="true" />}
         </button>
 
-        {/* Close */}
         <button
           onClick={onClose}
-          className="p-1.5 rounded bg-stone-700 text-stone-300 hover:bg-red-600 hover:text-white transition-colors"
+          className="icon-button h-8 w-8 hover:text-[hsl(var(--color-error))]"
           title="关闭 (ESC)"
+          aria-label="关闭"
         >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-          </svg>
+          <X className="h-4 w-4" aria-hidden="true" />
         </button>
       </div>
     </div>

--- a/frontend/src/components/compare/CompareView.tsx
+++ b/frontend/src/components/compare/CompareView.tsx
@@ -146,11 +146,10 @@ export default function CompareView({ images, onClose }: CompareViewProps) {
   return (
     <div
       ref={containerRef}
-      className={`fixed inset-0 z-50 flex flex-col bg-stone-900 ${
+      className={`fixed inset-0 z-50 flex flex-col bg-[hsl(var(--foreground))] ${
         isFullscreen ? "" : "p-4"
       }`}
     >
-      {/* Toolbar */}
       <CompareToolbar
         layout={layout}
         onLayoutChange={setLayout}
@@ -169,7 +168,6 @@ export default function CompareView({ images, onClose }: CompareViewProps) {
         onClose={onClose}
       />
 
-      {/* Image Grid */}
       <div className="flex-1 p-4 overflow-hidden">
         <CompareGrid
           images={images}
@@ -186,8 +184,7 @@ export default function CompareView({ images, onClose }: CompareViewProps) {
         />
       </div>
 
-      {/* Help Text */}
-      <div className="px-4 py-2 bg-stone-800 border-t border-stone-700 text-xs text-stone-400 flex items-center justify-center gap-4">
+      <div className="flex items-center justify-center gap-4 border-t border-[hsl(var(--border))] bg-[hsl(var(--card))] px-4 py-2 text-xs text-foreground-muted">
         <span>滚轮缩放</span>
         <span>拖拽平移</span>
         <span>← → 切换图片</span>

--- a/frontend/src/components/competitors/CompetitorsPage.tsx
+++ b/frontend/src/components/competitors/CompetitorsPage.tsx
@@ -5,6 +5,7 @@
 "use client";
 
 import { useState } from "react";
+import { ExternalLink, Link2, Plus, Save, Trash2, X } from "lucide-react";
 import { useCompetitors, PLATFORM_LABELS, type Platform, type Competitor } from "@/hooks/useCompetitors";
 import { StateMessage } from "@/components/StateMessage";
 
@@ -61,48 +62,47 @@ function CompetitorForm({
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4" onClick={(e) => e.stopPropagation()}>
-      <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
-        {initial ? "编辑竞品" : "添加竞品"}
-      </h2>
+      <div className="flex items-start justify-between gap-4">
+        <h2 className="font-display text-2xl font-semibold text-foreground">
+          {initial ? "编辑竞品" : "添加竞品"}
+        </h2>
+        <button type="button" onClick={onCancel} className="icon-button h-9 w-9" aria-label="关闭">
+          <X className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
 
       <div>
-        <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
-          名称
-        </label>
+        <label className="panel-label mb-1 block">名称</label>
         <input
           type="text"
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="如：Anker Soundcore 旗舰店"
-          className="w-full px-3 py-2 border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+          className="input"
           maxLength={200}
           required
         />
       </div>
 
       <div>
-        <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
-          链接
-        </label>
+        <label className="panel-label mb-1 block">链接</label>
         <input
           type="url"
           value={url}
           onChange={(e) => setUrl(e.target.value)}
           placeholder="https://..."
-          className="w-full px-3 py-2 border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+          className="input"
           maxLength={2000}
           required
         />
       </div>
 
       <div>
-        <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
-          平台
-        </label>
+        <label className="panel-label mb-1 block">平台</label>
         <select
           value={platform}
           onChange={(e) => setPlatform(e.target.value as Platform)}
-          className="w-full px-3 py-2 border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+          className="input"
         >
           {Object.entries(PLATFORM_LABELS).map(([key, label]) => (
             <option key={key} value={key}>
@@ -113,24 +113,20 @@ function CompetitorForm({
       </div>
 
       <div>
-        <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
-          笔记
-        </label>
+        <label className="panel-label mb-1 block">笔记</label>
         <textarea
           value={notes}
           onChange={(e) => setNotes(e.target.value)}
           placeholder="可记录差异化点、定价、风格观察等"
           rows={3}
-          className="w-full px-3 py-2 border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+          className="input"
           maxLength={2000}
         />
       </div>
 
       <div>
-        <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
-          截图 URL（每行一个，最多 20 个）
-        </label>
-        <div className="flex gap-2 mb-2">
+        <label className="panel-label mb-1 block">截图 URL（每行一个，最多 20 个）</label>
+        <div className="mb-2 flex gap-2">
           <input
             type="url"
             value={screenshotInput}
@@ -142,27 +138,24 @@ function CompetitorForm({
               }
             }}
             placeholder="https://... 回车添加"
-            className="flex-1 px-3 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+            className="input flex-1"
           />
-          <button
-            type="button"
-            onClick={addScreenshot}
-            className="px-3 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded"
-          >
+          <button type="button" onClick={addScreenshot} className="btn-secondary h-10 px-3">
             添加
           </button>
         </div>
         {screenshots.length > 0 && (
           <div className="space-y-1">
             {screenshots.map((s, i) => (
-              <div key={i} className="flex items-center gap-2 text-xs bg-slate-50 dark:bg-slate-800 p-2 rounded">
-                <span className="flex-1 truncate font-mono text-slate-600 dark:text-slate-400">{s}</span>
+              <div key={i} className="panel-muted flex items-center gap-2 p-2 text-xs">
+                <span className="font-utility flex-1 truncate text-foreground-muted">{s}</span>
                 <button
                   type="button"
                   onClick={() => setScreenshots((prev) => prev.filter((_, idx) => idx !== i))}
-                  className="text-slate-400 hover:text-red-500"
+                  className="icon-button h-7 w-7 hover:text-[hsl(var(--color-error))]"
+                  aria-label="移除截图 URL"
                 >
-                  ✕
+                  <X className="h-3.5 w-3.5" aria-hidden="true" />
                 </button>
               </div>
             ))}
@@ -170,19 +163,16 @@ function CompetitorForm({
         )}
       </div>
 
-      <div className="flex gap-2 justify-end pt-2">
-        <button
-          type="button"
-          onClick={onCancel}
-          className="px-4 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded"
-        >
+      <div className="flex justify-end gap-2 pt-2">
+        <button type="button" onClick={onCancel} className="btn-secondary h-10 px-4">
           取消
         </button>
         <button
           type="submit"
           disabled={!name.trim() || !url.trim() || submitting}
-          className="px-4 py-2 text-sm bg-slate-900 text-white rounded hover:bg-slate-800 disabled:opacity-50"
+          className="btn-primary h-10 gap-2 px-4 disabled:cursor-not-allowed disabled:opacity-50"
         >
+          <Save className="h-4 w-4" aria-hidden="true" />
           {submitting ? "保存中..." : "保存"}
         </button>
       </div>
@@ -196,130 +186,132 @@ export default function CompetitorsPage() {
   const [editing, setEditing] = useState<Competitor | null>(null);
 
   return (
-    <div className="max-w-5xl mx-auto p-6">
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">竞品分析</h1>
-          <p className="text-sm text-slate-500 mt-1">记录竞品链接、平台和笔记</p>
-        </div>
-        <button
-          onClick={() => {
-            setEditing(null);
-            setShowForm(true);
-          }}
-          className="px-4 py-2 bg-slate-900 text-white text-sm rounded hover:bg-slate-800"
-        >
-          + 添加竞品
-        </button>
-      </div>
+    <div className="workbench-page">
+      <div className="workbench-container max-w-6xl">
+        <header className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="page-kicker">Market / Competitors</p>
+            <h1 className="page-title mt-2">竞品分析</h1>
+            <p className="page-description mt-3">记录竞品链接、平台和笔记</p>
+          </div>
+          <button
+            onClick={() => {
+              setEditing(null);
+              setShowForm(true);
+            }}
+            className="btn-primary h-10 gap-2 px-4"
+          >
+            <Plus className="h-4 w-4" aria-hidden="true" />
+            添加竞品
+          </button>
+        </header>
 
-      {error && <StateMessage variant="error" message={error} className="mb-4" />}
+        {error && <StateMessage variant="error" message={error} className="mb-4" />}
 
-      {loading && competitors.length === 0 ? (
-        <StateMessage variant="loading" message="加载竞品..." />
-      ) : competitors.length === 0 ? (
-        <StateMessage
-          variant="empty"
-          title="还没有竞品记录"
-          description="点击右上角添加第一个竞品"
-        />
-      ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {competitors.map((c) => (
-            <div
-              key={c.id}
-              className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-4"
-            >
-              <div className="flex items-start justify-between mb-2">
-                <div className="flex-1 min-w-0">
-                  <h3 className="font-semibold text-slate-900 dark:text-slate-100 truncate">{c.name}</h3>
-                  <a
-                    href={c.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-xs text-blue-600 dark:text-blue-400 hover:underline truncate block"
-                  >
-                    {c.url}
-                  </a>
-                </div>
-                <span className="px-2 py-0.5 text-xs rounded bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 ml-2 flex-shrink-0">
-                  {PLATFORM_LABELS[c.platform]}
-                </span>
-              </div>
-              {c.notes && (
-                <p className="text-sm text-slate-600 dark:text-slate-400 mb-2 whitespace-pre-wrap">
-                  {c.notes}
-                </p>
-              )}
-              {c.screenshots.length > 0 && (
-                <div className="grid grid-cols-4 gap-2 mb-2">
-                  {c.screenshots.slice(0, 4).map((s, i) => (
+        {loading && competitors.length === 0 ? (
+          <StateMessage variant="loading" message="加载竞品..." />
+        ) : competitors.length === 0 ? (
+          <StateMessage
+            variant="empty"
+            title="还没有竞品记录"
+            description="点击右上角添加第一个竞品"
+          />
+        ) : (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            {competitors.map((c) => (
+              <article key={c.id} className="card card-hover p-4">
+                <div className="mb-3 flex items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <h2 className="truncate font-semibold text-foreground">{c.name}</h2>
                     <a
-                      key={i}
-                      href={s}
+                      href={c.url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="block aspect-square bg-slate-100 dark:bg-slate-800 rounded overflow-hidden"
+                      className="mt-1 flex items-center gap-1 truncate text-xs font-semibold text-[hsl(var(--primary))] hover:text-[hsl(var(--primary-hover))]"
                     >
-                      <img src={s} alt={`Screenshot ${i + 1}`} className="w-full h-full object-cover" loading="lazy" decoding="async" />
+                      <ExternalLink className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                      {c.url}
                     </a>
-                  ))}
+                  </div>
+                  <span className="status-badge status-badge-neutral flex-shrink-0">
+                    {PLATFORM_LABELS[c.platform]}
+                  </span>
                 </div>
-              )}
-              <div className="flex items-center justify-between pt-2 border-t border-slate-100 dark:border-slate-800">
-                <span className="text-xs text-slate-500">{formatDate(c.createdAt)}</span>
-                <div className="flex gap-2">
-                  <button
-                    onClick={() => {
-                      setEditing(c);
-                      setShowForm(true);
-                    }}
-                    className="text-xs text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
-                  >
-                    编辑
-                  </button>
-                  <button
-                    onClick={async () => {
-                      if (confirm(`确定删除 "${c.name}"?`)) await deleteCompetitor(c.id);
-                    }}
-                    className="text-xs text-slate-500 hover:text-red-500"
-                  >
-                    删除
-                  </button>
+                {c.notes && (
+                  <p className="mb-3 whitespace-pre-wrap text-sm text-foreground-muted">{c.notes}</p>
+                )}
+                {c.screenshots.length > 0 && (
+                  <div className="mb-3 grid grid-cols-4 gap-2">
+                    {c.screenshots.slice(0, 4).map((s, i) => (
+                      <a
+                        key={i}
+                        href={s}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="block aspect-square overflow-hidden rounded-md bg-[hsl(var(--secondary))]"
+                      >
+                        <img src={s} alt={`Screenshot ${i + 1}`} className="h-full w-full object-cover" loading="lazy" decoding="async" />
+                      </a>
+                    ))}
+                  </div>
+                )}
+                <div className="flex items-center justify-between border-t border-[hsl(var(--border))] pt-3">
+                  <span className="font-utility text-xs text-foreground-muted">{formatDate(c.createdAt)}</span>
+                  <div className="flex gap-1">
+                    <button
+                      onClick={() => {
+                        setEditing(c);
+                        setShowForm(true);
+                      }}
+                      className="icon-button h-8 w-8"
+                      aria-label="编辑竞品"
+                    >
+                      <Link2 className="h-4 w-4" aria-hidden="true" />
+                    </button>
+                    <button
+                      onClick={async () => {
+                        if (confirm(`确定删除 "${c.name}"?`)) await deleteCompetitor(c.id);
+                      }}
+                      className="icon-button h-8 w-8 hover:text-[hsl(var(--color-error))]"
+                      aria-label="删除竞品"
+                    >
+                      <Trash2 className="h-4 w-4" aria-hidden="true" />
+                    </button>
+                  </div>
                 </div>
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
-
-      {showForm && (
-        <div
-          className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4 overflow-y-auto"
-          onClick={() => setShowForm(false)}
-          role="dialog"
-          aria-modal="true"
-        >
-          <div className="bg-white dark:bg-slate-900 rounded-lg shadow-xl max-w-2xl w-full p-6 my-8">
-            <CompetitorForm
-              initial={editing ?? undefined}
-              onSubmit={async (data) => {
-                if (editing) {
-                  await updateCompetitor(editing.id, data);
-                } else {
-                  await createCompetitor(data);
-                }
-                setShowForm(false);
-                setEditing(null);
-              }}
-              onCancel={() => {
-                setShowForm(false);
-                setEditing(null);
-              }}
-            />
+              </article>
+            ))}
           </div>
-        </div>
-      )}
+        )}
+
+        {showForm && (
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-[hsl(var(--foreground)/0.42)] p-4"
+            onClick={() => setShowForm(false)}
+            role="dialog"
+            aria-modal="true"
+          >
+            <div className="panel my-8 w-full max-w-2xl p-6 shadow-xl">
+              <CompetitorForm
+                initial={editing ?? undefined}
+                onSubmit={async (data) => {
+                  if (editing) {
+                    await updateCompetitor(editing.id, data);
+                  } else {
+                    await createCompetitor(data);
+                  }
+                  setShowForm(false);
+                  setEditing(null);
+                }}
+                onCancel={() => {
+                  setShowForm(false);
+                  setEditing(null);
+                }}
+              />
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/editor/EditorToolbar.tsx
+++ b/frontend/src/components/editor/EditorToolbar.tsx
@@ -4,6 +4,7 @@
  * Toolbar for image editing operations
  */
 
+import { FlipHorizontal, FlipVertical, RotateCcw, RotateCw, Undo2, Redo2 } from "lucide-react";
 import type { EditState, CropPreset } from "@/hooks/useImageEdit";
 import { CROP_PRESETS } from "@/hooks/useImageEdit";
 
@@ -45,9 +46,9 @@ function Slider({
 }) {
   return (
     <div>
-      <label className="flex items-center justify-between text-xs text-stone-400 mb-1">
+      <label className="mb-1 flex items-center justify-between text-xs text-foreground-muted">
         <span>{label}</span>
-        <span>
+        <span className="font-utility">
           {value > 0 ? "+" : ""}
           {value}
           {unit ?? ""}
@@ -59,7 +60,7 @@ function Slider({
         max={max}
         value={value}
         onChange={(e) => onChange(Number(e.target.value))}
-        className="w-full h-2 bg-stone-700 rounded-lg appearance-none cursor-pointer accent-amber-600"
+        className="range"
       />
     </div>
   );
@@ -86,56 +87,30 @@ export default function EditorToolbar({
   onRedo,
 }: EditorToolbarProps) {
   return (
-    <div className="flex flex-col gap-4 p-4 bg-stone-800 rounded-lg">
-      {/* Undo/Redo & Reset */}
-      <div className="flex gap-2 pb-4 border-b border-stone-700">
-        <button
-          onClick={onUndo}
-          disabled={!canUndo}
-          className="flex items-center gap-2 px-3 py-2 bg-stone-700 hover:bg-stone-600 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-colors"
-          title="撤销 (Ctrl+Z)"
-        >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
-          </svg>
+    <div className="flex flex-col gap-4 p-4">
+      <div className="flex gap-2 border-b border-[hsl(var(--border))] pb-4">
+        <button onClick={onUndo} disabled={!canUndo} className="btn-secondary h-10 gap-2 px-3 disabled:cursor-not-allowed disabled:opacity-50" title="撤销 (Ctrl+Z)">
+          <Undo2 className="h-4 w-4" aria-hidden="true" />
           <span className="text-sm">撤销</span>
         </button>
-        <button
-          onClick={onRedo}
-          disabled={!canRedo}
-          className="flex items-center gap-2 px-3 py-2 bg-stone-700 hover:bg-stone-600 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-colors"
-          title="重做 (Ctrl+Y)"
-        >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 10H11a8 8 0 00-8 8v2m18-10l-6 6m6-6l-6-6" />
-          </svg>
+        <button onClick={onRedo} disabled={!canRedo} className="btn-secondary h-10 gap-2 px-3 disabled:cursor-not-allowed disabled:opacity-50" title="重做 (Ctrl+Y)">
+          <Redo2 className="h-4 w-4" aria-hidden="true" />
           <span className="text-sm">重做</span>
         </button>
-        <button
-          onClick={onReset}
-          className="flex items-center gap-2 px-3 py-2 bg-stone-700 hover:bg-stone-600 rounded-lg transition-colors ml-auto"
-          title="重置所有编辑"
-        >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-          </svg>
+        <button onClick={onReset} className="btn-secondary ml-auto h-10 gap-2 px-3" title="重置所有编辑">
+          <RotateCcw className="h-4 w-4" aria-hidden="true" />
           <span className="text-sm">重置</span>
         </button>
       </div>
 
-      {/* Crop Preset */}
       <div>
-        <h3 className="text-sm font-medium text-stone-300 mb-2">裁剪比例</h3>
+        <h3 className="panel-title mb-2">裁剪比例</h3>
         <div className="grid grid-cols-5 gap-1.5">
           {CROP_PRESETS.map((preset) => (
             <button
               key={preset.value}
               onClick={() => onCropPresetChange(preset.value)}
-              className={`px-2 py-1.5 text-xs rounded transition-colors ${
-                state.cropPreset === preset.value
-                  ? "bg-amber-600 text-white"
-                  : "bg-stone-700 hover:bg-stone-600 text-stone-300"
-              }`}
+              className={`segmented-option ${state.cropPreset === preset.value ? "segmented-option-active" : ""}`}
             >
               {preset.label}
             </button>
@@ -143,56 +118,36 @@ export default function EditorToolbar({
         </div>
       </div>
 
-      {/* Transform */}
       <div>
-        <h3 className="text-sm font-medium text-stone-300 mb-2">变换</h3>
+        <h3 className="panel-title mb-2">变换</h3>
         <div className="grid grid-cols-2 gap-2">
-          <button
-            onClick={onRotateLeft}
-            className="flex items-center justify-center gap-2 px-3 py-2 bg-stone-700 hover:bg-stone-600 rounded-lg transition-colors"
-          >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
-            </svg>
+          <button onClick={onRotateLeft} className="btn-secondary h-10 gap-2 px-3">
+            <RotateCcw className="h-4 w-4" aria-hidden="true" />
             <span className="text-sm">左旋转</span>
           </button>
-          <button
-            onClick={onRotateRight}
-            className="flex items-center justify-center gap-2 px-3 py-2 bg-stone-700 hover:bg-stone-600 rounded-lg transition-colors"
-          >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 10H11a8 8 0 00-8 8v2m18-10l-6 6m6-6l-6-6" />
-            </svg>
+          <button onClick={onRotateRight} className="btn-secondary h-10 gap-2 px-3">
+            <RotateCw className="h-4 w-4" aria-hidden="true" />
             <span className="text-sm">右旋转</span>
           </button>
           <button
             onClick={onFlipHorizontal}
-            className={`flex items-center justify-center gap-2 px-3 py-2 rounded-lg transition-colors ${
-              state.flipHorizontal ? "bg-amber-600 hover:bg-amber-500" : "bg-stone-700 hover:bg-stone-600"
-            }`}
+            className={`h-10 gap-2 px-3 ${state.flipHorizontal ? "btn-primary" : "btn-secondary"}`}
           >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
-            </svg>
+            <FlipHorizontal className="h-4 w-4" aria-hidden="true" />
             <span className="text-sm">水平翻转</span>
           </button>
           <button
             onClick={onFlipVertical}
-            className={`flex items-center justify-center gap-2 px-3 py-2 rounded-lg transition-colors ${
-              state.flipVertical ? "bg-amber-600 hover:bg-amber-500" : "bg-stone-700 hover:bg-stone-600"
-            }`}
+            className={`h-10 gap-2 px-3 ${state.flipVertical ? "btn-primary" : "btn-secondary"}`}
           >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 17H4m0 0l4-4m-4 4l4 4m4-12h12m0 0l-4 4m4-4l-4-4" />
-            </svg>
+            <FlipVertical className="h-4 w-4" aria-hidden="true" />
             <span className="text-sm">垂直翻转</span>
           </button>
         </div>
       </div>
 
-      {/* Adjustments */}
       <div>
-        <h3 className="text-sm font-medium text-stone-300 mb-2">基础调整</h3>
+        <h3 className="panel-title mb-2">基础调整</h3>
         <div className="space-y-3">
           <Slider label="亮度" value={state.brightness} min={0} max={200} unit="%" onChange={onBrightnessChange} />
           <Slider label="对比度" value={state.contrast} min={0} max={200} unit="%" onChange={onContrastChange} />
@@ -200,33 +155,30 @@ export default function EditorToolbar({
         </div>
       </div>
 
-      {/* Color */}
       <div>
-        <h3 className="text-sm font-medium text-stone-300 mb-2">色彩</h3>
+        <h3 className="panel-title mb-2">色彩</h3>
         <div className="space-y-3">
           <Slider label="色温" value={state.colorTemp} min={-100} max={100} onChange={onColorTempChange} />
           <Slider label="色调" value={state.tint} min={-100} max={100} onChange={onTintChange} />
         </div>
       </div>
 
-      {/* Sharpen */}
       <div>
-        <h3 className="text-sm font-medium text-stone-300 mb-2">细节</h3>
+        <h3 className="panel-title mb-2">细节</h3>
         <Slider label="锐化" value={state.sharpen} min={0} max={100} unit="%" onChange={onSharpenChange} />
       </div>
 
-      {/* Watermark */}
       <div>
-        <h3 className="text-sm font-medium text-stone-300 mb-2">水印</h3>
+        <h3 className="panel-title mb-2">水印</h3>
         <div className="space-y-2">
           <label className="flex items-center gap-2">
             <input
               type="checkbox"
               checked={state.watermarkEnabled}
               onChange={(e) => onWatermarkChange(state.watermarkText, e.target.checked)}
-              className="w-4 h-4 rounded border-stone-600 bg-stone-700 text-amber-600 focus:ring-amber-600"
+              className="h-4 w-4 rounded border-[hsl(var(--border))] text-[hsl(var(--primary))] focus:ring-[hsl(var(--primary)/0.28)]"
             />
-            <span className="text-sm text-stone-300">启用文字水印</span>
+            <span className="text-sm text-foreground">启用文字水印</span>
           </label>
           {state.watermarkEnabled && (
             <input
@@ -234,7 +186,7 @@ export default function EditorToolbar({
               value={state.watermarkText}
               onChange={(e) => onWatermarkChange(e.target.value, true)}
               placeholder="输入水印文字"
-              className="w-full px-3 py-2 bg-stone-700 border border-stone-600 rounded-lg text-sm text-stone-100 placeholder-stone-500 focus:outline-none focus:ring-2 focus:ring-amber-600"
+              className="input"
             />
           )}
         </div>

--- a/frontend/src/components/editor/ImageEditor.tsx
+++ b/frontend/src/components/editor/ImageEditor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
+import { Save, X } from "lucide-react";
 import { useImageEdit } from "@/hooks/useImageEdit";
 import EditorToolbar from "./EditorToolbar";
 
@@ -78,32 +79,31 @@ export default function ImageEditor({ imageUrl, onSave, onClose }: ImageEditorPr
   };
 
   return (
-    <div className="fixed inset-0 bg-black/90 z-50 flex items-center justify-center" role="dialog" aria-modal="true">
-      <div className="w-full h-full max-w-7xl max-h-[90vh] bg-stone-900 rounded-lg overflow-hidden flex flex-col">
-        {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-stone-700">
-          <h2 className="text-xl font-semibold text-stone-100">图片编辑器</h2>
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[hsl(var(--foreground)/0.78)]" role="dialog" aria-modal="true">
+      <div className="panel flex h-full max-h-[90vh] w-full max-w-7xl flex-col overflow-hidden">
+        <div className="flex items-center justify-between border-b border-[hsl(var(--border))] px-6 py-4">
+          <h2 className="font-display text-2xl font-semibold text-foreground">图片编辑器</h2>
           <div className="flex gap-3">
             <button
               onClick={onClose}
-              className="px-4 py-2 text-stone-300 hover:text-stone-100 transition-colors"
+              className="btn-secondary h-10 gap-2 px-4"
             >
+              <X className="h-4 w-4" aria-hidden="true" />
               取消
             </button>
             <button
               onClick={handleSave}
               disabled={isSaving}
-              className="px-6 py-2 bg-amber-600 hover:bg-amber-500 disabled:bg-amber-800 disabled:cursor-not-allowed text-white rounded-lg transition-colors"
+              className="btn-primary h-10 gap-2 px-6 disabled:cursor-not-allowed disabled:opacity-50"
             >
+              <Save className="h-4 w-4" aria-hidden="true" />
               {isSaving ? "保存中..." : "保存"}
             </button>
           </div>
         </div>
 
-        {/* Main Content */}
         <div className="flex-1 flex overflow-hidden">
-          {/* Canvas Area */}
-          <div className="flex-1 flex items-center justify-center p-8 bg-stone-950 overflow-auto">
+          <div className="flex flex-1 items-center justify-center overflow-auto bg-[hsl(var(--foreground))] p-8">
             <div className="relative">
               <img
                 src={imageUrl}
@@ -129,8 +129,7 @@ export default function ImageEditor({ imageUrl, onSave, onClose }: ImageEditorPr
             </div>
           </div>
 
-          {/* Toolbar Sidebar */}
-          <div className="w-80 border-l border-stone-700 overflow-y-auto">
+          <div className="w-80 overflow-y-auto border-l border-[hsl(var(--border))] bg-[hsl(var(--card))]">
             <EditorToolbar
               state={state}
               canUndo={canUndo}
@@ -154,8 +153,7 @@ export default function ImageEditor({ imageUrl, onSave, onClose }: ImageEditorPr
           </div>
         </div>
 
-        {/* Footer Info */}
-        <div className="px-6 py-3 border-t border-stone-700 text-xs text-stone-500">
+        <div className="border-t border-[hsl(var(--border))] px-6 py-3 text-xs text-foreground-muted">
           <span>快捷键: Ctrl+Z 撤销 | Ctrl+Y/Ctrl+Shift+Z 重做</span>
         </div>
       </div>

--- a/frontend/src/components/errors/ErrorsDashboard.tsx
+++ b/frontend/src/components/errors/ErrorsDashboard.tsx
@@ -6,19 +6,21 @@
 
 "use client";
 
-import { useState, useMemo } from "react";
+import { useMemo, useState } from "react";
+import { RefreshCw, Trash2, X } from "lucide-react";
 import { useErrorDashboard, type ErrorRecord } from "@/hooks/useErrorDashboard";
+import { StateMessage } from "@/components/StateMessage";
 
 type SeverityFilter = "" | "critical" | "high" | "medium" | "low";
 type TypeFilter = "" | "network" | "validation" | "authentication" | "business_logic" | "runtime" | "unknown";
 type ModuleFilter = "" | "api" | "frontend" | "worker" | "database";
 type RangeFilter = "24h" | "7d" | "30d";
 
-const SEVERITY_COLORS: Record<string, string> = {
-  critical: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300",
-  high: "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300",
-  medium: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-300",
-  low: "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300",
+const SEVERITY_BADGES: Record<string, string> = {
+  critical: "status-badge-error",
+  high: "status-badge-error",
+  medium: "status-badge-warning",
+  low: "status-badge-neutral",
 };
 
 function formatTime(dateString: string): string {
@@ -48,60 +50,51 @@ function ErrorDetailPanel({
   }, [error.context]);
 
   return (
-    <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4" onClick={onClose} role="dialog" aria-modal="true">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[hsl(var(--foreground)/0.42)] p-4" onClick={onClose} role="dialog" aria-modal="true">
       <div
-        className="bg-white dark:bg-slate-900 rounded-lg shadow-xl max-w-3xl w-full max-h-[80vh] overflow-y-auto"
+        className="panel max-h-[80vh] w-full max-w-3xl overflow-y-auto shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="p-6 border-b border-slate-200 dark:border-slate-700 flex items-start justify-between">
+        <div className="flex items-start justify-between border-b border-[hsl(var(--border))] p-6">
           <div>
-            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
-              错误详情
-            </h2>
-            <p className="text-xs text-slate-500 mt-1 font-mono">{error.hash}</p>
+            <p className="page-kicker">Error detail</p>
+            <h2 className="font-display mt-1 text-2xl font-semibold text-foreground">错误详情</h2>
+            <p className="font-utility mt-1 text-xs text-foreground-muted">{error.hash}</p>
           </div>
-          <button
-            onClick={onClose}
-            className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200"
-            aria-label="Close"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
+          <button onClick={onClose} className="icon-button h-9 w-9" aria-label="Close">
+            <X className="h-4 w-4" aria-hidden="true" />
           </button>
         </div>
 
-        <div className="p-6 space-y-4">
+        <div className="space-y-4 p-6">
           <div>
-            <h3 className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">消息</h3>
-            <p className="text-sm text-slate-900 dark:text-slate-100 break-words">{error.message}</p>
+            <h3 className="panel-label mb-2">消息</h3>
+            <p className="break-words text-sm text-foreground">{error.message}</p>
           </div>
 
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
+          <div className="grid grid-cols-2 gap-4 text-sm sm:grid-cols-4">
             <div>
-              <div className="text-xs text-slate-500">严重程度</div>
-              <span className={`inline-block mt-1 px-2 py-0.5 rounded text-xs font-medium ${SEVERITY_COLORS[error.severity]}`}>
-                {error.severity}
-              </span>
+              <div className="panel-label">严重程度</div>
+              <span className={`status-badge mt-1 ${SEVERITY_BADGES[error.severity]}`}>{error.severity}</span>
             </div>
             <div>
-              <div className="text-xs text-slate-500">类型</div>
-              <div className="mt-1 text-slate-900 dark:text-slate-100">{error.type}</div>
+              <div className="panel-label">类型</div>
+              <div className="mt-1 text-foreground">{error.type}</div>
             </div>
             <div>
-              <div className="text-xs text-slate-500">模块</div>
-              <div className="mt-1 text-slate-900 dark:text-slate-100">{error.module}</div>
+              <div className="panel-label">模块</div>
+              <div className="mt-1 text-foreground">{error.module}</div>
             </div>
             <div>
-              <div className="text-xs text-slate-500">出现次数</div>
-              <div className="mt-1 text-slate-900 dark:text-slate-100 font-mono">{error.occurrences}</div>
+              <div className="panel-label">出现次数</div>
+              <div className="font-utility mt-1 text-foreground">{error.occurrences}</div>
             </div>
           </div>
 
           {error.stack && (
             <div>
-              <h3 className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">堆栈</h3>
-              <pre className="text-xs bg-slate-50 dark:bg-slate-800 p-3 rounded overflow-x-auto whitespace-pre-wrap break-all">
+              <h3 className="panel-label mb-2">堆栈</h3>
+              <pre className="panel-muted font-utility overflow-x-auto whitespace-pre-wrap break-all p-3 text-xs">
                 {error.stack}
               </pre>
             </div>
@@ -109,14 +102,14 @@ function ErrorDetailPanel({
 
           {contextObj && (
             <div>
-              <h3 className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">上下文</h3>
-              <pre className="text-xs bg-slate-50 dark:bg-slate-800 p-3 rounded overflow-x-auto">
+              <h3 className="panel-label mb-2">上下文</h3>
+              <pre className="panel-muted font-utility overflow-x-auto p-3 text-xs">
                 {JSON.stringify(contextObj, null, 2)}
               </pre>
             </div>
           )}
 
-          <div className="grid grid-cols-2 gap-4 text-xs text-slate-500 pt-2 border-t border-slate-200 dark:border-slate-700">
+          <div className="grid grid-cols-2 gap-4 border-t border-[hsl(var(--border))] pt-2 text-xs text-foreground-muted">
             <div>首次出现: {formatTime(error.createdAt)}</div>
             <div>最近出现: {formatTime(error.lastSeenAt)}</div>
           </div>
@@ -170,212 +163,199 @@ export default function ErrorsDashboard() {
   };
 
   return (
-    <div className="max-w-7xl mx-auto p-6">
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">错误追踪</h1>
-          <p className="text-sm text-slate-500 mt-1">监控前端和后端错误</p>
-        </div>
-        <button
-          onClick={refetch}
-          className="px-3 py-1.5 text-sm bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 rounded"
-        >
-          刷新
-        </button>
-      </div>
-
-      {/* Stats */}
-      {stats && (
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6">
-          <div className="bg-white dark:bg-slate-900 p-4 rounded-lg border border-slate-200 dark:border-slate-700">
-            <div className="text-xs text-slate-500">总错误数</div>
-            <div className="text-2xl font-semibold mt-1 text-slate-900 dark:text-slate-100">{stats.total}</div>
+    <div className="workbench-page">
+      <div className="workbench-container">
+        <header className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="page-kicker">Operations / Errors</p>
+            <h1 className="page-title mt-2">错误追踪</h1>
+            <p className="page-description mt-3">监控前端和后端错误</p>
           </div>
-          {(["critical", "high", "medium", "low"] as const).map((sev) => (
-            <div key={sev} className="bg-white dark:bg-slate-900 p-4 rounded-lg border border-slate-200 dark:border-slate-700">
-              <div className="text-xs text-slate-500">{sev}</div>
-              <div className="text-2xl font-semibold mt-1 text-slate-900 dark:text-slate-100">
-                {stats.bySeverity[sev] ?? 0}
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
-
-      {/* Filters */}
-      <div className="bg-white dark:bg-slate-900 p-4 rounded-lg border border-slate-200 dark:border-slate-700 mb-4 flex flex-wrap gap-3">
-        <select
-          value={range}
-          onChange={(e) => {
-            setRange(e.target.value as RangeFilter);
-            setPage(1);
-          }}
-          className="px-3 py-1.5 text-sm border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
-        >
-          <option value="24h">最近 24 小时</option>
-          <option value="7d">最近 7 天</option>
-          <option value="30d">最近 30 天</option>
-        </select>
-        <select
-          value={severity}
-          onChange={(e) => {
-            setSeverity(e.target.value as SeverityFilter);
-            setPage(1);
-          }}
-          className="px-3 py-1.5 text-sm border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
-        >
-          <option value="">所有严重程度</option>
-          <option value="critical">critical</option>
-          <option value="high">high</option>
-          <option value="medium">medium</option>
-          <option value="low">low</option>
-        </select>
-        <select
-          value={type}
-          onChange={(e) => {
-            setType(e.target.value as TypeFilter);
-            setPage(1);
-          }}
-          className="px-3 py-1.5 text-sm border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
-        >
-          <option value="">所有类型</option>
-          <option value="network">network</option>
-          <option value="validation">validation</option>
-          <option value="authentication">authentication</option>
-          <option value="business_logic">business_logic</option>
-          <option value="runtime">runtime</option>
-          <option value="unknown">unknown</option>
-        </select>
-        <select
-          value={module}
-          onChange={(e) => {
-            setModule(e.target.value as ModuleFilter);
-            setPage(1);
-          }}
-          className="px-3 py-1.5 text-sm border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
-        >
-          <option value="">所有模块</option>
-          <option value="api">api</option>
-          <option value="frontend">frontend</option>
-          <option value="worker">worker</option>
-          <option value="database">database</option>
-        </select>
-        {selectedIds.size > 0 && (
-          <button
-            onClick={handleBatchDelete}
-            className="ml-auto px-3 py-1.5 text-sm bg-red-600 text-white rounded hover:bg-red-700"
-          >
-            删除选中 ({selectedIds.size})
+          <button onClick={refetch} className="btn-secondary h-10 gap-2 px-4">
+            <RefreshCw className="h-4 w-4" aria-hidden="true" />
+            刷新
           </button>
+        </header>
+
+        {stats && (
+          <div className="mb-6 grid grid-cols-2 gap-4 sm:grid-cols-5">
+            <div className="panel p-4">
+              <div className="panel-label">总错误数</div>
+              <div className="font-utility mt-1 text-2xl font-semibold text-foreground">{stats.total}</div>
+            </div>
+            {(["critical", "high", "medium", "low"] as const).map((sev) => (
+              <div key={sev} className="panel p-4">
+                <div className="panel-label">{sev}</div>
+                <div className="font-utility mt-1 text-2xl font-semibold text-foreground">
+                  {stats.bySeverity[sev] ?? 0}
+                </div>
+              </div>
+            ))}
+          </div>
         )}
-      </div>
 
-      {/* Error List */}
-      {error && (
-        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-4 rounded-lg mb-4">
-          <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
+        <div className="panel mb-4 flex flex-wrap gap-3 p-4">
+          <select
+            value={range}
+            onChange={(e) => {
+              setRange(e.target.value as RangeFilter);
+              setPage(1);
+            }}
+            className="input w-auto py-1.5"
+          >
+            <option value="24h">最近 24 小时</option>
+            <option value="7d">最近 7 天</option>
+            <option value="30d">最近 30 天</option>
+          </select>
+          <select
+            value={severity}
+            onChange={(e) => {
+              setSeverity(e.target.value as SeverityFilter);
+              setPage(1);
+            }}
+            className="input w-auto py-1.5"
+          >
+            <option value="">所有严重程度</option>
+            <option value="critical">critical</option>
+            <option value="high">high</option>
+            <option value="medium">medium</option>
+            <option value="low">low</option>
+          </select>
+          <select
+            value={type}
+            onChange={(e) => {
+              setType(e.target.value as TypeFilter);
+              setPage(1);
+            }}
+            className="input w-auto py-1.5"
+          >
+            <option value="">所有类型</option>
+            <option value="network">network</option>
+            <option value="validation">validation</option>
+            <option value="authentication">authentication</option>
+            <option value="business_logic">business_logic</option>
+            <option value="runtime">runtime</option>
+            <option value="unknown">unknown</option>
+          </select>
+          <select
+            value={module}
+            onChange={(e) => {
+              setModule(e.target.value as ModuleFilter);
+              setPage(1);
+            }}
+            className="input w-auto py-1.5"
+          >
+            <option value="">所有模块</option>
+            <option value="api">api</option>
+            <option value="frontend">frontend</option>
+            <option value="worker">worker</option>
+            <option value="database">database</option>
+          </select>
+          {selectedIds.size > 0 && (
+            <button onClick={handleBatchDelete} className="btn-primary ml-auto h-10 gap-2 bg-[hsl(var(--color-error))] px-3 hover:bg-[hsl(var(--color-error))]">
+              <Trash2 className="h-4 w-4" aria-hidden="true" />
+              删除选中 ({selectedIds.size})
+            </button>
+          )}
         </div>
-      )}
 
-      {loading && !list ? (
-        <div className="text-center py-12 text-slate-500">加载中...</div>
-      ) : list && list.data.length === 0 ? (
-        <div className="text-center py-12 text-slate-500">暂无错误 🎉</div>
-      ) : (
-        list && (
-          <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead className="bg-slate-50 dark:bg-slate-800 text-xs uppercase text-slate-500">
-                <tr>
-                  <th className="px-4 py-3 text-left w-10">
-                    <input
-                      type="checkbox"
-                      checked={selectedIds.size === list.data.length && list.data.length > 0}
-                      onChange={toggleSelectAll}
-                    />
-                  </th>
-                  <th className="px-4 py-3 text-left">严重程度</th>
-                  <th className="px-4 py-3 text-left">类型</th>
-                  <th className="px-4 py-3 text-left">模块</th>
-                  <th className="px-4 py-3 text-left">消息</th>
-                  <th className="px-4 py-3 text-right">次数</th>
-                  <th className="px-4 py-3 text-left">最近</th>
-                  <th className="px-4 py-3 text-right w-20">操作</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-slate-200 dark:divide-slate-700">
-                {list.data.map((err) => (
-                  <tr
-                    key={err.id}
-                    className="hover:bg-slate-50 dark:hover:bg-slate-800/50 cursor-pointer"
-                    onClick={() => setSelected(err)}
-                  >
-                    <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
+        {error && (
+          <div className="error-banner mb-4">
+            <p>{error}</p>
+          </div>
+        )}
+
+        {loading && !list ? (
+          <StateMessage variant="loading" message="加载错误..." />
+        ) : list && list.data.length === 0 ? (
+          <StateMessage variant="empty" title="暂无错误" description="当前筛选条件下没有错误记录" />
+        ) : (
+          list && (
+            <div className="table-shell">
+              <table className="w-full text-sm">
+                <thead className="bg-[hsl(var(--secondary)/0.72)] text-xs uppercase text-foreground-muted">
+                  <tr>
+                    <th className="w-10 px-4 py-3 text-left">
                       <input
                         type="checkbox"
-                        checked={selectedIds.has(err.id)}
-                        onChange={() => toggleSelect(err.id)}
+                        checked={selectedIds.size === list.data.length && list.data.length > 0}
+                        onChange={toggleSelectAll}
+                        aria-label="选择全部错误"
                       />
-                    </td>
-                    <td className="px-4 py-3">
-                      <span className={`px-2 py-0.5 rounded text-xs font-medium ${SEVERITY_COLORS[err.severity]}`}>
-                        {err.severity}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 text-slate-600 dark:text-slate-400">{err.type}</td>
-                    <td className="px-4 py-3 text-slate-600 dark:text-slate-400">{err.module}</td>
-                    <td className="px-4 py-3 max-w-md truncate text-slate-900 dark:text-slate-100">
-                      {err.message}
-                    </td>
-                    <td className="px-4 py-3 text-right font-mono">{err.occurrences}</td>
-                    <td className="px-4 py-3 text-slate-500 text-xs">{formatTime(err.lastSeenAt)}</td>
-                    <td className="px-4 py-3 text-right" onClick={(e) => e.stopPropagation()}>
-                      <button
-                        onClick={async () => {
-                          if (confirm("确定删除？")) await deleteOne(err.id);
-                        }}
-                        className="text-slate-400 hover:text-red-500"
-                        aria-label="Delete"
-                      >
-                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3" />
-                        </svg>
-                      </button>
-                    </td>
+                    </th>
+                    <th className="px-4 py-3 text-left">严重程度</th>
+                    <th className="px-4 py-3 text-left">类型</th>
+                    <th className="px-4 py-3 text-left">模块</th>
+                    <th className="px-4 py-3 text-left">消息</th>
+                    <th className="px-4 py-3 text-right">次数</th>
+                    <th className="px-4 py-3 text-left">最近</th>
+                    <th className="w-20 px-4 py-3 text-right">操作</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {list.data.map((err) => (
+                    <tr key={err.id} className="data-row cursor-pointer" onClick={() => setSelected(err)}>
+                      <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
+                        <input
+                          type="checkbox"
+                          checked={selectedIds.has(err.id)}
+                          onChange={() => toggleSelect(err.id)}
+                          aria-label="选择错误"
+                        />
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className={`status-badge ${SEVERITY_BADGES[err.severity]}`}>{err.severity}</span>
+                      </td>
+                      <td className="px-4 py-3 text-foreground-muted">{err.type}</td>
+                      <td className="px-4 py-3 text-foreground-muted">{err.module}</td>
+                      <td className="max-w-md truncate px-4 py-3 text-foreground">{err.message}</td>
+                      <td className="font-utility px-4 py-3 text-right">{err.occurrences}</td>
+                      <td className="font-utility px-4 py-3 text-xs text-foreground-muted">{formatTime(err.lastSeenAt)}</td>
+                      <td className="px-4 py-3 text-right" onClick={(e) => e.stopPropagation()}>
+                        <button
+                          onClick={async () => {
+                            if (confirm("确定删除？")) await deleteOne(err.id);
+                          }}
+                          className="icon-button h-8 w-8 hover:text-[hsl(var(--color-error))]"
+                          aria-label="Delete"
+                        >
+                          <Trash2 className="h-4 w-4" aria-hidden="true" />
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
 
-            {/* Pagination */}
-            {list.pagination.totalPages > 1 && (
-              <div className="px-4 py-3 border-t border-slate-200 dark:border-slate-700 flex items-center justify-between text-sm">
-                <div className="text-slate-500">
-                  第 {list.pagination.page} / {list.pagination.totalPages} 页 · 共 {list.pagination.total} 条
+              {list.pagination.totalPages > 1 && (
+                <div className="flex items-center justify-between border-t border-[hsl(var(--border))] px-4 py-3 text-sm">
+                  <div className="text-foreground-muted">
+                    第 {list.pagination.page} / {list.pagination.totalPages} 页 · 共 {list.pagination.total} 条
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => setPage((p) => Math.max(1, p - 1))}
+                      disabled={page === 1}
+                      className="btn-secondary h-9 px-3 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      上一页
+                    </button>
+                    <button
+                      onClick={() => setPage((p) => Math.min(list.pagination.totalPages, p + 1))}
+                      disabled={page === list.pagination.totalPages}
+                      className="btn-secondary h-9 px-3 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      下一页
+                    </button>
+                  </div>
                 </div>
-                <div className="flex gap-2">
-                  <button
-                    onClick={() => setPage((p) => Math.max(1, p - 1))}
-                    disabled={page === 1}
-                    className="px-3 py-1 border border-slate-200 dark:border-slate-700 rounded disabled:opacity-50"
-                  >
-                    上一页
-                  </button>
-                  <button
-                    onClick={() => setPage((p) => Math.min(list.pagination.totalPages, p + 1))}
-                    disabled={page === list.pagination.totalPages}
-                    className="px-3 py-1 border border-slate-200 dark:border-slate-700 rounded disabled:opacity-50"
-                  >
-                    下一页
-                  </button>
-                </div>
-              </div>
-            )}
-          </div>
-        )
-      )}
+              )}
+            </div>
+          )
+        )}
 
-      {selected && <ErrorDetailPanel error={selected} onClose={() => setSelected(null)} />}
+        {selected && <ErrorDetailPanel error={selected} onClose={() => setSelected(null)} />}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/feedback/FeedbackForm.tsx
+++ b/frontend/src/components/feedback/FeedbackForm.tsx
@@ -102,15 +102,15 @@ export default function FeedbackForm({ generationId }: FeedbackFormProps) {
   };
 
   return (
-    <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-4">
+    <div className="panel p-4">
       <div className="flex items-center justify-between mb-3">
-        <h3 className="text-sm font-medium text-slate-700 dark:text-slate-300">用户反馈</h3>
+        <h3 className="panel-title">用户反馈</h3>
         {stats && stats.count > 0 && (
-          <div className="flex items-center gap-2 text-sm text-slate-500">
+          <div className="flex items-center gap-2 text-sm text-foreground-muted">
             <span>{stats.count} 条评价</span>
             <span className="flex items-center gap-1">
-              <span className="text-yellow-500">★</span>
-              <span className="font-medium text-slate-700 dark:text-slate-300">
+              <span className="font-medium text-[hsl(var(--accent))]">★</span>
+              <span className="font-medium text-foreground">
                 {stats.avgRating?.toFixed(1) ?? "-"}
               </span>
             </span>
@@ -119,27 +119,27 @@ export default function FeedbackForm({ generationId }: FeedbackFormProps) {
       </div>
 
       {error && (
-        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-2 rounded mb-3">
-          <p className="text-xs text-red-700 dark:text-red-300">{error}</p>
+        <div className="error-banner mb-3 p-2">
+          <p className="text-xs">{error}</p>
         </div>
       )}
 
       {showThanks ? (
-        <p className="text-sm text-green-600 dark:text-green-400 text-center py-2">感谢您的反馈！</p>
+        <p className="success-banner py-2 text-center text-sm">感谢您的反馈！</p>
       ) : showForm ? (
         <form onSubmit={handleSubmit}>
           <div className="mb-3">
-            <label className="block text-xs text-slate-500 mb-1">评分</label>
+            <label className="panel-label mb-1 block">评分</label>
             <RatingStars value={rating} onChange={setRating} />
           </div>
           <div className="mb-3">
-            <label className="block text-xs text-slate-500 mb-1">评论（可选）</label>
+            <label className="panel-label mb-1 block">评论（可选）</label>
             <textarea
               value={comment}
               onChange={(e) => setComment(e.target.value)}
               rows={3}
               maxLength={2000}
-              className="w-full px-3 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+              className="input"
               placeholder="说说你的感受..."
             />
           </div>
@@ -147,14 +147,14 @@ export default function FeedbackForm({ generationId }: FeedbackFormProps) {
             <button
               type="button"
               onClick={() => setShowForm(false)}
-              className="px-3 py-1.5 text-sm border border-slate-200 dark:border-slate-700 rounded"
+              className="btn-secondary h-9 px-3"
             >
               取消
             </button>
             <button
               type="submit"
               disabled={rating === 0 || submitting}
-              className="px-3 py-1.5 text-sm bg-slate-900 text-white rounded hover:bg-slate-800 disabled:opacity-50"
+              className="btn-primary h-9 px-3 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {submitting ? "提交中..." : "提交"}
             </button>
@@ -163,27 +163,27 @@ export default function FeedbackForm({ generationId }: FeedbackFormProps) {
       ) : (
         <button
           onClick={() => setShowForm(true)}
-          className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+          className="text-sm font-semibold text-[hsl(var(--primary))] hover:text-[hsl(var(--primary-hover))]"
         >
-          提交反馈 →
+          提交反馈
         </button>
       )}
 
       {loading && list.length === 0 ? (
-        <p className="text-xs text-slate-400 mt-3">加载反馈...</p>
+        <p className="mt-3 text-xs text-foreground-muted">加载反馈...</p>
       ) : list.length > 0 ? (
         <div className="mt-4 space-y-2">
           {list.slice(0, 5).map((f) => (
-            <div key={f.id} className="border-t border-slate-100 dark:border-slate-800 pt-2">
+            <div key={f.id} className="border-t border-[hsl(var(--border))] pt-2">
               <div className="flex items-center gap-2 mb-1">
                 <RatingStars value={f.rating} readonly />
-                <span className="text-xs text-slate-400">{formatDate(f.createdAt)}</span>
+                <span className="font-utility text-xs text-foreground-muted">{formatDate(f.createdAt)}</span>
               </div>
-              {f.comment && <p className="text-sm text-slate-600 dark:text-slate-400">{f.comment}</p>}
+              {f.comment && <p className="text-sm text-foreground-muted">{f.comment}</p>}
             </div>
           ))}
           {list.length > 5 && (
-            <p className="text-xs text-slate-400 text-center">还有 {list.length - 5} 条反馈...</p>
+            <p className="text-center text-xs text-foreground-muted">还有 {list.length - 5} 条反馈...</p>
           )}
         </div>
       ) : null}

--- a/frontend/src/components/keys/ApiKeysPage.tsx
+++ b/frontend/src/components/keys/ApiKeysPage.tsx
@@ -7,6 +7,7 @@
 "use client";
 
 import { useState } from "react";
+import { AlertTriangle, Ban, Check, Copy, KeyRound, Plus, X } from "lucide-react";
 import { useApiKeys } from "@/hooks/useApiKeys";
 import { StateMessage } from "@/components/StateMessage";
 
@@ -37,10 +38,14 @@ function CopyableKey({ value }: { value: string }) {
   return (
     <button
       onClick={handleCopy}
-      className="inline-flex items-center gap-2 px-2 py-1 text-xs font-mono bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 rounded"
+      className="panel-muted inline-flex max-w-full items-center gap-2 px-2 py-1 text-xs"
     >
       <code className="break-all">{value}</code>
-      <span className="text-slate-500">{copied ? "✓" : "📋"}</span>
+      {copied ? (
+        <Check className="h-3.5 w-3.5 text-[hsl(var(--color-success))]" aria-hidden="true" />
+      ) : (
+        <Copy className="h-3.5 w-3.5 text-foreground-muted" aria-hidden="true" />
+      )}
     </button>
   );
 }
@@ -56,41 +61,48 @@ function NewKeyModal({
 }) {
   return (
     <div
-      className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[hsl(var(--foreground)/0.42)] p-4"
       onClick={onClose}
       role="dialog"
       aria-modal="true"
+      aria-labelledby="new-key-modal-title"
     >
       <div
-        className="bg-white dark:bg-slate-900 rounded-lg shadow-xl max-w-xl w-full p-6"
+        className="panel w-full max-w-xl overflow-hidden p-6 shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
-        <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-2">
-          API Key 已创建
-        </h2>
-        <p className="text-sm text-slate-500 mb-4">
-          ⚠️ 请立即保存这个 Key。出于安全考虑，<strong>关闭此弹窗后无法再次查看完整 Key</strong>。
-        </p>
-        <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded p-3 mb-4">
-          <p className="text-xs text-amber-700 dark:text-amber-300 mb-2">完整 Key：</p>
+        <div className="mb-4 flex items-start justify-between gap-4">
+          <div>
+            <p className="page-kicker">Credential issued</p>
+            <h2 id="new-key-modal-title" className="font-display mt-1 text-2xl font-semibold text-foreground">
+              API Key 已创建
+            </h2>
+          </div>
+          <button onClick={onClose} className="icon-button h-9 w-9" aria-label="关闭">
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+        <div className="warning-banner mb-4 flex gap-2">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+          <p>请立即保存这个 Key。出于安全考虑，关闭此弹窗后无法再次查看完整 Key。</p>
+        </div>
+        <div className="panel-muted mb-4 p-3">
+          <p className="panel-label mb-2">完整 Key</p>
           <CopyableKey value={fullKey} />
-          <p className="text-xs text-amber-700 dark:text-amber-300 mt-2">
+          <p className="font-utility mt-2 text-xs text-foreground-muted">
             前缀: <code>{prefix}</code>
           </p>
         </div>
-        <div className="bg-slate-50 dark:bg-slate-800 rounded p-3 mb-4">
-          <p className="text-xs text-slate-600 dark:text-slate-400 mb-1">使用示例：</p>
-          <pre className="text-xs font-mono overflow-x-auto whitespace-pre">
+        <div className="panel-muted mb-4 p-3">
+          <p className="panel-label mb-1">使用示例</p>
+          <pre className="font-utility overflow-x-auto whitespace-pre text-xs text-foreground">
 {`curl -X POST https://api.ourapix.jiahongw.com/api/v1/generate \\
   -H "Authorization: Bearer ${prefix}..." \\
   -H "Content-Type: application/json" \\
   -d '{ "productImageId": "...", "settings": { ... } }'`}
           </pre>
         </div>
-        <button
-          onClick={onClose}
-          className="w-full px-4 py-2 bg-slate-900 text-white rounded hover:bg-slate-800"
-        >
+        <button onClick={onClose} className="btn-primary h-10 w-full">
           我已保存，关闭
         </button>
       </div>
@@ -120,173 +132,168 @@ export default function ApiKeysPage() {
   };
 
   return (
-    <div className="max-w-5xl mx-auto p-6">
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">API Keys</h1>
-          <p className="text-sm text-slate-500 mt-1">通过 API Key 访问 <code className="text-xs">/api/v1/*</code> 端点</p>
-        </div>
-        <button
-          onClick={() => setShowCreate(true)}
-          className="px-4 py-2 bg-slate-900 text-white text-sm rounded hover:bg-slate-800"
-        >
-          + 创建 API Key
-        </button>
-      </div>
+    <div className="workbench-page">
+      <div className="workbench-container max-w-6xl">
+        <header className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="page-kicker">Developer / API keys</p>
+            <h1 className="page-title mt-2">API Keys</h1>
+            <p className="page-description mt-3">
+              通过 API Key 访问 <code className="font-utility text-sm">/api/v1/*</code> 端点
+            </p>
+          </div>
+          <button onClick={() => setShowCreate(true)} className="btn-primary h-10 gap-2 px-4">
+            <Plus className="h-4 w-4" aria-hidden="true" />
+            创建 API Key
+          </button>
+        </header>
 
-      {error && <StateMessage variant="error" message={error} className="mb-4" />}
+        {error && <StateMessage variant="error" message={error} className="mb-4" />}
 
-      <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 overflow-x-auto">
-        {loading && keys.length === 0 ? (
-          <StateMessage variant="loading" message="加载 API Keys..." />
-        ) : keys.length === 0 ? (
-          <StateMessage
-            variant="empty"
-            title="还没有 API Key"
-            description="点击右上角创建第一个 API Key"
-          />
-        ) : (
-          <table className="w-full text-sm">
-            <thead className="bg-slate-50 dark:bg-slate-800 text-xs uppercase text-slate-500">
-              <tr>
-                <th className="px-4 py-3 text-left">名称</th>
-                <th className="px-4 py-3 text-left">Key</th>
-                <th className="px-4 py-3 text-left">状态</th>
-                <th className="px-4 py-3 text-left">最后使用</th>
-                <th className="px-4 py-3 text-left">过期时间</th>
-                <th className="px-4 py-3 text-left">创建时间</th>
-                <th className="px-4 py-3 text-right w-20">操作</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-slate-200 dark:divide-slate-700">
-              {keys.map((k) => (
-                <tr key={k.id} className="hover:bg-slate-50 dark:hover:bg-slate-800/50">
-                  <td className="px-4 py-3 font-medium text-slate-900 dark:text-slate-100">
-                    {k.name}
-                  </td>
-                  <td className="px-4 py-3">
-                    <code className="text-xs text-slate-600 dark:text-slate-400 font-mono">
-                      {k.keyPrefix}…
-                    </code>
-                  </td>
-                  <td className="px-4 py-3">
-                    {k.isRevoked ? (
-                      <span className="px-2 py-0.5 text-xs rounded bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300">
-                        已吊销
-                      </span>
-                    ) : k.expiresAt && new Date(k.expiresAt) < new Date() ? (
-                      <span className="px-2 py-0.5 text-xs rounded bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-300">
-                        已过期
-                      </span>
-                    ) : (
-                      <span className="px-2 py-0.5 text-xs rounded bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300">
-                        有效
-                      </span>
-                    )}
-                  </td>
-                  <td className="px-4 py-3 text-slate-500 text-xs">{formatDate(k.lastUsedAt)}</td>
-                  <td className="px-4 py-3 text-slate-500 text-xs">{formatDate(k.expiresAt)}</td>
-                  <td className="px-4 py-3 text-slate-500 text-xs">{formatDate(k.createdAt)}</td>
-                  <td className="px-4 py-3 text-right">
-                    {!k.isRevoked && (
-                      <button
-                        onClick={async () => {
-                          if (confirm(`确定吊销 "${k.name}"?`)) await revokeKey(k.id);
-                        }}
-                        className="text-xs text-slate-500 hover:text-red-500"
-                      >
-                        吊销
-                      </button>
-                    )}
-                  </td>
+        <div className="table-shell">
+          {loading && keys.length === 0 ? (
+            <StateMessage variant="loading" message="加载 API Keys..." />
+          ) : keys.length === 0 ? (
+            <StateMessage
+              variant="empty"
+              title="还没有 API Key"
+              description="点击右上角创建第一个 API Key"
+            />
+          ) : (
+            <table className="w-full text-sm">
+              <thead className="bg-[hsl(var(--secondary)/0.72)] text-xs uppercase text-foreground-muted">
+                <tr>
+                  <th className="px-4 py-3 text-left">名称</th>
+                  <th className="px-4 py-3 text-left">Key</th>
+                  <th className="px-4 py-3 text-left">状态</th>
+                  <th className="px-4 py-3 text-left">最后使用</th>
+                  <th className="px-4 py-3 text-left">过期时间</th>
+                  <th className="px-4 py-3 text-left">创建时间</th>
+                  <th className="w-20 px-4 py-3 text-right">操作</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {keys.map((k) => (
+                  <tr key={k.id} className="data-row">
+                    <td className="px-4 py-3 font-semibold text-foreground">{k.name}</td>
+                    <td className="px-4 py-3">
+                      <code className="font-utility text-xs text-foreground-muted">
+                        {k.keyPrefix}…
+                      </code>
+                    </td>
+                    <td className="px-4 py-3">
+                      {k.isRevoked ? (
+                        <span className="status-badge status-badge-error">已吊销</span>
+                      ) : k.expiresAt && new Date(k.expiresAt) < new Date() ? (
+                        <span className="status-badge status-badge-warning">已过期</span>
+                      ) : (
+                        <span className="status-badge status-badge-success">有效</span>
+                      )}
+                    </td>
+                    <td className="font-utility px-4 py-3 text-xs text-foreground-muted">{formatDate(k.lastUsedAt)}</td>
+                    <td className="font-utility px-4 py-3 text-xs text-foreground-muted">{formatDate(k.expiresAt)}</td>
+                    <td className="font-utility px-4 py-3 text-xs text-foreground-muted">{formatDate(k.createdAt)}</td>
+                    <td className="px-4 py-3 text-right">
+                      {!k.isRevoked && (
+                        <button
+                          onClick={async () => {
+                            if (confirm(`确定吊销 "${k.name}"?`)) await revokeKey(k.id);
+                          }}
+                          className="icon-button h-8 w-8 hover:text-[hsl(var(--color-error))]"
+                          aria-label="吊销 API Key"
+                        >
+                          <Ban className="h-4 w-4" aria-hidden="true" />
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        <div className="info-banner mt-6">
+          <h2 className="mb-1 font-semibold">使用说明</h2>
+          <ul className="list-inside list-disc space-y-1 text-xs">
+            <li>API Key 格式：<code className="font-utility rounded bg-[hsl(var(--card)/0.7)] px-1">op_</code> + 64 位十六进制</li>
+            <li>认证方式：HTTP Header <code className="font-utility rounded bg-[hsl(var(--card)/0.7)] px-1">Authorization: Bearer op_xxx</code></li>
+            <li>完整 Key 仅在创建时显示一次，请立即保存</li>
+            <li>可吊销 Key 而非删除（吊销后无法恢复，但保留审计记录）</li>
+          </ul>
+        </div>
+
+        {showCreate && (
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-[hsl(var(--foreground)/0.42)] p-4"
+            onClick={() => setShowCreate(false)}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="create-key-title"
+          >
+            <form
+              onSubmit={handleCreate}
+              className="panel w-full max-w-md p-6 shadow-xl"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="mb-4 flex items-start justify-between gap-4">
+                <h2 id="create-key-title" className="font-display text-2xl font-semibold text-foreground">
+                  创建 API Key
+                </h2>
+                <button type="button" onClick={() => setShowCreate(false)} className="icon-button h-9 w-9" aria-label="关闭">
+                  <X className="h-4 w-4" aria-hidden="true" />
+                </button>
+              </div>
+              <div className="mb-4">
+                <label className="panel-label mb-1 block">名称</label>
+                <input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="如：production-server"
+                  className="input"
+                  maxLength={100}
+                  required
+                  autoFocus
+                />
+              </div>
+              <div className="mb-6">
+                <label className="panel-label mb-1 block">过期天数（可选）</label>
+                <input
+                  type="number"
+                  value={expiresInDays}
+                  onChange={(e) => setExpiresInDays(e.target.value)}
+                  placeholder="留空表示永不过期"
+                  min={1}
+                  max={365}
+                  className="input"
+                />
+              </div>
+              <div className="flex justify-end gap-2">
+                <button type="button" onClick={() => setShowCreate(false)} className="btn-secondary h-10 px-4">
+                  取消
+                </button>
+                <button
+                  type="submit"
+                  disabled={!name.trim() || submitting}
+                  className="btn-primary h-10 gap-2 px-4 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <KeyRound className="h-4 w-4" aria-hidden="true" />
+                  {submitting ? "创建中..." : "创建"}
+                </button>
+              </div>
+            </form>
+          </div>
+        )}
+
+        {newlyCreated && (
+          <NewKeyModal
+            fullKey={newlyCreated.key}
+            prefix={newlyCreated.keyPrefix}
+            onClose={() => setNewlyCreated(null)}
+          />
         )}
       </div>
-
-      <div className="mt-6 p-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded text-sm text-blue-800 dark:text-blue-300">
-        <h3 className="font-medium mb-1">使用说明</h3>
-        <ul className="text-xs space-y-1 list-disc list-inside">
-          <li>API Key 格式：<code className="bg-blue-100 dark:bg-blue-900/40 px-1 rounded">op_</code> + 64 位十六进制</li>
-          <li>认证方式：HTTP Header <code className="bg-blue-100 dark:bg-blue-900/40 px-1 rounded">Authorization: Bearer op_xxx</code></li>
-          <li>完整 Key 仅在创建时显示一次，请立即保存</li>
-          <li>可吊销 Key 而非删除（吊销后无法恢复，但保留审计记录）</li>
-        </ul>
-      </div>
-
-      {showCreate && (
-        <div
-          className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
-          onClick={() => setShowCreate(false)}
-          role="dialog"
-          aria-modal="true"
-        >
-          <form
-            onSubmit={handleCreate}
-            className="bg-white dark:bg-slate-900 rounded-lg shadow-xl max-w-md w-full p-6"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-4">
-              创建 API Key
-            </h2>
-            <div className="mb-4">
-              <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
-                名称
-              </label>
-              <input
-                type="text"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder="如：production-server"
-                className="w-full px-3 py-2 border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
-                maxLength={100}
-                required
-                autoFocus
-              />
-            </div>
-            <div className="mb-6">
-              <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
-                过期天数（可选）
-              </label>
-              <input
-                type="number"
-                value={expiresInDays}
-                onChange={(e) => setExpiresInDays(e.target.value)}
-                placeholder="留空表示永不过期"
-                min={1}
-                max={365}
-                className="w-full px-3 py-2 border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
-              />
-            </div>
-            <div className="flex gap-2 justify-end">
-              <button
-                type="button"
-                onClick={() => setShowCreate(false)}
-                className="px-4 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded"
-              >
-                取消
-              </button>
-              <button
-                type="submit"
-                disabled={!name.trim() || submitting}
-                className="px-4 py-2 text-sm bg-slate-900 text-white rounded hover:bg-slate-800 disabled:opacity-50"
-              >
-                {submitting ? "创建中..." : "创建"}
-              </button>
-            </div>
-          </form>
-        </div>
-      )}
-
-      {newlyCreated && (
-        <NewKeyModal
-          fullKey={newlyCreated.key}
-          prefix={newlyCreated.keyPrefix}
-          onClose={() => setNewlyCreated(null)}
-        />
-      )}
     </div>
   );
 }

--- a/frontend/src/components/metrics/MetricsDashboard.tsx
+++ b/frontend/src/components/metrics/MetricsDashboard.tsx
@@ -8,6 +8,7 @@
 "use client";
 
 import { useState } from "react";
+import { RefreshCw } from "lucide-react";
 import { useMetricsDashboard, type MetricSummary } from "@/hooks/useMetricsDashboard";
 import { StateMessage } from "@/components/StateMessage";
 
@@ -31,18 +32,11 @@ const METRIC_DESCRIPTIONS: Record<string, string> = {
   TTFB: "Time to First Byte",
 };
 
-function ratingColor(rating: "good" | "needs-improvement" | "poor" | null | undefined): string {
-  if (rating === "good") return "text-green-600 dark:text-green-400";
-  if (rating === "needs-improvement") return "text-yellow-600 dark:text-yellow-400";
-  if (rating === "poor") return "text-red-600 dark:text-red-400";
-  return "text-slate-400";
-}
-
-function ratingBg(rating: "good" | "needs-improvement" | "poor" | null | undefined): string {
-  if (rating === "good") return "bg-green-100 dark:bg-green-900/30";
-  if (rating === "needs-improvement") return "bg-yellow-100 dark:bg-yellow-900/30";
-  if (rating === "poor") return "bg-red-100 dark:bg-red-900/30";
-  return "bg-slate-100 dark:bg-slate-800";
+function ratingClass(rating: "good" | "needs-improvement" | "poor" | null | undefined): string {
+  if (rating === "good") return "status-badge-success";
+  if (rating === "needs-improvement") return "status-badge-warning";
+  if (rating === "poor") return "status-badge-error";
+  return "status-badge-neutral";
 }
 
 function formatValue(metric: string, value: number): string {
@@ -53,47 +47,41 @@ function formatValue(metric: string, value: number): string {
 
 function MetricCard({ summary }: { summary: MetricSummary }) {
   return (
-    <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-4">
+    <div className="panel p-4">
       <div className="flex items-baseline justify-between">
-        <h3 className="text-sm font-medium text-slate-700 dark:text-slate-300">{summary.name}</h3>
-        <span className="text-xs text-slate-500">{summary.count} samples</span>
+        <h3 className="panel-title">{summary.name}</h3>
+        <span className="font-utility text-xs text-foreground-muted">{summary.count} samples</span>
       </div>
-      <p className="text-xs text-slate-500 mt-0.5 mb-3">{METRIC_DESCRIPTIONS[summary.name]}</p>
+      <p className="mb-3 mt-0.5 text-xs text-foreground-muted">{METRIC_DESCRIPTIONS[summary.name]}</p>
 
       <div className="grid grid-cols-3 gap-2 text-center">
-        <div>
-          <div className="text-xs text-slate-500">P50</div>
-          <div className="text-lg font-semibold text-slate-900 dark:text-slate-100">
-            {formatValue(summary.name, summary.p50)}
+        {[
+          ["P50", summary.p50],
+          ["P95", summary.p95],
+          ["avg", summary.avg],
+        ].map(([label, value]) => (
+          <div key={label}>
+            <div className="panel-label">{label}</div>
+            <div className="font-utility text-lg font-semibold text-foreground">
+              {formatValue(summary.name, Number(value))}
+            </div>
           </div>
-        </div>
-        <div>
-          <div className="text-xs text-slate-500">P95</div>
-          <div className="text-lg font-semibold text-slate-900 dark:text-slate-100">
-            {formatValue(summary.name, summary.p95)}
-          </div>
-        </div>
-        <div>
-          <div className="text-xs text-slate-500">avg</div>
-          <div className="text-lg font-semibold text-slate-900 dark:text-slate-100">
-            {formatValue(summary.name, summary.avg)}
-          </div>
-        </div>
+        ))}
       </div>
 
       {summary.count > 0 && (
-        <div className="mt-3 h-2 bg-slate-100 dark:bg-slate-800 rounded overflow-hidden flex">
+        <div className="mt-3 flex h-2 overflow-hidden rounded-full bg-[hsl(var(--secondary))]">
           <div
-            className="bg-green-500"
+            className="bg-[hsl(var(--color-success))]"
             style={{ width: `${summary.goodPct}%` }}
             title={`Good: ${summary.goodPct}%`}
           />
           <div
-            className="bg-yellow-500"
+            className="bg-[hsl(var(--color-warning))]"
             style={{ width: `${100 - summary.goodPct - summary.poorPct}%` }}
             title="Needs improvement"
           />
-          <div className="bg-red-500" style={{ width: `${summary.poorPct}%` }} title={`Poor: ${summary.poorPct}%`} />
+          <div className="bg-[hsl(var(--color-error))]" style={{ width: `${summary.poorPct}%` }} title={`Poor: ${summary.poorPct}%`} />
         </div>
       )}
     </div>
@@ -107,105 +95,97 @@ export default function MetricsDashboard() {
   const { stats, points, loading, error, refetch } = useMetricsDashboard({ range, selectedMetric });
 
   return (
-    <div className="max-w-7xl mx-auto p-6">
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">性能监控</h1>
-          <p className="text-sm text-slate-500 mt-1">Web Vitals 和导航时序指标</p>
-        </div>
-        <button
-          onClick={refetch}
-          className="px-3 py-1.5 text-sm bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 rounded"
-        >
-          刷新
-        </button>
-      </div>
-
-      {/* Range selector */}
-      <div className="flex gap-2 mb-4">
-        {(["1h", "24h", "7d", "30d"] as RangeFilter[]).map((r) => (
-          <button
-            key={r}
-            onClick={() => setRange(r)}
-            className={`px-3 py-1.5 text-sm rounded ${
-              range === r
-                ? "bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900"
-                : "bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700"
-            }`}
-          >
-            {r}
+    <div className="workbench-page">
+      <div className="workbench-container">
+        <header className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="page-kicker">Operations / Web vitals</p>
+            <h1 className="page-title mt-2">性能监控</h1>
+            <p className="page-description mt-3">Web Vitals 和导航时序指标</p>
+          </div>
+          <button onClick={refetch} className="btn-secondary h-10 gap-2 px-4">
+            <RefreshCw className="h-4 w-4" aria-hidden="true" />
+            刷新
           </button>
-        ))}
-      </div>
+        </header>
 
-      {error && <StateMessage variant="error" message={error} className="mb-4" />}
-
-      {/* Core Web Vitals cards */}
-      <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-3">核心指标</h2>
-      {loading && !stats ? (
-        <StateMessage variant="loading" message="加载指标..." />
-      ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-4 mb-8">
-          {stats?.metrics.map((m) => <MetricCard key={m.name} summary={m} />) ??
-            CORE_METRICS.map((name) => <MetricCard key={name} summary={{ name, count: 0, p50: 0, p95: 0, avg: 0, goodPct: 0, poorPct: 0 }} />)}
-        </div>
-      )}
-
-      {/* Recent data points */}
-      <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 overflow-x-auto">
-        <div className="px-4 py-3 border-b border-slate-200 dark:border-slate-700 flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">最近数据</h2>
-          <select
-            value={selectedMetric}
-            onChange={(e) => setSelectedMetric(e.target.value)}
-            className="px-3 py-1 text-sm border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
-          >
-            {CORE_METRICS.map((m) => (
-              <option key={m} value={m}>
-                {m}
-              </option>
-            ))}
-          </select>
+        <div className="mb-4 flex flex-wrap gap-2">
+          {(["1h", "24h", "7d", "30d"] as RangeFilter[]).map((r) => (
+            <button
+              key={r}
+              onClick={() => setRange(r)}
+              className={`segmented-option ${range === r ? "segmented-option-active" : ""}`}
+            >
+              {r}
+            </button>
+          ))}
         </div>
 
-        {points.length === 0 ? (
-          <StateMessage variant="empty" title="暂无数据" description="选择指标后数据将在这里展示" />
+        {error && <StateMessage variant="error" message={error} className="mb-4" />}
+
+        <h2 className="mb-3 text-lg font-semibold text-foreground">核心指标</h2>
+        {loading && !stats ? (
+          <StateMessage variant="loading" message="加载指标..." />
         ) : (
-          <table className="w-full text-sm">
-            <thead className="bg-slate-50 dark:bg-slate-800 text-xs uppercase text-slate-500">
-              <tr>
-                <th className="px-4 py-3 text-left">时间</th>
-                <th className="px-4 py-3 text-left">设备</th>
-                <th className="px-4 py-3 text-left">评分</th>
-                <th className="px-4 py-3 text-right">值</th>
-                <th className="px-4 py-3 text-left">URL</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-slate-200 dark:divide-slate-700">
-              {points.map((p) => (
-                <tr key={p.id} className="hover:bg-slate-50 dark:hover:bg-slate-800/50">
-                  <td className="px-4 py-3 text-slate-500 text-xs">
-                    {new Date(p.recordedAt).toLocaleString("zh-CN", { month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit" })}
-                  </td>
-                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400">{p.deviceType ?? "-"}</td>
-                  <td className="px-4 py-3">
-                    {p.rating ? (
-                      <span className={`px-2 py-0.5 rounded text-xs font-medium ${ratingBg(p.rating)} ${ratingColor(p.rating)}`}>
-                        {p.rating}
-                      </span>
-                    ) : (
-                      <span className="text-slate-400">-</span>
-                    )}
-                  </td>
-                  <td className={`px-4 py-3 text-right font-mono ${ratingColor(p.rating)}`}>
-                    {formatValue(selectedMetric, p.value)}
-                  </td>
-                  <td className="px-4 py-3 text-slate-500 text-xs max-w-md truncate">{p.url ?? "-"}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          <div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+            {stats?.metrics.map((m) => <MetricCard key={m.name} summary={m} />) ??
+              CORE_METRICS.map((name) => <MetricCard key={name} summary={{ name, count: 0, p50: 0, p95: 0, avg: 0, goodPct: 0, poorPct: 0 }} />)}
+          </div>
         )}
+
+        <div className="table-shell">
+          <div className="flex items-center justify-between border-b border-[hsl(var(--border))] px-4 py-3">
+            <h2 className="text-lg font-semibold text-foreground">最近数据</h2>
+            <select
+              value={selectedMetric}
+              onChange={(e) => setSelectedMetric(e.target.value)}
+              className="input w-auto py-1"
+            >
+              {CORE_METRICS.map((m) => (
+                <option key={m} value={m}>
+                  {m}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {points.length === 0 ? (
+            <StateMessage variant="empty" title="暂无数据" description="选择指标后数据将在这里展示" />
+          ) : (
+            <table className="w-full text-sm">
+              <thead className="bg-[hsl(var(--secondary)/0.72)] text-xs uppercase text-foreground-muted">
+                <tr>
+                  <th className="px-4 py-3 text-left">时间</th>
+                  <th className="px-4 py-3 text-left">设备</th>
+                  <th className="px-4 py-3 text-left">评分</th>
+                  <th className="px-4 py-3 text-right">值</th>
+                  <th className="px-4 py-3 text-left">URL</th>
+                </tr>
+              </thead>
+              <tbody>
+                {points.map((p) => (
+                  <tr key={p.id} className="data-row">
+                    <td className="font-utility px-4 py-3 text-xs text-foreground-muted">
+                      {new Date(p.recordedAt).toLocaleString("zh-CN", { month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit" })}
+                    </td>
+                    <td className="px-4 py-3 text-foreground-muted">{p.deviceType ?? "-"}</td>
+                    <td className="px-4 py-3">
+                      {p.rating ? (
+                        <span className={`status-badge ${ratingClass(p.rating)}`}>{p.rating}</span>
+                      ) : (
+                        <span className="text-foreground-muted">-</span>
+                      )}
+                    </td>
+                    <td className="font-utility px-4 py-3 text-right text-foreground">
+                      {formatValue(selectedMetric, p.value)}
+                    </td>
+                    <td className="max-w-md truncate px-4 py-3 text-xs text-foreground-muted">{p.url ?? "-"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/notifications/NotificationBell.tsx
+++ b/frontend/src/components/notifications/NotificationBell.tsx
@@ -7,6 +7,7 @@
 "use client";
 
 import { useState } from "react";
+import { Bell } from "lucide-react";
 import { useNotifications } from "@/hooks/useNotifications";
 import NotificationPanel from "./NotificationPanel";
 
@@ -18,25 +19,13 @@ export default function NotificationBell() {
     <div className="relative">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="relative p-2 text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100 transition-colors"
+        className="icon-button relative h-9 w-9"
         aria-label="Notifications"
       >
-        <svg
-          className="w-6 h-6"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
-          />
-        </svg>
+        <Bell className="h-5 w-5" aria-hidden="true" />
 
         {unreadCount > 0 && (
-          <span className="absolute -top-1 -right-1 flex items-center justify-center w-5 h-5 text-xs font-bold text-white bg-red-500 rounded-full">
+          <span className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-[hsl(var(--color-error))] text-xs font-bold text-white">
             {unreadCount > 99 ? "99+" : unreadCount}
           </span>
         )}

--- a/frontend/src/components/notifications/NotificationPanel.tsx
+++ b/frontend/src/components/notifications/NotificationPanel.tsx
@@ -7,6 +7,16 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import {
+  AlertTriangle,
+  Bell,
+  CheckCircle2,
+  CreditCard,
+  Megaphone,
+  User,
+  X,
+  XCircle,
+} from "lucide-react";
 import * as m from "@/paraglide/messages.js";
 import { localizeHref } from "@/paraglide/runtime.js";
 import { useNotifications, type Notification } from "@/hooks/useNotifications";
@@ -30,22 +40,23 @@ function formatTimeAgo(dateString: string): string {
   return date.toLocaleDateString("zh-CN");
 }
 
-function getNotificationIcon(type: string): string {
+function NotificationTypeIcon({ type }: { type: string }) {
+  const className = "h-5 w-5";
   switch (type) {
     case "generation_complete":
-      return "✅";
+      return <CheckCircle2 className={className} aria-hidden="true" />;
     case "generation_failed":
-      return "❌";
+      return <XCircle className={className} aria-hidden="true" />;
     case "system_announcement":
-      return "📢";
+      return <Megaphone className={className} aria-hidden="true" />;
     case "account_update":
-      return "👤";
+      return <User className={className} aria-hidden="true" />;
     case "subscription_renewal":
-      return "💳";
+      return <CreditCard className={className} aria-hidden="true" />;
     case "subscription_expiring":
-      return "⚠️";
+      return <AlertTriangle className={className} aria-hidden="true" />;
     default:
-      return "🔔";
+      return <Bell className={className} aria-hidden="true" />;
   }
 }
 
@@ -71,51 +82,37 @@ function NotificationItem({
 
   return (
     <div
-      className={`p-4 border-b border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors cursor-pointer ${
-        !notification.isRead ? "bg-blue-50 dark:bg-blue-900/10" : ""
+      className={`data-row cursor-pointer p-4 transition-colors ${
+        !notification.isRead ? "bg-[hsl(var(--primary)/0.08)]" : ""
       }`}
       onClick={handleClick}
     >
       <div className="flex items-start gap-3">
-        <div className="text-2xl flex-shrink-0">
-          {getNotificationIcon(notification.type)}
+        <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-md bg-[hsl(var(--secondary))] text-[hsl(var(--primary))]">
+          <NotificationTypeIcon type={notification.type} />
         </div>
 
-        <div className="flex-1 min-w-0">
+        <div className="min-w-0 flex-1">
           <div className="flex items-start justify-between gap-2">
-            <h4 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
-              {notification.title}
-            </h4>
+            <h4 className="text-sm font-semibold text-foreground">{notification.title}</h4>
             <button
               onClick={(e) => {
                 e.stopPropagation();
                 onDelete(notification.id);
               }}
-              className="text-slate-400 hover:text-red-500 transition-colors flex-shrink-0"
+              className="icon-button h-7 w-7 flex-shrink-0 hover:text-[hsl(var(--color-error))]"
               aria-label="Delete notification"
             >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M6 18L18 6M6 6l12 12"
-                />
-              </svg>
+              <X className="h-4 w-4" aria-hidden="true" />
             </button>
           </div>
 
-          <p className="text-sm text-slate-600 dark:text-slate-400 mt-1 line-clamp-2">
-            {notification.message}
-          </p>
-
-          <p className="text-xs text-slate-500 dark:text-slate-500 mt-2">
-            {formatTimeAgo(notification.createdAt)}
-          </p>
+          <p className="mt-1 line-clamp-2 text-sm text-foreground-muted">{notification.message}</p>
+          <p className="font-utility mt-2 text-xs text-foreground-muted">{formatTimeAgo(notification.createdAt)}</p>
         </div>
 
         {!notification.isRead && (
-          <div className="w-2 h-2 bg-blue-500 rounded-full flex-shrink-0 mt-2" />
+          <div className="mt-2 h-2 w-2 flex-shrink-0 rounded-full bg-[hsl(var(--primary))]" />
         )}
       </div>
     </div>
@@ -135,7 +132,6 @@ export default function NotificationPanel({ onClose }: NotificationPanelProps) {
     fetchNotifications,
   } = useNotifications();
 
-  // Close on click outside
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
       if (panelRef.current && !panelRef.current.contains(event.target as Node)) {
@@ -147,7 +143,6 @@ export default function NotificationPanel({ onClose }: NotificationPanelProps) {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [onClose]);
 
-  // Close on escape key
   useEffect(() => {
     function handleEscape(event: KeyboardEvent) {
       if (event.key === "Escape") {
@@ -162,14 +157,13 @@ export default function NotificationPanel({ onClose }: NotificationPanelProps) {
   return (
     <div
       ref={panelRef}
-      className="absolute right-0 top-full mt-2 w-96 max-h-[500px] bg-white dark:bg-slate-900 rounded-lg shadow-xl border border-slate-200 dark:border-slate-700 overflow-hidden z-50"
+      className="panel absolute right-0 top-full z-50 mt-2 max-h-[500px] w-96 overflow-hidden shadow-xl"
     >
-      {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-slate-200 dark:border-slate-700">
-        <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+      <div className="flex items-center justify-between border-b border-[hsl(var(--border))] p-4">
+        <h3 className="text-lg font-semibold text-foreground">
           {m.notification_title()}
           {unreadCount > 0 && (
-            <span className="ml-2 text-sm font-normal text-slate-500 dark:text-slate-400">
+            <span className="ml-2 text-sm font-normal text-foreground-muted">
               ({m.notification_unreadCount({ count: unreadCount.toString() })})
             </span>
           )}
@@ -177,45 +171,32 @@ export default function NotificationPanel({ onClose }: NotificationPanelProps) {
         {unreadCount > 0 && (
           <button
             onClick={markAllAsRead}
-            className="text-sm text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 transition-colors"
+            className="text-sm font-semibold text-[hsl(var(--primary))] hover:text-[hsl(var(--primary-hover))]"
           >
             {m.notification_markAllRead()}
           </button>
         )}
       </div>
 
-      {/* Content */}
-      <div className="overflow-y-auto max-h-[400px]">
+      <div className="max-h-[400px] overflow-y-auto">
         {loading && notifications.length === 0 ? (
-          <div className="p-8 text-center text-slate-500 dark:text-slate-400">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto mb-3" />
+          <div className="p-8 text-center text-foreground-muted">
+            <div className="mx-auto mb-3 h-8 w-8 animate-spin rounded-full border-b-2 border-[hsl(var(--primary))]" />
             <p>{m.common_loading()}</p>
           </div>
         ) : error ? (
           <div className="p-8 text-center">
-            <p className="text-red-500 dark:text-red-400 mb-3">{error}</p>
+            <p className="mb-3 text-[hsl(var(--color-error))]">{error}</p>
             <button
               onClick={fetchNotifications}
-              className="text-sm text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
+              className="text-sm font-semibold text-[hsl(var(--primary))] hover:text-[hsl(var(--primary-hover))]"
             >
               {m.common_retry()}
             </button>
           </div>
         ) : notifications.length === 0 ? (
-          <div className="p-8 text-center text-slate-500 dark:text-slate-400">
-            <svg
-              className="w-16 h-16 mx-auto mb-3 text-slate-300 dark:text-slate-600"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={1.5}
-                d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
-              />
-            </svg>
+          <div className="p-8 text-center text-foreground-muted">
+            <Bell className="mx-auto mb-3 h-16 w-16" aria-hidden="true" />
             <p>{m.notification_empty()}</p>
           </div>
         ) : (
@@ -230,12 +211,11 @@ export default function NotificationPanel({ onClose }: NotificationPanelProps) {
         )}
       </div>
 
-      {/* Footer */}
       {notifications.length > 0 && (
-        <div className="p-3 border-t border-slate-200 dark:border-slate-700 text-center">
+        <div className="border-t border-[hsl(var(--border))] p-3 text-center">
           <a
             href={localizeHref("/notifications")}
-            className="text-sm text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 transition-colors"
+            className="text-sm font-semibold text-[hsl(var(--primary))] hover:text-[hsl(var(--primary-hover))]"
           >
             {m.notification_viewAll()}
           </a>

--- a/frontend/src/components/stats/DistributionChart.tsx
+++ b/frontend/src/components/stats/DistributionChart.tsx
@@ -15,8 +15,8 @@ export default function DistributionChart({ data, title, color = '#d97706' }: Di
   const total = data.reduce((sum, d) => sum + d.value, 0);
 
   return (
-    <div className="bg-white dark:bg-stone-800 rounded-lg shadow-sm border border-stone-200 dark:border-stone-700 p-6">
-      <h3 className="text-lg font-semibold text-stone-900 dark:text-stone-100 mb-4">
+    <div className="panel p-6">
+      <h3 className="mb-4 text-lg font-semibold text-foreground">
         {title}
       </h3>
 
@@ -28,14 +28,14 @@ export default function DistributionChart({ data, title, color = '#d97706' }: Di
           return (
             <div key={index}>
               <div className="flex items-center justify-between mb-1">
-                <span className="text-sm font-medium text-stone-700 dark:text-stone-300">
+                <span className="text-sm font-medium text-foreground">
                   {item.label}
                 </span>
-                <span className="text-sm text-stone-600 dark:text-stone-400">
+                <span className="font-utility text-sm text-foreground-muted">
                   {item.value} ({actualPercentage.toFixed(1)}%)
                 </span>
               </div>
-              <div className="w-full bg-stone-200 dark:bg-stone-700 rounded-full h-2">
+              <div className="h-2 w-full rounded-full bg-[hsl(var(--secondary))]">
                 <div
                   className="h-2 rounded-full transition-all duration-500"
                   style={{
@@ -50,7 +50,7 @@ export default function DistributionChart({ data, title, color = '#d97706' }: Di
       </div>
 
       {data.length === 0 && (
-        <p className="text-sm text-stone-500 dark:text-stone-500 text-center py-8">
+        <p className="py-8 text-center text-sm text-foreground-muted">
           暂无数据
         </p>
       )}

--- a/frontend/src/components/stats/StatsCard.tsx
+++ b/frontend/src/components/stats/StatsCard.tsx
@@ -13,23 +13,23 @@ interface StatsCardProps {
 
 export default function StatsCard({ title, value, subtitle, icon }: StatsCardProps) {
   return (
-    <div className="bg-white dark:bg-stone-800 rounded-lg shadow-sm border border-stone-200 dark:border-stone-700 p-6">
+    <div className="panel p-6">
       <div className="flex items-start justify-between">
         <div className="flex-1">
-          <p className="text-sm font-medium text-stone-600 dark:text-stone-400 mb-1">
+          <p className="mb-1 text-sm font-medium text-foreground-muted">
             {title}
           </p>
-          <p className="text-3xl font-bold text-stone-900 dark:text-stone-100">
+          <p className="font-utility text-3xl font-semibold text-foreground">
             {value}
           </p>
           {subtitle && (
-            <p className="text-xs text-stone-500 dark:text-stone-500 mt-2">
+            <p className="mt-2 text-xs text-foreground-muted">
               {subtitle}
             </p>
           )}
         </div>
         {icon && (
-          <div className="text-amber-600 dark:text-amber-500">
+          <div className="text-[hsl(var(--primary))]">
             {icon}
           </div>
         )}

--- a/frontend/src/components/stats/StatsPage.tsx
+++ b/frontend/src/components/stats/StatsPage.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Heart, ImageIcon, Timer, Zap } from 'lucide-react';
 import { useStats, type TimeRange } from '@/hooks/useStats';
 import StatsCard from './StatsCard';
 import DistributionChart from './DistributionChart';
@@ -32,42 +33,29 @@ export default function StatsPage() {
   };
 
   return (
-    <div className="min-h-screen bg-stone-50 dark:bg-stone-950">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {/* Header */}
-        <div className="mb-8">
-          <h1 className="text-3xl font-bold text-stone-900 dark:text-stone-100">
-            生成统计
-          </h1>
-          <p className="text-stone-600 dark:text-stone-400 mt-2">
-            查看您的生成历史数据分析
-          </p>
-        </div>
+    <div className="workbench-page">
+      <div className="workbench-container">
+        <header className="mb-8">
+          <p className="page-kicker">Analytics / Generation stats</p>
+          <h1 className="page-title mt-2">生成统计</h1>
+          <p className="page-description mt-3">查看您的生成历史数据分析</p>
+        </header>
 
-        {/* Time Range Selector */}
-        <div className="mb-6 flex gap-2">
+        <div className="mb-6 flex flex-wrap gap-2">
           {timeRanges.map((tr) => (
             <button
               key={tr.value}
               onClick={() => setRange(tr.value)}
-              className={`px-4 py-2 rounded-lg font-medium transition-colors ${
-                range === tr.value
-                  ? 'bg-amber-600 text-white'
-                  : 'bg-white dark:bg-stone-800 text-stone-700 dark:text-stone-300 hover:bg-stone-100 dark:hover:bg-stone-700'
-              }`}
+              className={`segmented-option ${range === tr.value ? 'segmented-option-active' : ''}`}
             >
               {tr.label}
             </button>
           ))}
         </div>
 
-        {/* Loading State */}
         {loading && <StateMessage variant="loading" message="加载统计数据..." />}
-
-        {/* Error State */}
         {error && <StateMessage variant="error" message={error} onRetry={refresh} />}
 
-        {/* Empty State */}
         {data && !loading && data.totalGenerations === 0 && (
           <StateMessage
             variant="empty"
@@ -76,62 +64,43 @@ export default function StatsPage() {
           />
         )}
 
-        {/* Stats Content */}
         {data && !loading && data.totalGenerations > 0 && (
           <>
-            {/* Summary Cards */}
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+            <div className="mb-8 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
               <StatsCard
                 title="总生成次数"
                 value={data.totalGenerations}
                 subtitle="AI 生成任务总数"
-                icon={
-                  <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
-                  </svg>
-                }
+                icon={<Zap className="h-8 w-8" aria-hidden="true" />}
               />
               <StatsCard
                 title="总图片数"
                 value={data.totalImages}
                 subtitle="生成的图片总数"
-                icon={
-                  <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                  </svg>
-                }
+                icon={<ImageIcon className="h-8 w-8" aria-hidden="true" />}
               />
               <StatsCard
                 title="平均生成时间"
                 value={`${data.avgGenerationTime}s`}
                 subtitle="每次生成的平均耗时"
-                icon={
-                  <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-                  </svg>
-                }
+                icon={<Timer className="h-8 w-8" aria-hidden="true" />}
               />
               <StatsCard
                 title="收藏率"
                 value={`${data.favoriteRate}%`}
                 subtitle="收藏图片占比"
-                icon={
-                  <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
-                  </svg>
-                }
+                icon={<Heart className="h-8 w-8" aria-hidden="true" />}
               />
             </div>
 
-            {/* Charts */}
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+            <div className="mb-6 grid grid-cols-1 gap-6 lg:grid-cols-2">
               <DistributionChart
                 data={data.byPlatform.map(p => ({
                   label: platformLabels[p.platform] || p.platform,
                   value: p.count,
                 }))}
                 title="平台分布"
-                color="#d97706"
+                color="#2563eb"
               />
               <DistributionChart
                 data={data.byStyle.map(s => ({
@@ -139,14 +108,11 @@ export default function StatsPage() {
                   value: s.count,
                 }))}
                 title="风格分布"
-                color="#059669"
+                color="#b45309"
               />
             </div>
 
-            <TrendChart
-              data={data.trend}
-              title="生成趋势"
-            />
+            <TrendChart data={data.trend} title="生成趋势" />
           </>
         )}
       </div>

--- a/frontend/src/components/stats/TrendChart.tsx
+++ b/frontend/src/components/stats/TrendChart.tsx
@@ -12,11 +12,11 @@ interface TrendChartProps {
 export default function TrendChart({ data, title }: TrendChartProps) {
   if (data.length === 0) {
     return (
-      <div className="bg-white dark:bg-stone-800 rounded-lg shadow-sm border border-stone-200 dark:border-stone-700 p-6">
-        <h3 className="text-lg font-semibold text-stone-900 dark:text-stone-100 mb-4">
+      <div className="panel p-6">
+        <h3 className="mb-4 text-lg font-semibold text-foreground">
           {title}
         </h3>
-        <p className="text-sm text-stone-500 dark:text-stone-500 text-center py-8">
+        <p className="py-8 text-center text-sm text-foreground-muted">
           暂无数据
         </p>
       </div>
@@ -44,8 +44,8 @@ export default function TrendChart({ data, title }: TrendChartProps) {
   const areaD = `${pathD} L ${points[points.length - 1]?.x || 0} ${chartHeight} L 0 ${chartHeight} Z`;
 
   return (
-    <div className="bg-white dark:bg-stone-800 rounded-lg shadow-sm border border-stone-200 dark:border-stone-700 p-6">
-      <h3 className="text-lg font-semibold text-stone-900 dark:text-stone-100 mb-4">
+    <div className="panel p-6">
+      <h3 className="mb-4 text-lg font-semibold text-foreground">
         {title}
       </h3>
 
@@ -67,7 +67,7 @@ export default function TrendChart({ data, title }: TrendChartProps) {
               y2={chartHeight - ratio * (chartHeight - padding)}
               stroke="currentColor"
               strokeWidth="0.2"
-              className="text-stone-200 dark:text-stone-700"
+              className="text-[hsl(var(--border))]"
             />
           ))}
 
@@ -111,7 +111,7 @@ export default function TrendChart({ data, title }: TrendChartProps) {
         </svg>
 
         {/* X-axis labels */}
-        <div className="absolute bottom-0 left-0 right-0 flex justify-between text-xs text-stone-500 dark:text-stone-500">
+        <div className="absolute bottom-0 left-0 right-0 flex justify-between text-xs text-foreground-muted">
           {data.length > 0 && (
             <>
               <span>{data[0].date}</span>
@@ -125,16 +125,16 @@ export default function TrendChart({ data, title }: TrendChartProps) {
       </div>
 
       {/* Summary */}
-      <div className="mt-4 pt-4 border-t border-stone-200 dark:border-stone-700">
+      <div className="mt-4 border-t border-[hsl(var(--border))] pt-4">
         <div className="flex justify-between text-sm">
-          <span className="text-stone-600 dark:text-stone-400">总计</span>
-          <span className="font-semibold text-stone-900 dark:text-stone-100">
+          <span className="text-foreground-muted">总计</span>
+          <span className="font-semibold text-foreground">
             {data.reduce((sum, d) => sum + d.count, 0)} 次
           </span>
         </div>
         <div className="flex justify-between text-sm mt-2">
-          <span className="text-stone-600 dark:text-stone-400">平均</span>
-          <span className="font-semibold text-stone-900 dark:text-stone-100">
+          <span className="text-foreground-muted">平均</span>
+          <span className="font-semibold text-foreground">
             {(data.reduce((sum, d) => sum + d.count, 0) / data.length).toFixed(1)} 次/天
           </span>
         </div>

--- a/frontend/src/components/teams/TeamDetailPage.tsx
+++ b/frontend/src/components/teams/TeamDetailPage.tsx
@@ -7,6 +7,7 @@
 "use client";
 
 import { useState } from "react";
+import { ArrowLeft, Check, Copy, LogOut, Save, Trash2, Users, X } from "lucide-react";
 import { localizeHref } from "@/paraglide/runtime.js";
 import { useTeam, type TeamMember, type TeamRole } from "@/hooks/useTeams";
 
@@ -24,10 +25,10 @@ const ROLE_LABELS: Record<TeamRole, string> = {
   member: "成员",
 };
 
-const ROLE_COLORS: Record<TeamRole, string> = {
-  owner: "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300",
-  admin: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
-  member: "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300",
+const ROLE_BADGES: Record<TeamRole, string> = {
+  owner: "status-badge-info",
+  admin: "status-badge-warning",
+  member: "status-badge-neutral",
 };
 
 export default function TeamDetailPage({ teamId }: { teamId: string }) {
@@ -36,16 +37,23 @@ export default function TeamDetailPage({ teamId }: { teamId: string }) {
   const [editingName, setEditingName] = useState(false);
   const [nameInput, setNameInput] = useState("");
   const [confirmAction, setConfirmAction] = useState<"leave" | "delete" | null>(null);
+  const [copied, setCopied] = useState(false);
 
   if (loading && !team) {
-    return <div className="text-center py-12 text-slate-500">加载中...</div>;
+    return (
+      <div className="workbench-page">
+        <div className="workbench-container text-center text-foreground-muted">加载中...</div>
+      </div>
+    );
   }
 
   if (error && !team) {
     return (
-      <div className="max-w-3xl mx-auto p-6">
-        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-4 rounded">
-          <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
+      <div className="workbench-page">
+        <div className="workbench-container max-w-3xl">
+          <div className="error-banner">
+            <p>{error}</p>
+          </div>
         </div>
       </div>
     );
@@ -55,10 +63,10 @@ export default function TeamDetailPage({ teamId }: { teamId: string }) {
 
   const isOwner = team.role === "owner";
   const isAdmin = team.role === "admin" || isOwner;
-  const canManageMember = (m: TeamMember) => {
-    if (m.role === "owner") return false;
+  const canManageMember = (member: TeamMember) => {
+    if (member.role === "owner") return false;
     if (isOwner) return true;
-    if (isAdmin && m.role === "member") return true;
+    if (isAdmin && member.role === "member") return true;
     return false;
   };
 
@@ -81,205 +89,199 @@ export default function TeamDetailPage({ teamId }: { teamId: string }) {
     if (ok) window.location.href = localizeHref("/teams");
   };
 
+  const copyInvite = async () => {
+    try {
+      await navigator.clipboard.writeText(team.inviteCode);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* ignore */
+    }
+  };
+
   return (
-    <div className="max-w-4xl mx-auto p-6">
-      <div className="mb-6">
-        <a href={localizeHref("/teams")} className="text-sm text-slate-500 hover:text-slate-700 dark:hover:text-slate-300">
-          ← 返回团队列表
-        </a>
-      </div>
+    <div className="workbench-page">
+      <div className="workbench-container max-w-5xl">
+        <div className="mb-6">
+          <a href={localizeHref("/teams")} className="btn-ghost h-9 gap-2 px-3">
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+            返回团队列表
+          </a>
+        </div>
 
-      <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-6 mb-4">
-        <div className="flex items-start justify-between mb-4">
-          <div className="flex-1">
-            {editingName ? (
-              <div className="flex gap-2">
-                <input
-                  type="text"
-                  value={nameInput}
-                  onChange={(e) => setNameInput(e.target.value)}
-                  className="flex-1 px-3 py-1.5 text-lg font-semibold border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
-                  autoFocus
-                />
-                <button
-                  onClick={handleSaveName}
-                  className="px-3 py-1.5 text-sm bg-slate-900 text-white rounded"
-                >
-                  保存
-                </button>
-                <button
-                  onClick={() => setEditingName(false)}
-                  className="px-3 py-1.5 text-sm border border-slate-200 dark:border-slate-700 rounded"
-                >
-                  取消
-                </button>
-              </div>
-            ) : (
-              <div className="flex items-center gap-2">
-                <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">{team.name}</h1>
-                {isOwner && (
-                  <button
-                    onClick={() => {
-                      setNameInput(team.name);
-                      setEditingName(true);
-                    }}
-                    className="text-sm text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
-                  >
-                    编辑
+        <section className="panel mb-4 p-6">
+          <div className="mb-4 flex items-start justify-between gap-4">
+            <div className="flex-1">
+              {editingName ? (
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    value={nameInput}
+                    onChange={(e) => setNameInput(e.target.value)}
+                    className="input flex-1 text-lg font-semibold"
+                    autoFocus
+                  />
+                  <button onClick={handleSaveName} className="btn-primary h-10 gap-2 px-3">
+                    <Save className="h-4 w-4" aria-hidden="true" />
+                    保存
                   </button>
-                )}
-              </div>
-            )}
-            <p className="text-sm text-slate-500 mt-1">
-              {team.memberCount} 成员 · 创建于 {formatDate(team.createdAt)}
-            </p>
-          </div>
-          <span className={`px-3 py-1 text-sm rounded ${ROLE_COLORS[team.role]}`}>
-            你是 {ROLE_LABELS[team.role]}
-          </span>
-        </div>
-
-        <div className="flex items-center gap-2 text-sm bg-slate-50 dark:bg-slate-800 p-3 rounded">
-          <span className="text-slate-500">邀请码:</span>
-          <code className="font-mono text-slate-900 dark:text-slate-100">{team.inviteCode}</code>
-          <button
-            onClick={async () => {
-              try {
-                await navigator.clipboard.writeText(team.inviteCode);
-              } catch {
-                /* ignore */
-              }
-            }}
-            className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
-          >
-            复制
-          </button>
-        </div>
-
-        <div className="flex gap-2 mt-4">
-          {!isOwner && (
-            <button
-              onClick={() => setConfirmAction("leave")}
-              className="px-3 py-1.5 text-sm border border-slate-200 dark:border-slate-700 rounded hover:bg-slate-50 dark:hover:bg-slate-800"
-            >
-              退出团队
-            </button>
-          )}
-          {isOwner && (
-            <button
-              onClick={() => setConfirmAction("delete")}
-              className="px-3 py-1.5 text-sm text-red-600 dark:text-red-400 border border-red-200 dark:border-red-800 rounded hover:bg-red-50 dark:hover:bg-red-900/20"
-            >
-              解散团队
-            </button>
-          )}
-        </div>
-      </div>
-
-      <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-3">成员</h2>
-      <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 overflow-x-auto">
-        <table className="w-full text-sm">
-          <thead className="bg-slate-50 dark:bg-slate-800 text-xs uppercase text-slate-500">
-            <tr>
-              <th className="px-4 py-3 text-left">用户</th>
-              <th className="px-4 py-3 text-left">角色</th>
-              <th className="px-4 py-3 text-left">加入时间</th>
-              <th className="px-4 py-3 text-right w-32">操作</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-slate-200 dark:divide-slate-700">
-            {team.members.map((m) => (
-              <tr key={m.id} className="hover:bg-slate-50 dark:hover:bg-slate-800/50">
-                <td className="px-4 py-3">
-                  <div className="text-slate-900 dark:text-slate-100">
-                    {m.user?.name ?? "(未命名)"}
-                  </div>
-                  <div className="text-xs text-slate-500">{m.user?.email}</div>
-                </td>
-                <td className="px-4 py-3">
-                  {isOwner && m.role !== "owner" ? (
-                    <select
-                      value={m.role}
-                      onChange={async (e) => {
-                        await updateMemberRole(m.userId, e.target.value as "admin" | "member");
-                      }}
-                      className={`px-2 py-0.5 text-xs rounded ${ROLE_COLORS[m.role]}`}
-                    >
-                      <option value="admin">admin</option>
-                      <option value="member">member</option>
-                    </select>
-                  ) : (
-                    <span className={`px-2 py-0.5 text-xs rounded ${ROLE_COLORS[m.role]}`}>
-                      {ROLE_LABELS[m.role]}
-                    </span>
-                  )}
-                </td>
-                <td className="px-4 py-3 text-slate-500 text-xs">{formatDate(m.joinedAt)}</td>
-                <td className="px-4 py-3 text-right">
-                  {canManageMember(m) && (
+                  <button onClick={() => setEditingName(false)} className="btn-secondary h-10 px-3">
+                    取消
+                  </button>
+                </div>
+              ) : (
+                <div className="flex items-center gap-2">
+                  <Users className="h-6 w-6 text-[hsl(var(--primary))]" aria-hidden="true" />
+                  <h1 className="font-display text-3xl font-semibold text-foreground">{team.name}</h1>
+                  {isOwner && (
                     <button
-                      onClick={async () => {
-                        if (confirm(`确定移除 ${m.user?.name ?? m.user?.email}?`)) {
-                          await removeMember(m.userId);
-                        }
+                      onClick={() => {
+                        setNameInput(team.name);
+                        setEditingName(true);
                       }}
-                      className="text-xs text-slate-500 hover:text-red-500"
+                      className="btn-ghost h-8 px-2 text-xs"
                     >
-                      移除
+                      编辑
                     </button>
                   )}
-                </td>
+                </div>
+              )}
+              <p className="mt-2 text-sm text-foreground-muted">
+                {team.memberCount} 成员 · 创建于 {formatDate(team.createdAt)}
+              </p>
+            </div>
+            <span className={`status-badge ${ROLE_BADGES[team.role]}`}>
+              你是 {ROLE_LABELS[team.role]}
+            </span>
+          </div>
+
+          <div className="panel-muted flex items-center gap-2 p-3 text-sm">
+            <span className="text-foreground-muted">邀请码:</span>
+            <code className="font-utility text-foreground">{team.inviteCode}</code>
+            <button onClick={copyInvite} className="icon-button h-8 w-8" aria-label="复制邀请码">
+              {copied ? <Check className="h-4 w-4 text-[hsl(var(--color-success))]" aria-hidden="true" /> : <Copy className="h-4 w-4" aria-hidden="true" />}
+            </button>
+          </div>
+
+          <div className="mt-4 flex gap-2">
+            {!isOwner && (
+              <button onClick={() => setConfirmAction("leave")} className="btn-secondary h-9 gap-2 px-3">
+                <LogOut className="h-4 w-4" aria-hidden="true" />
+                退出团队
+              </button>
+            )}
+            {isOwner && (
+              <button
+                onClick={() => setConfirmAction("delete")}
+                className="btn-secondary h-9 gap-2 px-3 text-[hsl(var(--color-error))]"
+              >
+                <Trash2 className="h-4 w-4" aria-hidden="true" />
+                解散团队
+              </button>
+            )}
+          </div>
+        </section>
+
+        <h2 className="mb-3 text-lg font-semibold text-foreground">成员</h2>
+        <div className="table-shell">
+          <table className="w-full text-sm">
+            <thead className="bg-[hsl(var(--secondary)/0.72)] text-xs uppercase text-foreground-muted">
+              <tr>
+                <th className="px-4 py-3 text-left">用户</th>
+                <th className="px-4 py-3 text-left">角色</th>
+                <th className="px-4 py-3 text-left">加入时间</th>
+                <th className="w-32 px-4 py-3 text-right">操作</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+            </thead>
+            <tbody>
+              {team.members.map((member) => (
+                <tr key={member.id} className="data-row">
+                  <td className="px-4 py-3">
+                    <div className="text-foreground">{member.user?.name ?? "(未命名)"}</div>
+                    <div className="text-xs text-foreground-muted">{member.user?.email}</div>
+                  </td>
+                  <td className="px-4 py-3">
+                    {isOwner && member.role !== "owner" ? (
+                      <select
+                        value={member.role}
+                        onChange={async (e) => {
+                          await updateMemberRole(member.userId, e.target.value as "admin" | "member");
+                        }}
+                        className="input w-auto py-1 text-xs"
+                      >
+                        <option value="admin">admin</option>
+                        <option value="member">member</option>
+                      </select>
+                    ) : (
+                      <span className={`status-badge ${ROLE_BADGES[member.role]}`}>
+                        {ROLE_LABELS[member.role]}
+                      </span>
+                    )}
+                  </td>
+                  <td className="font-utility px-4 py-3 text-xs text-foreground-muted">{formatDate(member.joinedAt)}</td>
+                  <td className="px-4 py-3 text-right">
+                    {canManageMember(member) && (
+                      <button
+                        onClick={async () => {
+                          if (confirm(`确定移除 ${member.user?.name ?? member.user?.email}?`)) {
+                            await removeMember(member.userId);
+                          }
+                        }}
+                        className="icon-button h-8 w-8 hover:text-[hsl(var(--color-error))]"
+                        aria-label="移除成员"
+                      >
+                        <Trash2 className="h-4 w-4" aria-hidden="true" />
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
 
-      <div className="mt-4">
-        <a
-          href={`/teams/${teamId}/generations`}
-          className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
-        >
-          查看团队生成历史 →
-        </a>
-      </div>
+        <div className="mt-4">
+          <a href={localizeHref(`/teams/${teamId}/generations`)} className="text-sm font-semibold text-[hsl(var(--primary))] hover:text-[hsl(var(--primary-hover))]">
+            查看团队生成历史
+          </a>
+        </div>
 
-      {confirmAction && (
-        <div
-          className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
-          onClick={() => setConfirmAction(null)}
-          role="dialog"
-          aria-modal="true"
-        >
+        {confirmAction && (
           <div
-            className="bg-white dark:bg-slate-900 rounded-lg shadow-xl max-w-sm w-full p-6"
-            onClick={(e) => e.stopPropagation()}
+            className="fixed inset-0 z-50 flex items-center justify-center bg-[hsl(var(--foreground)/0.42)] p-4"
+            onClick={() => setConfirmAction(null)}
+            role="dialog"
+            aria-modal="true"
           >
-            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-2">
-              {confirmAction === "delete" ? "解散团队" : "退出团队"}
-            </h2>
-            <p className="text-sm text-slate-500 mb-4">
-              {confirmAction === "delete"
-                ? "解散后所有成员将失去访问权限，且无法恢复。确定继续？"
-                : "退出后将无法访问该团队的生成历史。确定继续？"}
-            </p>
-            <div className="flex gap-2 justify-end">
-              <button
-                onClick={() => setConfirmAction(null)}
-                className="px-4 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded"
-              >
-                取消
-              </button>
-              <button
-                onClick={confirmAction === "delete" ? handleDelete : handleLeave}
-                className="px-4 py-2 text-sm bg-red-600 text-white rounded hover:bg-red-700"
-              >
-                确认
-              </button>
+            <div className="panel w-full max-w-sm p-6 shadow-xl" onClick={(e) => e.stopPropagation()}>
+              <div className="mb-4 flex items-start justify-between gap-4">
+                <h2 className="font-display text-2xl font-semibold text-foreground">
+                  {confirmAction === "delete" ? "解散团队" : "退出团队"}
+                </h2>
+                <button onClick={() => setConfirmAction(null)} className="icon-button h-9 w-9" aria-label="关闭">
+                  <X className="h-4 w-4" aria-hidden="true" />
+                </button>
+              </div>
+              <p className="mb-4 text-sm text-foreground-muted">
+                {confirmAction === "delete"
+                  ? "解散后所有成员将失去访问权限，且无法恢复。确定继续？"
+                  : "退出后将无法访问该团队的生成历史。确定继续？"}
+              </p>
+              <div className="flex justify-end gap-2">
+                <button onClick={() => setConfirmAction(null)} className="btn-secondary h-10 px-4">
+                  取消
+                </button>
+                <button
+                  onClick={confirmAction === "delete" ? handleDelete : handleLeave}
+                  className="btn-primary h-10 bg-[hsl(var(--color-error))] px-4 hover:bg-[hsl(var(--color-error))]"
+                >
+                  确认
+                </button>
+              </div>
             </div>
           </div>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/teams/TeamsPage.tsx
+++ b/frontend/src/components/teams/TeamsPage.tsx
@@ -7,6 +7,8 @@
 "use client";
 
 import { useState } from "react";
+import { Check, Copy, Plus, UserPlus, Users, X } from "lucide-react";
+import { localizeHref } from "@/paraglide/runtime.js";
 import { useTeams, type Team } from "@/hooks/useTeams";
 import { StateMessage } from "@/components/StateMessage";
 
@@ -24,17 +26,19 @@ const ROLE_LABELS: Record<Team["role"], string> = {
   member: "成员",
 };
 
-const ROLE_COLORS: Record<Team["role"], string> = {
-  owner: "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300",
-  admin: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
-  member: "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300",
+const ROLE_BADGES: Record<Team["role"], string> = {
+  owner: "status-badge-info",
+  admin: "status-badge-warning",
+  member: "status-badge-neutral",
 };
 
 function CopyableCode({ code }: { code: string }) {
   const [copied, setCopied] = useState(false);
   return (
     <button
-      onClick={async () => {
+      type="button"
+      onClick={async (e) => {
+        e.preventDefault();
         try {
           await navigator.clipboard.writeText(code);
           setCopied(true);
@@ -43,10 +47,15 @@ function CopyableCode({ code }: { code: string }) {
           /* ignore */
         }
       }}
-      className="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-mono bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 rounded"
+      className="panel-muted inline-flex items-center gap-1 px-2 py-0.5 text-xs"
+      aria-label="复制邀请码"
     >
       <code>{code}</code>
-      <span className="text-slate-500">{copied ? "✓" : "📋"}</span>
+      {copied ? (
+        <Check className="h-3.5 w-3.5 text-[hsl(var(--color-success))]" aria-hidden="true" />
+      ) : (
+        <Copy className="h-3.5 w-3.5 text-foreground-muted" aria-hidden="true" />
+      )}
     </button>
   );
 }
@@ -79,164 +88,141 @@ export default function TeamsPage() {
   };
 
   return (
-    <div className="max-w-5xl mx-auto p-6">
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">团队</h1>
-          <p className="text-sm text-slate-500 mt-1">协作共享生成历史</p>
-        </div>
-        <div className="flex gap-2">
-          <button
-            onClick={() => setShowJoin(true)}
-            className="px-3 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded hover:bg-slate-50 dark:hover:bg-slate-800"
-          >
-            加入团队
-          </button>
-          <button
-            onClick={() => setShowCreate(true)}
-            className="px-3 py-2 text-sm bg-slate-900 text-white rounded hover:bg-slate-800"
-          >
-            + 创建团队
-          </button>
-        </div>
-      </div>
-
-      {error && <StateMessage variant="error" message={error} className="mb-4" />}
-
-      {loading && teams.length === 0 ? (
-        <StateMessage variant="loading" message="加载团队..." />
-      ) : teams.length === 0 ? (
-        <StateMessage
-          variant="empty"
-          title="还没有加入任何团队"
-          description="创建或加入团队开始协作"
-        />
-      ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {teams.map((team) => (
-            <a
-              key={team.id}
-              href={`/teams/${team.id}`}
-              className="block bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-4 hover:border-slate-400 dark:hover:border-slate-500 transition-colors"
-            >
-              <div className="flex items-start justify-between mb-2">
-                <h3 className="font-semibold text-slate-900 dark:text-slate-100">
-                  {team.name}
-                </h3>
-                <span className={`px-2 py-0.5 text-xs rounded ${ROLE_COLORS[team.role]}`}>
-                  {ROLE_LABELS[team.role]}
-                </span>
-              </div>
-              <p className="text-xs text-slate-500 mb-2">
-                {team.memberCount} 成员 · 创建于 {formatDate(team.createdAt)}
-              </p>
-              <div className="flex items-center gap-2 text-xs">
-                <span className="text-slate-500">邀请码:</span>
-                <CopyableCode code={team.inviteCode} />
-              </div>
-            </a>
-          ))}
-        </div>
-      )}
-
-      {showCreate && (
-        <div
-          className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
-          onClick={() => setShowCreate(false)}
-          role="dialog"
-          aria-modal="true"
-        >
-          <form
-            onSubmit={handleCreate}
-            className="bg-white dark:bg-slate-900 rounded-lg shadow-xl max-w-md w-full p-6"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-4">
-              创建团队
-            </h2>
-            <div className="mb-4">
-              <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
-                团队名称
-              </label>
-              <input
-                type="text"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder="如：电商产品组"
-                className="w-full px-3 py-2 border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
-                maxLength={100}
-                required
-                autoFocus
-              />
-            </div>
-            <div className="flex gap-2 justify-end">
-              <button
-                type="button"
-                onClick={() => setShowCreate(false)}
-                className="px-4 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded"
-              >
-                取消
-              </button>
-              <button
-                type="submit"
-                disabled={!name.trim()}
-                className="px-4 py-2 text-sm bg-slate-900 text-white rounded hover:bg-slate-800 disabled:opacity-50"
-              >
-                创建
-              </button>
-            </div>
-          </form>
-        </div>
-      )}
-
-      {showJoin && (
-        <div
-          className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
-          onClick={() => setShowJoin(false)}
-          role="dialog"
-          aria-modal="true"
-        >
-          <form
-            onSubmit={handleJoin}
-            className="bg-white dark:bg-slate-900 rounded-lg shadow-xl max-w-md w-full p-6"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-4">
+    <div className="workbench-page">
+      <div className="workbench-container max-w-6xl">
+        <header className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="page-kicker">Team / Collaboration</p>
+            <h1 className="page-title mt-2">团队</h1>
+            <p className="page-description mt-3">协作共享生成历史</p>
+          </div>
+          <div className="flex gap-2">
+            <button onClick={() => setShowJoin(true)} className="btn-secondary h-10 gap-2 px-4">
+              <UserPlus className="h-4 w-4" aria-hidden="true" />
               加入团队
-            </h2>
-            <div className="mb-4">
-              <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
-                邀请码
-              </label>
-              <input
-                type="text"
-                value={inviteCode}
-                onChange={(e) => setInviteCode(e.target.value.toUpperCase())}
-                placeholder="TEAM-XXXXXXXX"
-                className="w-full px-3 py-2 border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800 font-mono"
-                required
-                autoFocus
-              />
-            </div>
-            <div className="flex gap-2 justify-end">
-              <button
-                type="button"
-                onClick={() => setShowJoin(false)}
-                className="px-4 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded"
-              >
-                取消
-              </button>
-              <button
-                type="submit"
-                disabled={!inviteCode.trim()}
-                className="px-4 py-2 text-sm bg-slate-900 text-white rounded hover:bg-slate-800 disabled:opacity-50"
-              >
-                加入
-              </button>
-            </div>
-          </form>
+            </button>
+            <button onClick={() => setShowCreate(true)} className="btn-primary h-10 gap-2 px-4">
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              创建团队
+            </button>
+          </div>
+        </header>
+
+        {error && <StateMessage variant="error" message={error} className="mb-4" />}
+
+        {loading && teams.length === 0 ? (
+          <StateMessage variant="loading" message="加载团队..." />
+        ) : teams.length === 0 ? (
+          <StateMessage
+            variant="empty"
+            title="还没有加入任何团队"
+            description="创建或加入团队开始协作"
+          />
+        ) : (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {teams.map((team) => (
+              <div key={team.id} className="card card-hover p-4">
+                <div className="mb-3 flex items-start justify-between gap-3">
+                  <a
+                    href={localizeHref(`/teams/${team.id}`)}
+                    className="flex min-w-0 items-center gap-2 rounded-sm focus-ring"
+                  >
+                    <Users className="h-5 w-5 shrink-0 text-[hsl(var(--primary))]" aria-hidden="true" />
+                    <h2 className="truncate font-semibold text-foreground">{team.name}</h2>
+                  </a>
+                  <span className={`status-badge ${ROLE_BADGES[team.role]}`}>
+                    {ROLE_LABELS[team.role]}
+                  </span>
+                </div>
+                <p className="mb-3 text-xs text-foreground-muted">
+                  {team.memberCount} 成员 · 创建于 {formatDate(team.createdAt)}
+                </p>
+                <div className="flex items-center gap-2 text-xs">
+                  <span className="text-foreground-muted">邀请码:</span>
+                  <CopyableCode code={team.inviteCode} />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {showCreate && (
+          <TeamModal title="创建团队" onClose={() => setShowCreate(false)} onSubmit={handleCreate}>
+            <label className="panel-label mb-1 block">团队名称</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="如：电商产品组"
+              className="input"
+              maxLength={100}
+              required
+              autoFocus
+            />
+            <button type="submit" disabled={!name.trim()} className="btn-primary h-10 px-4 disabled:cursor-not-allowed disabled:opacity-50">
+              创建
+            </button>
+          </TeamModal>
+        )}
+
+        {showJoin && (
+          <TeamModal title="加入团队" onClose={() => setShowJoin(false)} onSubmit={handleJoin}>
+            <label className="panel-label mb-1 block">邀请码</label>
+            <input
+              type="text"
+              value={inviteCode}
+              onChange={(e) => setInviteCode(e.target.value.toUpperCase())}
+              placeholder="TEAM-XXXXXXXX"
+              className="input font-utility"
+              required
+              autoFocus
+            />
+            <button type="submit" disabled={!inviteCode.trim()} className="btn-primary h-10 px-4 disabled:cursor-not-allowed disabled:opacity-50">
+              加入
+            </button>
+          </TeamModal>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TeamModal({
+  title,
+  onClose,
+  onSubmit,
+  children,
+}: {
+  title: string;
+  onClose: () => void;
+  onSubmit: (e: React.FormEvent) => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[hsl(var(--foreground)/0.42)] p-4"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+    >
+      <form
+        onSubmit={onSubmit}
+        className="panel w-full max-w-md space-y-4 p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <h2 className="font-display text-2xl font-semibold text-foreground">{title}</h2>
+          <button type="button" onClick={onClose} className="icon-button h-9 w-9" aria-label="关闭">
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
         </div>
-      )}
+        {children}
+        <div className="flex justify-end">
+          <button type="button" onClick={onClose} className="btn-secondary h-10 px-4">
+            取消
+          </button>
+        </div>
+      </form>
     </div>
   );
 }

--- a/frontend/src/components/tools/BackgroundRemover.tsx
+++ b/frontend/src/components/tools/BackgroundRemover.tsx
@@ -8,6 +8,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
+import { Download, RefreshCw, Upload, Wand2 } from "lucide-react";
 import { useBackgroundRemoval } from "@/hooks/useBackgroundRemoval";
 
 export default function BackgroundRemover() {
@@ -52,16 +53,18 @@ export default function BackgroundRemover() {
   };
 
   return (
-    <div className="max-w-5xl mx-auto p-6">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">智能去背景</h1>
-        <p className="text-sm text-slate-500 mt-1">
+    <div className="workbench-page">
+      <div className="workbench-container">
+        <header className="mb-8 max-w-3xl">
+          <p className="page-kicker">Tool bench / Background</p>
+          <h1 className="page-title mt-2">智能去背景</h1>
+          <p className="page-description mt-3">
           浏览器内运行，无需上传服务器。基于 @imgly/background-removal（WASM）。
         </p>
-      </div>
+        </header>
 
-      {!imageUrl ? (
-        <div className="bg-white dark:bg-slate-900 rounded-lg border-2 border-dashed border-slate-300 dark:border-slate-700 p-12 text-center">
+        {!imageUrl ? (
+          <div className="drop-zone p-12 text-center">
           <input
             ref={fileInputRef}
             type="file"
@@ -72,49 +75,42 @@ export default function BackgroundRemover() {
           />
           <label
             htmlFor="bg-remover-input"
-            className="inline-block cursor-pointer px-6 py-3 bg-slate-900 text-white rounded-lg hover:bg-slate-800 transition-colors"
+              className="btn-primary h-11 cursor-pointer gap-2 px-6"
           >
+              <Upload className="h-4 w-4" aria-hidden="true" />
             选择图片
           </label>
-          <p className="text-xs text-slate-500 mt-3">支持 PNG / JPG / WebP</p>
+            <p className="mt-3 text-xs font-medium text-foreground-muted">支持 PNG / JPG / WebP</p>
         </div>
       ) : (
         <div className="space-y-4">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {/* Original */}
-            <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-4">
-              <div className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">原图</div>
-              <div className="bg-slate-100 dark:bg-slate-800 rounded p-2 flex items-center justify-center min-h-[200px]">
+            <div className="panel p-4">
+              <div className="panel-title mb-2">原图</div>
+              <div className="panel-muted flex min-h-[220px] items-center justify-center p-2">
                 <img src={imageUrl} alt="Original" className="max-w-full max-h-96 object-contain" loading="lazy" decoding="async" />
               </div>
             </div>
 
-            {/* Result */}
-            <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-4">
+            <div className="panel p-4">
               <div className="flex items-center justify-between mb-2">
-                <div className="text-sm font-medium text-slate-700 dark:text-slate-300">去背景后</div>
+                <div className="panel-title">去背景后</div>
                 {result && (
-                  <span className="text-xs text-slate-500">
+                    <span className="font-utility text-xs text-foreground-muted">
                     {result.width} × {result.height}
                   </span>
                 )}
               </div>
-              <div
-                className="rounded p-2 flex items-center justify-center min-h-[200px]"
-                style={{
-                  backgroundImage:
-                    "linear-gradient(45deg, #f1f5f9 25%, transparent 25%), linear-gradient(-45deg, #f1f5f9 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #f1f5f9 75%), linear-gradient(-45deg, transparent 75%, #f1f5f9 75%)",
-                  backgroundSize: "16px 16px",
-                  backgroundPosition: "0 0, 0 8px, 8px -8px, -8px 0px",
-                }}
-              >
+                <div className="checkerboard flex min-h-[220px] items-center justify-center rounded-md p-2">
                 {loading ? (
                   <div className="text-center">
-                    <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-slate-900 mx-auto mb-2" />
-                    <p className="text-sm text-slate-500">处理中... {progress}%</p>
-                    <div className="w-32 h-1 bg-slate-200 dark:bg-slate-800 rounded mt-2 mx-auto overflow-hidden">
+                      <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-md bg-[hsl(var(--primary)/0.1)] text-[hsl(var(--primary))]">
+                        <Wand2 className="h-5 w-5 animate-pulse" aria-hidden="true" />
+                      </div>
+                      <p className="text-sm font-semibold text-foreground">处理中... {progress}%</p>
+                      <div className="mx-auto mt-3 h-1 w-32 overflow-hidden rounded-full bg-[hsl(var(--secondary))]">
                       <div
-                        className="h-full bg-slate-900 transition-all"
+                          className="h-full bg-[hsl(var(--primary))] transition-all"
                         style={{ width: `${progress}%` }}
                       />
                     </div>
@@ -122,45 +118,49 @@ export default function BackgroundRemover() {
                 ) : result ? (
                   <img src={result.url} alt="Result" className="max-w-full max-h-96 object-contain" loading="lazy" decoding="async" />
                 ) : (
-                  <p className="text-sm text-slate-400">点击"开始处理"生成结果</p>
+                    <p className="text-sm font-medium text-foreground-muted">点击"开始处理"生成结果</p>
                 )}
               </div>
             </div>
           </div>
 
           {error && (
-            <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-3 rounded">
-              <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
+              <div className="error-banner">
+                <p>{error}</p>
             </div>
           )}
 
           <div className="flex gap-2 justify-end">
             <button
               onClick={handleReset}
-              className="px-4 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded hover:bg-slate-50 dark:hover:bg-slate-800"
+                className="btn-secondary h-10 gap-2 px-4"
             >
+                <RefreshCw className="h-4 w-4" aria-hidden="true" />
               重新选择
             </button>
             {!result && (
               <button
                 onClick={handleRemove}
                 disabled={loading}
-                className="px-4 py-2 text-sm bg-slate-900 text-white rounded hover:bg-slate-800 disabled:opacity-50"
+                  className="btn-primary h-10 gap-2 px-4 disabled:cursor-not-allowed disabled:opacity-50"
               >
+                  <Wand2 className="h-4 w-4" aria-hidden="true" />
                 {loading ? "处理中..." : "开始处理"}
               </button>
             )}
             {result && (
               <button
                 onClick={handleDownload}
-                className="px-4 py-2 text-sm bg-slate-900 text-white rounded hover:bg-slate-800"
+                  className="btn-primary h-10 gap-2 px-4"
               >
+                  <Download className="h-4 w-4" aria-hidden="true" />
                 下载 PNG
               </button>
             )}
           </div>
         </div>
       )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/tools/BatchProcessor.tsx
+++ b/frontend/src/components/tools/BatchProcessor.tsx
@@ -8,6 +8,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
+import { Download, PackageOpen, Trash2, Upload, Wand2, X } from "lucide-react";
 import { useBatchProcess, type OutputFormat, type BatchItem } from "@/hooks/useBatchProcess";
 
 function formatBytes(bytes: number): string {
@@ -64,25 +65,26 @@ export default function BatchProcessor() {
   }, 0);
 
   return (
-    <div className="max-w-6xl mx-auto p-6">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">批量处理工具</h1>
-        <p className="text-sm text-slate-500 mt-1">
+    <div className="workbench-page">
+      <div className="workbench-container">
+        <header className="mb-8 max-w-3xl">
+          <p className="page-kicker">Tool bench / Batch</p>
+          <h1 className="page-title mt-2">批量处理工具</h1>
+          <p className="page-description mt-3">
           浏览器内批量处理图片：调整尺寸、压缩、添加水印、格式转换。
         </p>
-      </div>
+        </header>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-        {/* Options panel */}
-        <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-4 space-y-4">
-          <h2 className="text-sm font-medium text-slate-700 dark:text-slate-300">处理选项</h2>
+          <div className="panel space-y-4 p-4">
+            <h2 className="panel-title">处理选项</h2>
 
           <div>
-            <label className="block text-xs text-slate-500 mb-1">输出格式</label>
+              <label className="panel-label mb-1 block">输出格式</label>
             <select
               value={options.format}
               onChange={(e) => setOptions({ ...options, format: e.target.value as OutputFormat })}
-              className="w-full px-2 py-1.5 text-sm border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+                className="input py-1.5"
             >
               <option value="image/jpeg">JPEG</option>
               <option value="image/png">PNG</option>
@@ -92,30 +94,30 @@ export default function BatchProcessor() {
 
           <div className="grid grid-cols-2 gap-2">
             <div>
-              <label className="block text-xs text-slate-500 mb-1">宽 (px)</label>
+                <label className="panel-label mb-1 block">宽 (px)</label>
               <input
                 type="number"
                 value={options.resizeWidth ?? ""}
                 onChange={(e) => setOptions({ ...options, resizeWidth: e.target.value ? Number(e.target.value) : undefined })}
                 placeholder="原图"
-                className="w-full px-2 py-1.5 text-sm border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+                  className="input py-1.5"
               />
             </div>
             <div>
-              <label className="block text-xs text-slate-500 mb-1">高 (px)</label>
+                <label className="panel-label mb-1 block">高 (px)</label>
               <input
                 type="number"
                 value={options.resizeHeight ?? ""}
                 onChange={(e) => setOptions({ ...options, resizeHeight: e.target.value ? Number(e.target.value) : undefined })}
                 placeholder="原图"
-                className="w-full px-2 py-1.5 text-sm border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+                  className="input py-1.5"
               />
             </div>
           </div>
 
           {options.format !== "image/png" && (
             <div>
-              <div className="flex justify-between text-xs text-slate-500 mb-1">
+                <div className="mb-1 flex justify-between text-xs font-medium text-foreground-muted">
                 <span>质量</span>
                 <span>{Math.round(options.quality * 100)}%</span>
               </div>
@@ -126,20 +128,21 @@ export default function BatchProcessor() {
                 step="0.05"
                 value={options.quality}
                 onChange={(e) => setOptions({ ...options, quality: Number(e.target.value) })}
-                className="w-full accent-slate-900"
+                  className="range"
+                  aria-label="输出质量"
               />
             </div>
           )}
 
-          <div className="space-y-2 pt-2 border-t border-slate-100 dark:border-slate-800">
+            <div className="space-y-2 border-t border-[hsl(var(--border))] pt-2">
             <label className="flex items-center gap-2">
               <input
                 type="checkbox"
                 checked={options.watermarkEnabled}
                 onChange={(e) => setOptions({ ...options, watermarkEnabled: e.target.checked })}
-                className="rounded"
+                  className="h-4 w-4 rounded border-[hsl(var(--border))] text-[hsl(var(--primary))] focus:ring-[hsl(var(--primary)/0.28)]"
               />
-              <span className="text-sm text-slate-700 dark:text-slate-300">添加水印</span>
+                <span className="text-sm font-medium text-foreground">添加水印</span>
             </label>
             {options.watermarkEnabled && (
               <input
@@ -147,7 +150,7 @@ export default function BatchProcessor() {
                 value={options.watermarkText}
                 onChange={(e) => setOptions({ ...options, watermarkText: e.target.value })}
                 placeholder="水印文字"
-                className="w-full px-2 py-1.5 text-sm border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+                  className="input py-1.5"
               />
             )}
           </div>
@@ -155,16 +158,18 @@ export default function BatchProcessor() {
           <button
             onClick={processAll}
             disabled={items.length === 0 || processing}
-            className="w-full px-4 py-2 text-sm bg-slate-900 text-white rounded hover:bg-slate-800 disabled:opacity-50"
+              className="btn-primary h-10 w-full gap-2 disabled:cursor-not-allowed disabled:opacity-50"
           >
+              <Wand2 className="h-4 w-4" aria-hidden="true" />
             {processing ? `处理中 ${progress}%` : `开始处理 (${items.length})`}
           </button>
 
           {completedCount > 0 && (
             <button
               onClick={downloadZip}
-              className="w-full px-4 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded hover:bg-slate-50 dark:hover:bg-slate-800"
+                className="btn-secondary h-10 w-full gap-2"
             >
+                <Download className="h-4 w-4" aria-hidden="true" />
               下载 ZIP ({completedCount})
             </button>
           )}
@@ -176,11 +181,7 @@ export default function BatchProcessor() {
             onDragOver={(e) => { e.preventDefault(); setDragActive(true); }}
             onDragLeave={() => setDragActive(false)}
             onDrop={handleDrop}
-            className={`border-2 border-dashed rounded-lg p-6 text-center transition-colors ${
-              dragActive
-                ? "border-slate-900 dark:border-slate-100 bg-slate-50 dark:bg-slate-800/50"
-                : "border-slate-300 dark:border-slate-700"
-            }`}
+              className={`drop-zone p-8 text-center ${dragActive ? "drop-zone-active" : ""}`}
           >
             <input
               ref={fileInputRef}
@@ -193,34 +194,44 @@ export default function BatchProcessor() {
             />
             <label
               htmlFor="batch-input"
-              className="inline-block cursor-pointer px-4 py-2 bg-slate-900 text-white text-sm rounded hover:bg-slate-800"
+                className="btn-primary h-10 cursor-pointer gap-2 px-4"
             >
+                <Upload className="h-4 w-4" aria-hidden="true" />
               选择多张图片
             </label>
-            <p className="text-xs text-slate-500 mt-2">或拖放图片到这里</p>
+              <p className="mt-2 text-xs font-medium text-foreground-muted">或拖放图片到这里</p>
           </div>
 
           {items.length > 0 && (
-            <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 overflow-hidden">
-              <div className="px-4 py-2 border-b border-slate-200 dark:border-slate-700 flex items-center justify-between">
-                <div className="text-sm">
+              <div className="panel overflow-hidden">
+                <div className="flex items-center justify-between border-b border-[hsl(var(--border))] px-4 py-3">
+                  <div className="text-sm font-semibold text-foreground">
                   共 {items.length} 张 · 完成 {completedCount}
                   {totalSavings > 0 && ` · 节省 ${formatBytes(totalSavings)}`}
                 </div>
                 <button
                   onClick={clearAll}
-                  className="text-xs text-slate-500 hover:text-red-500"
+                    className="icon-button h-8 gap-1 px-2 text-xs"
                 >
+                    <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
                   清空
                 </button>
               </div>
-              <div className="divide-y divide-slate-100 dark:divide-slate-800 max-h-[500px] overflow-y-auto">
+                <div className="max-h-[500px] overflow-y-auto">
                 {items.map((item) => (
                   <BatchItemRow key={item.id} item={item} onRemove={removeItem} onDownload={downloadOne} />
                 ))}
               </div>
             </div>
           )}
+            {items.length === 0 && (
+              <div className="panel-muted flex min-h-[260px] flex-col items-center justify-center p-8 text-center">
+                <PackageOpen className="mb-4 h-10 w-10 text-foreground-muted" aria-hidden="true" />
+                <p className="font-semibold text-foreground">还没有待处理图片</p>
+                <p className="mt-1 text-sm text-foreground-muted">选择或拖入图片后，这里会显示处理队列。</p>
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>
@@ -229,15 +240,15 @@ export default function BatchProcessor() {
 
 function BatchItemRow({ item, onRemove, onDownload }: { item: BatchItem; onRemove: (id: string) => void; onDownload: (item: BatchItem) => void }) {
   return (
-    <div className="px-4 py-3 flex items-center gap-3">
-      <div className="w-12 h-12 bg-slate-100 dark:bg-slate-800 rounded overflow-hidden flex-shrink-0">
+    <div className="data-row flex items-center gap-3 px-4 py-3">
+      <div className="h-12 w-12 flex-shrink-0 overflow-hidden rounded-md bg-[hsl(var(--secondary))]">
         <img src={item.resultUrl ?? item.originalUrl} alt="" className="w-full h-full object-cover" loading="lazy" decoding="async" />
       </div>
       <div className="flex-1 min-w-0">
-        <div className="text-sm font-medium text-slate-900 dark:text-slate-100 truncate">
+        <div className="truncate text-sm font-semibold text-foreground">
           {item.file.name}
         </div>
-        <div className="text-xs text-slate-500">
+        <div className="font-utility text-xs text-foreground-muted">
           {item.status === "done" ? (
             <>
               {item.width}×{item.height} · {formatBytes(item.originalSize)} → {formatBytes(item.resultSize)}
@@ -248,28 +259,29 @@ function BatchItemRow({ item, onRemove, onDownload }: { item: BatchItem; onRemov
         </div>
       </div>
       <div className="flex items-center gap-2">
-        <span className={`text-xs px-2 py-0.5 rounded ${
-          item.status === "done" ? "bg-green-100 text-green-700" :
-          item.status === "error" ? "bg-red-100 text-red-700" :
-          item.status === "processing" ? "bg-blue-100 text-blue-700" :
-          "bg-slate-100 text-slate-700"
+        <span className={`status-badge ${
+          item.status === "done" ? "status-badge-success" :
+          item.status === "error" ? "status-badge-error" :
+          item.status === "processing" ? "status-badge-info" :
+          "status-badge-neutral"
         }`}>
           {item.status === "done" ? "完成" : item.status === "error" ? "失败" : item.status === "processing" ? "处理中" : "等待"}
         </span>
         {item.status === "done" && (
           <button
             onClick={() => onDownload(item)}
-            className="text-xs text-blue-600 hover:underline"
+            className="icon-button h-8 gap-1 px-2 text-xs"
           >
+            <Download className="h-3.5 w-3.5" aria-hidden="true" />
             下载
           </button>
         )}
         <button
           onClick={() => onRemove(item.id)}
-          className="text-slate-400 hover:text-red-500"
-          aria-label="Remove"
+          className="icon-button h-8 w-8 hover:text-[hsl(var(--color-error))]"
+          aria-label="Remove image"
         >
-          ✕
+          <X className="h-4 w-4" aria-hidden="true" />
         </button>
       </div>
     </div>

--- a/frontend/src/components/tools/CollageMaker.tsx
+++ b/frontend/src/components/tools/CollageMaker.tsx
@@ -7,6 +7,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
+import { Download, ImagePlus, X } from "lucide-react";
 import { useImageCollage, LAYOUTS, type LayoutTemplate, type CollageCell } from "@/hooks/useImageCollage";
 
 export default function CollageMaker() {
@@ -60,40 +61,37 @@ export default function CollageMaker() {
   const filledCount = cells.filter((c) => c.imageUrl).length;
 
   return (
-    <div className="max-w-6xl mx-auto p-6">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">图片拼图</h1>
-        <p className="text-sm text-slate-500 mt-1">
+    <div className="workbench-page">
+      <div className="workbench-container">
+        <header className="mb-8 max-w-3xl">
+          <p className="page-kicker">Tool bench / Collage</p>
+          <h1 className="page-title mt-2">图片拼图</h1>
+          <p className="page-description mt-3">
           浏览器内多图组合，导出 PNG
         </p>
-      </div>
+        </header>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-        {/* Options */}
-        <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-4 space-y-4">
-          <h2 className="text-sm font-medium text-slate-700 dark:text-slate-300">布局</h2>
+          <div className="panel space-y-4 p-4">
+            <h2 className="panel-title">布局</h2>
           <div className="grid grid-cols-2 gap-2">
             {(Object.keys(LAYOUTS) as LayoutTemplate[]).map((key) => (
               <button
                 key={key}
                 onClick={() => setOptions({ ...options, layout: key })}
-                className={`px-2 py-2 text-xs rounded ${
-                  options.layout === key
-                    ? "bg-slate-900 text-white"
-                    : "bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700"
-                }`}
+                  className={`segmented-option ${options.layout === key ? "segmented-option-active" : ""}`}
               >
                 {LAYOUTS[key].label}
               </button>
             ))}
           </div>
 
-          <h2 className="text-sm font-medium text-slate-700 dark:text-slate-300 pt-2 border-t border-slate-100 dark:border-slate-800">输出尺寸</h2>
+            <h2 className="panel-title border-t border-[hsl(var(--border))] pt-4">输出尺寸</h2>
           <div className="grid grid-cols-2 gap-2">
             <select
               value={String(options.outputWidth)}
               onChange={(e) => setOptions({ ...options, outputWidth: Number(e.target.value), outputHeight: Number(e.target.value) })}
-              className="px-2 py-1.5 text-sm border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+                className="input py-1.5"
             >
               <option value="1080">1080×1080</option>
               <option value="720">720×720</option>
@@ -103,12 +101,13 @@ export default function CollageMaker() {
               type="color"
               value={options.backgroundColor}
               onChange={(e) => setOptions({ ...options, backgroundColor: e.target.value })}
-              className="w-full h-8 border border-slate-200 dark:border-slate-700 rounded"
+                className="swatch"
+                aria-label="拼图背景色"
             />
           </div>
 
           <div>
-            <div className="flex justify-between text-xs text-slate-500 mb-1">
+              <div className="mb-1 flex justify-between text-xs font-medium text-foreground-muted">
               <span>间距</span>
               <span>{options.gap}px</span>
             </div>
@@ -118,12 +117,13 @@ export default function CollageMaker() {
               max="32"
               value={options.gap}
               onChange={(e) => setOptions({ ...options, gap: Number(e.target.value) })}
-              className="w-full accent-slate-900"
+                className="range"
+                aria-label="拼图间距"
             />
           </div>
 
           <div>
-            <div className="flex justify-between text-xs text-slate-500 mb-1">
+              <div className="mb-1 flex justify-between text-xs font-medium text-foreground-muted">
               <span>圆角</span>
               <span>{options.borderRadius}px</span>
             </div>
@@ -133,14 +133,16 @@ export default function CollageMaker() {
               max="32"
               value={options.borderRadius}
               onChange={(e) => setOptions({ ...options, borderRadius: Number(e.target.value) })}
-              className="w-full accent-slate-900"
+                className="range"
+                aria-label="拼图圆角"
             />
           </div>
 
           <button
             onClick={() => fileInputRef.current?.click()}
-            className="w-full px-4 py-2 text-sm bg-slate-900 text-white rounded hover:bg-slate-800"
+              className="btn-primary h-10 w-full gap-2"
           >
+              <ImagePlus className="h-4 w-4" aria-hidden="true" />
             添加图片 ({filledCount}/{cells.length})
           </button>
           <input
@@ -155,16 +157,16 @@ export default function CollageMaker() {
           <button
             onClick={download}
             disabled={filledCount === 0 || exporting}
-            className="w-full px-4 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded hover:bg-slate-50 dark:hover:bg-slate-800 disabled:opacity-50"
+              className="btn-secondary h-10 w-full gap-2 disabled:cursor-not-allowed disabled:opacity-50"
           >
+              <Download className="h-4 w-4" aria-hidden="true" />
             {exporting ? "导出中..." : "下载 PNG"}
           </button>
         </div>
 
-        {/* Preview */}
         <div className="lg:col-span-2 space-y-4">
-          <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-4">
-            <div className="flex items-center justify-center bg-slate-50 dark:bg-slate-800 rounded min-h-[400px]">
+            <div className="panel p-4">
+              <div className="panel-muted flex min-h-[400px] items-center justify-center">
               <canvas
                 ref={canvasRef}
                 className="max-w-full max-h-[600px]"
@@ -173,18 +175,18 @@ export default function CollageMaker() {
               {previewUrl ? (
                 <img src={previewUrl} alt="Preview" className="max-w-full max-h-[600px] object-contain" loading="lazy" decoding="async" />
               ) : (
-                <p className="text-slate-400 p-12">添加图片开始</p>
+                  <p className="p-12 text-sm font-medium text-foreground-muted">添加图片开始</p>
               )}
             </div>
           </div>
 
-          {/* Cell editor */}
           <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-2">
             {cells.map((cell, idx) => (
               <CellEditor key={idx} index={idx} cell={cell} onUpdate={(p) => updateCell(idx, p)} onRemove={() => removeCell(idx)} />
             ))}
           </div>
         </div>
+      </div>
       </div>
     </div>
   );
@@ -203,25 +205,26 @@ function CellEditor({
 }) {
   if (!cell.imageUrl) {
     return (
-      <div className="aspect-square bg-slate-100 dark:bg-slate-800 rounded flex items-center justify-center text-slate-400 text-xs">
+      <div className="panel-muted flex aspect-square items-center justify-center font-utility text-xs text-foreground-muted">
         #{index + 1}
       </div>
     );
   }
   return (
     <div className="space-y-1">
-      <div className="aspect-square rounded overflow-hidden bg-slate-100 dark:bg-slate-800 relative group">
+      <div className="group relative aspect-square overflow-hidden rounded-md bg-[hsl(var(--secondary))]">
         <img src={cell.imageUrl} alt={`Cell ${index + 1}`} className="w-full h-full object-cover" loading="lazy" decoding="async" />
         <button
           onClick={onRemove}
-          className="absolute top-1 right-1 w-5 h-5 bg-red-500 text-white rounded-full text-xs opacity-0 group-hover:opacity-100"
+          className="absolute right-1 top-1 flex h-6 w-6 items-center justify-center rounded-md bg-[hsl(var(--color-error))] text-white opacity-0 transition-opacity group-hover:opacity-100"
+          aria-label={`移除第 ${index + 1} 张图片`}
         >
-          ✕
+          <X className="h-3.5 w-3.5" aria-hidden="true" />
         </button>
       </div>
       <div className="space-y-0.5">
         <div className="flex items-center gap-1">
-          <span className="text-[10px] text-slate-500 w-6">缩放</span>
+          <span className="w-6 text-[10px] text-foreground-muted">缩放</span>
           <input
             type="range"
             min="1"
@@ -229,7 +232,8 @@ function CellEditor({
             step="0.1"
             value={cell.scale}
             onChange={(e) => onUpdate({ scale: Number(e.target.value) })}
-            className="flex-1 accent-slate-900"
+            className="range flex-1"
+            aria-label={`第 ${index + 1} 张图片缩放`}
           />
         </div>
       </div>

--- a/frontend/src/components/tools/ExportDemo.tsx
+++ b/frontend/src/components/tools/ExportDemo.tsx
@@ -7,6 +7,7 @@
 "use client";
 
 import { useState, useRef } from "react";
+import { Download, ImagePlus, Replace } from "lucide-react";
 import ExportDialog from "./ExportDialog";
 
 export default function ExportDemo() {
@@ -15,34 +16,38 @@ export default function ExportDemo() {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   return (
-    <div className="max-w-3xl mx-auto p-6">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">导出格式与质量</h1>
-        <p className="text-sm text-slate-500 mt-1">多格式输出 + 质量预设 + 平台尺寸</p>
-      </div>
+    <div className="workbench-page">
+      <div className="workbench-container max-w-4xl">
+        <header className="mb-8 max-w-3xl">
+          <p className="page-kicker">Tool bench / Export</p>
+          <h1 className="page-title mt-2">导出格式与质量</h1>
+          <p className="page-description mt-3">多格式输出 + 质量预设 + 平台尺寸</p>
+        </header>
 
       {imageUrl ? (
-        <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-6">
-          <div className="flex items-center justify-center bg-slate-50 dark:bg-slate-800 rounded mb-4 p-4 min-h-[300px]">
+          <div className="panel p-6">
+            <div className="panel-muted mb-4 flex min-h-[320px] items-center justify-center p-4">
             <img src={imageUrl} alt="Selected" className="max-w-full max-h-[400px] object-contain" loading="lazy" decoding="async" />
           </div>
           <div className="flex gap-2 justify-end">
             <button
               onClick={() => fileInputRef.current?.click()}
-              className="px-4 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded hover:bg-slate-50 dark:hover:bg-slate-800"
+                className="btn-secondary h-10 gap-2 px-4"
             >
+                <Replace className="h-4 w-4" aria-hidden="true" />
               更换图片
             </button>
             <button
               onClick={() => setShowDialog(true)}
-              className="px-4 py-2 text-sm bg-slate-900 text-white rounded hover:bg-slate-800"
+                className="btn-primary h-10 gap-2 px-4"
             >
-              导出...
+                <Download className="h-4 w-4" aria-hidden="true" />
+              导出
             </button>
           </div>
         </div>
       ) : (
-        <div className="bg-white dark:bg-slate-900 rounded-lg border-2 border-dashed border-slate-300 dark:border-slate-700 p-12 text-center">
+          <div className="drop-zone p-12 text-center">
           <input
             ref={fileInputRef}
             type="file"
@@ -56,15 +61,17 @@ export default function ExportDemo() {
           />
           <label
             htmlFor="export-input"
-            className="inline-block cursor-pointer px-6 py-3 bg-slate-900 text-white rounded hover:bg-slate-800"
+              className="btn-primary h-11 cursor-pointer gap-2 px-6"
           >
+              <ImagePlus className="h-4 w-4" aria-hidden="true" />
             选择图片
           </label>
-          <p className="text-xs text-slate-500 mt-3">支持 PNG / JPG / WebP</p>
+            <p className="mt-3 text-xs font-medium text-foreground-muted">支持 PNG / JPG / WebP</p>
         </div>
       )}
 
       <ExportDialog imageUrl={imageUrl} isOpen={showDialog} onClose={() => setShowDialog(false)} />
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/tools/ExportDialog.tsx
+++ b/frontend/src/components/tools/ExportDialog.tsx
@@ -8,6 +8,7 @@
 "use client";
 
 import { useState } from "react";
+import { Download, X } from "lucide-react";
 
 export type ExportFormat = "image/png" | "image/jpeg" | "image/webp";
 
@@ -106,22 +107,33 @@ export default function ExportDialog({ imageUrl, isOpen, onClose }: ExportDialog
 
   return (
     <div
-      className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[hsl(var(--foreground)/0.42)] p-4"
       onClick={onClose}
       role="dialog"
       aria-modal="true"
+      aria-labelledby="export-dialog-title"
     >
       <div
-        className="bg-white dark:bg-slate-900 rounded-lg shadow-xl max-w-md w-full p-6"
+        className="panel w-full max-w-md overflow-hidden shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
-        <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-4">
-          导出图片
-        </h2>
+        <div className="proof-strip h-2" />
+        <div className="p-6">
+          <div className="mb-4 flex items-start justify-between gap-4">
+            <div>
+              <p className="page-kicker">Export proof</p>
+              <h2 id="export-dialog-title" className="font-display mt-1 text-2xl font-semibold text-foreground">
+                导出图片
+              </h2>
+            </div>
+            <button type="button" onClick={onClose} className="icon-button h-9 w-9" aria-label="关闭导出弹窗">
+              <X className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </div>
 
         <div className="space-y-4">
           <div>
-            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+              <label className="mb-2 block text-sm font-semibold text-foreground">
               格式
             </label>
             <div className="grid grid-cols-3 gap-1.5">
@@ -129,20 +141,18 @@ export default function ExportDialog({ imageUrl, isOpen, onClose }: ExportDialog
                 <button
                   key={f}
                   onClick={() => setFormat(f)}
-                  className={`px-2 py-2 text-xs rounded ${
-                    format === f ? "bg-slate-900 text-white" : "bg-slate-100 dark:bg-slate-800"
-                  }`}
+                    className={`segmented-option ${format === f ? "segmented-option-active" : ""}`}
                 >
                   {FORMAT_LABELS[f].split(" ")[0]}
                 </button>
               ))}
             </div>
-            <p className="text-xs text-slate-500 mt-1">{FORMAT_LABELS[format]}</p>
+              <p className="mt-1 text-xs font-medium text-foreground-muted">{FORMAT_LABELS[format]}</p>
           </div>
 
           {format !== "image/png" && (
             <div>
-              <div className="flex justify-between text-xs text-slate-500 mb-1">
+                <div className="mb-1 flex justify-between text-xs font-medium text-foreground-muted">
                 <span>质量</span>
                 <span>{Math.round(quality * 100)}%</span>
               </div>
@@ -153,19 +163,20 @@ export default function ExportDialog({ imageUrl, isOpen, onClose }: ExportDialog
                 step="0.05"
                 value={quality}
                 onChange={(e) => setQuality(Number(e.target.value))}
-                className="w-full accent-slate-900"
+                  className="range"
+                  aria-label="导出质量"
               />
             </div>
           )}
 
           <div>
-            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+              <label className="mb-2 block text-sm font-semibold text-foreground">
               尺寸预设
             </label>
             <select
               value={presetIdx}
               onChange={(e) => setPresetIdx(Number(e.target.value))}
-              className="w-full px-3 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded bg-white dark:bg-slate-800"
+                className="input"
             >
               {DEFAULT_PRESETS.map((p, i) => (
                 <option key={i} value={i}>
@@ -179,17 +190,19 @@ export default function ExportDialog({ imageUrl, isOpen, onClose }: ExportDialog
         <div className="flex gap-2 justify-end mt-6">
           <button
             onClick={onClose}
-            className="px-4 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded"
+              className="btn-secondary h-10 px-4"
           >
             取消
           </button>
           <button
             onClick={handleExport}
             disabled={!imageUrl || exporting}
-            className="px-4 py-2 text-sm bg-slate-900 text-white rounded hover:bg-slate-800 disabled:opacity-50"
+              className="btn-primary h-10 gap-2 px-4 disabled:cursor-not-allowed disabled:opacity-50"
           >
+              <Download className="h-4 w-4" aria-hidden="true" />
             {exporting ? "导出中..." : "下载"}
           </button>
+        </div>
         </div>
       </div>
     </div>

--- a/frontend/src/components/tools/ImageBorder.tsx
+++ b/frontend/src/components/tools/ImageBorder.tsx
@@ -7,6 +7,7 @@
 "use client";
 
 import { useRef } from "react";
+import { Download, ImagePlus } from "lucide-react";
 import { useImageBorder, BORDER_STYLES, BADGES, type BorderStyle, type BadgeStyle } from "@/hooks/useImageBorder";
 
 export default function ImageBorder() {
@@ -14,25 +15,24 @@ export default function ImageBorder() {
   const { options, setOptions, imageUrl, setImage, canvasRef, previewUrl, exporting, download } = useImageBorder();
 
   return (
-    <div className="max-w-6xl mx-auto p-6">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">智能边框与装饰</h1>
-        <p className="text-sm text-slate-500 mt-1">
+    <div className="workbench-page">
+      <div className="workbench-container">
+        <header className="mb-8 max-w-3xl">
+          <p className="page-kicker">Tool bench / Product frame</p>
+          <h1 className="page-title mt-2">智能边框与装饰</h1>
+          <p className="page-description mt-3">
           为商品图片添加专业级边框、投影、徽章
         </p>
-      </div>
+        </header>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-        {/* Options */}
-        <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-4 space-y-4">
+          <div className="panel space-y-4 p-4">
           <div>
-            <h2 className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">边框样式</h2>
+              <h2 className="panel-title mb-2">边框样式</h2>
             <div className="grid grid-cols-2 gap-1.5">
               <button
                 onClick={() => setOptions({ ...options, borderStyle: "none" })}
-                className={`px-2 py-1.5 text-xs rounded ${
-                  options.borderStyle === "none" ? "bg-slate-900 text-white" : "bg-slate-100 dark:bg-slate-800"
-                }`}
+                  className={`segmented-option ${options.borderStyle === "none" ? "segmented-option-active" : ""}`}
               >
                 无
               </button>
@@ -40,9 +40,7 @@ export default function ImageBorder() {
                 <button
                   key={key}
                   onClick={() => setOptions({ ...options, borderStyle: key })}
-                  className={`px-2 py-1.5 text-xs rounded ${
-                    options.borderStyle === key ? "bg-slate-900 text-white" : "bg-slate-100 dark:bg-slate-800"
-                  }`}
+                    className={`segmented-option ${options.borderStyle === key ? "segmented-option-active" : ""}`}
                 >
                   {BORDER_STYLES[key].label}
                 </button>
@@ -53,17 +51,18 @@ export default function ImageBorder() {
           {options.borderStyle !== "none" && (
             <>
               <div>
-                <label className="block text-xs text-slate-500 mb-1">边框/背景色</label>
+                  <label className="panel-label mb-1 block">边框/背景色</label>
                 <input
                   type="color"
                   value={options.borderColor}
                   onChange={(e) => setOptions({ ...options, borderColor: e.target.value })}
-                  className="w-full h-8 border border-slate-200 dark:border-slate-700 rounded"
+                    className="swatch"
+                    aria-label="边框或背景色"
                 />
               </div>
 
               <div>
-                <div className="flex justify-between text-xs text-slate-500 mb-1">
+                  <div className="mb-1 flex justify-between text-xs font-medium text-foreground-muted">
                   <span>留白</span>
                   <span>{options.outputPadding}px</span>
                 </div>
@@ -73,20 +72,19 @@ export default function ImageBorder() {
                   max="80"
                   value={options.outputPadding}
                   onChange={(e) => setOptions({ ...options, outputPadding: Number(e.target.value) })}
-                  className="w-full accent-slate-900"
+                    className="range"
+                    aria-label="输出留白"
                 />
               </div>
             </>
           )}
 
-          <div className="pt-2 border-t border-slate-100 dark:border-slate-800">
-            <h2 className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">徽章</h2>
+            <div className="border-t border-[hsl(var(--border))] pt-4">
+              <h2 className="panel-title mb-2">徽章</h2>
             <div className="grid grid-cols-3 gap-1.5">
               <button
                 onClick={() => setOptions({ ...options, badge: "none" })}
-                className={`px-2 py-1.5 text-xs rounded ${
-                  options.badge === "none" ? "bg-slate-900 text-white" : "bg-slate-100 dark:bg-slate-800"
-                }`}
+                  className={`segmented-option ${options.badge === "none" ? "segmented-option-active" : ""}`}
               >
                 无
               </button>
@@ -94,9 +92,7 @@ export default function ImageBorder() {
                 <button
                   key={key}
                   onClick={() => setOptions({ ...options, badge: key })}
-                  className={`px-2 py-1.5 text-xs rounded ${
-                    options.badge === key ? "bg-slate-900 text-white" : "bg-slate-100 dark:bg-slate-800"
-                  }`}
+                    className={`segmented-option ${options.badge === key ? "segmented-option-active" : ""}`}
                 >
                   {BADGES[key].label}
                 </button>
@@ -107,15 +103,14 @@ export default function ImageBorder() {
           {options.badge !== "none" && (
             <>
               <div>
-                <h3 className="text-xs text-slate-500 mb-1">位置</h3>
+                  <h3 className="panel-label mb-1">位置</h3>
                 <div className="grid grid-cols-4 gap-1">
                   {(["tl", "tr", "bl", "br"] as const).map((pos) => (
                     <button
                       key={pos}
                       onClick={() => setOptions({ ...options, badgePosition: pos })}
-                      className={`h-8 text-xs rounded ${
-                        options.badgePosition === pos ? "bg-slate-900 text-white" : "bg-slate-100 dark:bg-slate-800"
-                      }`}
+                        className={`segmented-option h-8 ${options.badgePosition === pos ? "segmented-option-active" : ""}`}
+                        aria-label={`徽章位置 ${pos}`}
                     >
                       {pos === "tl" ? "↖" : pos === "tr" ? "↗" : pos === "bl" ? "↙" : "↘"}
                     </button>
@@ -124,7 +119,7 @@ export default function ImageBorder() {
               </div>
 
               <div>
-                <div className="flex justify-between text-xs text-slate-500 mb-1">
+                  <div className="mb-1 flex justify-between text-xs font-medium text-foreground-muted">
                   <span>大小</span>
                   <span>{options.badgeSize}px</span>
                 </div>
@@ -134,7 +129,8 @@ export default function ImageBorder() {
                   max="120"
                   value={options.badgeSize}
                   onChange={(e) => setOptions({ ...options, badgeSize: Number(e.target.value) })}
-                  className="w-full accent-slate-900"
+                    className="range"
+                    aria-label="徽章大小"
                 />
               </div>
             </>
@@ -142,8 +138,9 @@ export default function ImageBorder() {
 
           <button
             onClick={() => fileInputRef.current?.click()}
-            className="w-full px-4 py-2 text-sm bg-slate-900 text-white rounded hover:bg-slate-800"
+              className="btn-primary h-10 w-full gap-2"
           >
+              <ImagePlus className="h-4 w-4" aria-hidden="true" />
             {imageUrl ? "更换图片" : "选择图片"}
           </button>
           <input
@@ -161,22 +158,22 @@ export default function ImageBorder() {
             <button
               onClick={download}
               disabled={exporting}
-              className="w-full px-4 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded hover:bg-slate-50 dark:hover:bg-slate-800 disabled:opacity-50"
+                className="btn-secondary h-10 w-full gap-2 disabled:cursor-not-allowed disabled:opacity-50"
             >
+                <Download className="h-4 w-4" aria-hidden="true" />
               {exporting ? "导出中..." : "下载 PNG"}
             </button>
           )}
         </div>
 
-        {/* Preview */}
         <div className="lg:col-span-2">
-          <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-4">
-            <div className="flex items-center justify-center bg-slate-50 dark:bg-slate-800 rounded min-h-[500px]">
+            <div className="panel p-4">
+              <div className="panel-muted flex min-h-[500px] items-center justify-center">
               <canvas ref={canvasRef} className="hidden" />
               {previewUrl ? (
                 <img src={previewUrl} alt="Preview" className="max-w-full max-h-[600px] object-contain" loading="lazy" decoding="async" />
               ) : (
-                <p className="text-slate-400 p-12 text-center">
+                  <p className="p-12 text-center text-sm font-medium text-foreground-muted">
                   上传图片开始<br />
                   <span className="text-xs">支持 PNG / JPG / WebP</span>
                 </p>
@@ -184,6 +181,7 @@ export default function ImageBorder() {
             </div>
           </div>
         </div>
+      </div>
       </div>
     </div>
   );

--- a/frontend/src/components/tools/ImageCutout.tsx
+++ b/frontend/src/components/tools/ImageCutout.tsx
@@ -8,6 +8,7 @@
 "use client";
 
 import { useRef, useState, useEffect, useCallback } from "react";
+import { Download, Eraser, ImagePlus, Scissors } from "lucide-react";
 import { useImageCutout, type CutoutMode } from "@/hooks/useImageCutout";
 
 export default function ImageCutout() {
@@ -76,16 +77,18 @@ export default function ImageCutout() {
   }, [imageUrl]);
 
   return (
-    <div className="max-w-6xl mx-auto p-6">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">智能抠图</h1>
-        <p className="text-sm text-slate-500 mt-1">矩形或画笔选区 → 边缘羽化 → 导出透明 PNG</p>
-      </div>
+    <div className="workbench-page">
+      <div className="workbench-container">
+        <header className="mb-8 max-w-3xl">
+          <p className="page-kicker">Tool bench / Cutout</p>
+          <h1 className="page-title mt-2">智能抠图</h1>
+          <p className="page-description mt-3">矩形或画笔选区 → 边缘羽化 → 导出透明 PNG</p>
+        </header>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-        <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-4 space-y-4">
+          <div className="panel space-y-4 p-4">
           <div>
-            <h2 className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">选区模式</h2>
+              <h2 className="panel-title mb-2">选区模式</h2>
             <div className="grid grid-cols-2 gap-1.5">
               {(["rectangle", "brush"] as CutoutMode[]).map((m) => (
                 <button
@@ -94,9 +97,7 @@ export default function ImageCutout() {
                     setOptions({ ...options, mode: m });
                     clearSelection();
                   }}
-                  className={`px-2 py-1.5 text-xs rounded ${
-                    options.mode === m ? "bg-slate-900 text-white" : "bg-slate-100 dark:bg-slate-800"
-                  }`}
+                    className={`segmented-option ${options.mode === m ? "segmented-option-active" : ""}`}
                 >
                   {m === "rectangle" ? "矩形" : "画笔"}
                 </button>
@@ -106,7 +107,7 @@ export default function ImageCutout() {
 
           {options.mode === "brush" && (
             <div>
-              <div className="flex justify-between text-xs text-slate-500 mb-1">
+                <div className="mb-1 flex justify-between text-xs font-medium text-foreground-muted">
                 <span>画笔大小</span>
                 <span>{options.brushSize}px</span>
               </div>
@@ -116,13 +117,14 @@ export default function ImageCutout() {
                 max="100"
                 value={options.brushSize}
                 onChange={(e) => setOptions({ ...options, brushSize: Number(e.target.value) })}
-                className="w-full accent-slate-900"
+                  className="range"
+                  aria-label="画笔大小"
               />
             </div>
           )}
 
           <div>
-            <div className="flex justify-between text-xs text-slate-500 mb-1">
+              <div className="mb-1 flex justify-between text-xs font-medium text-foreground-muted">
               <span>边缘羽化</span>
               <span>{options.feather}px</span>
             </div>
@@ -132,22 +134,25 @@ export default function ImageCutout() {
               max="20"
               value={options.feather}
               onChange={(e) => setOptions({ ...options, feather: Number(e.target.value) })}
-              className="w-full accent-slate-900"
+                className="range"
+                aria-label="边缘羽化"
             />
           </div>
 
           <div className="flex gap-2">
             <button
               onClick={() => fileInputRef.current?.click()}
-              className="flex-1 px-3 py-1.5 text-sm bg-slate-900 text-white rounded hover:bg-slate-800"
+                className="btn-primary h-10 flex-1 gap-2"
             >
+                <ImagePlus className="h-4 w-4" aria-hidden="true" />
               {imageUrl ? "更换图片" : "选择图片"}
             </button>
             <button
               onClick={clearSelection}
               disabled={!selection && brushPath.length === 0}
-              className="px-3 py-1.5 text-sm border border-slate-200 dark:border-slate-700 rounded hover:bg-slate-50 dark:hover:bg-slate-800 disabled:opacity-50"
+                className="btn-secondary h-10 gap-2 px-3 disabled:cursor-not-allowed disabled:opacity-50"
             >
+                <Eraser className="h-4 w-4" aria-hidden="true" />
               清除
             </button>
           </div>
@@ -166,8 +171,9 @@ export default function ImageCutout() {
           {imageUrl && (
             <button
               onClick={download}
-              className="w-full px-4 py-2 text-sm border border-slate-200 dark:border-slate-700 rounded hover:bg-slate-50 dark:hover:bg-slate-800"
+                className="btn-secondary h-10 w-full gap-2"
             >
+                <Download className="h-4 w-4" aria-hidden="true" />
               下载 PNG
             </button>
           )}
@@ -176,7 +182,7 @@ export default function ImageCutout() {
             <a
               href={previewUrl}
               download="cutout.png"
-              className="block text-center text-xs text-blue-600 dark:text-blue-400 hover:underline"
+                className="block text-center text-xs font-semibold text-[hsl(var(--primary))] hover:text-[hsl(var(--primary-hover))]"
             >
               重新下载
             </a>
@@ -185,13 +191,7 @@ export default function ImageCutout() {
 
         <div className="lg:col-span-2">
           <div
-            className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-4"
-            style={{
-              backgroundImage:
-                "linear-gradient(45deg, #f1f5f9 25%, transparent 25%), linear-gradient(-45deg, #f1f5f9 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #f1f5f9 75%), linear-gradient(-45deg, transparent 75%, #f1f5f9 75%)",
-              backgroundSize: "16px 16px",
-              backgroundPosition: "0 0, 0 8px, 8px -8px, -8px 0px",
-            }}
+              className="checkerboard panel p-4"
           >
             {imageUrl ? (
               <div className="overflow-auto flex items-center justify-center min-h-[500px]">
@@ -210,16 +210,18 @@ export default function ImageCutout() {
                 />
               </div>
             ) : (
-              <div className="text-center py-12 text-slate-400">
+                <div className="flex min-h-[500px] flex-col items-center justify-center py-12 text-center text-foreground-muted">
+                  <Scissors className="mb-4 h-10 w-10" aria-hidden="true" />
                 上传图片开始<br />
                 <span className="text-xs">支持 PNG / JPG / WebP</span>
               </div>
             )}
           </div>
-          <p className="text-xs text-slate-500 mt-2 text-center">
+            <p className="mt-2 text-center text-xs font-medium text-foreground-muted">
             {options.mode === "rectangle" ? "拖动鼠标绘制矩形选区" : "拖动鼠标绘制选区"} · 羽化软化边缘
           </p>
         </div>
+      </div>
       </div>
     </div>
   );

--- a/frontend/src/components/tools/ShortcutsDemo.tsx
+++ b/frontend/src/components/tools/ShortcutsDemo.tsx
@@ -8,6 +8,7 @@
 "use client";
 
 import { useState } from "react";
+import { Keyboard, Zap } from "lucide-react";
 import { useKeyboardShortcuts, ShortcutBadge } from "@/hooks/useKeyboardShortcuts";
 
 const SHORTCUTS = [
@@ -34,18 +35,21 @@ export default function ShortcutsDemo() {
   });
 
   return (
-    <div className="max-w-3xl mx-auto p-6">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">快捷键参考</h1>
-        <p className="text-sm text-slate-500 mt-1">
+    <div className="workbench-page">
+      <div className="workbench-container max-w-4xl">
+        <header className="mb-8 max-w-3xl">
+          <p className="page-kicker">Tool bench / Shortcuts</p>
+          <h1 className="page-title mt-2">快捷键参考</h1>
+          <p className="page-description mt-3">
           全局快捷键在图片编辑器和工具页面生效
         </p>
-      </div>
+        </header>
 
       {lastAction && (
-        <div className="mb-4 p-3 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded">
-          <p className="text-sm text-blue-800 dark:text-blue-200">
-            最后触发：<span className="font-mono font-medium">{lastAction}</span>
+          <div className="info-banner mb-4 flex items-center gap-2">
+            <Zap className="h-4 w-4" aria-hidden="true" />
+            <p>
+              最后触发：<span className="font-utility font-semibold">{lastAction}</span>
           </p>
         </div>
       )}
@@ -57,18 +61,18 @@ export default function ShortcutsDemo() {
           return (
             <div
               key={cat}
-              className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 overflow-hidden"
+                className="panel overflow-hidden"
             >
-              <div className="px-4 py-2 bg-slate-50 dark:bg-slate-800 text-xs font-medium text-slate-700 dark:text-slate-300">
+                <div className="border-b border-[hsl(var(--border))] bg-[hsl(var(--secondary)/0.52)] px-4 py-2 text-xs font-bold text-foreground">
                 {cat}
               </div>
-              <div className="divide-y divide-slate-100 dark:divide-slate-800">
+                <div>
                 {items.map((s) => (
                   <div
                     key={s.keys}
-                    className="px-4 py-3 flex items-center justify-between hover:bg-slate-50 dark:hover:bg-slate-800/30"
+                      className="data-row flex items-center justify-between px-4 py-3"
                   >
-                    <span className="text-sm text-slate-700 dark:text-slate-300">{s.label}</span>
+                      <span className="text-sm font-medium text-foreground">{s.label}</span>
                     <ShortcutBadge keys={s.keys} />
                   </div>
                 ))}
@@ -78,8 +82,10 @@ export default function ShortcutsDemo() {
         })}
       </div>
 
-      <div className="mt-6 p-4 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded text-sm text-amber-800 dark:text-amber-200">
-        💡 提示：在输入框中输入时，快捷键不会触发，避免误操作。
+        <div className="warning-banner mt-6 flex items-center gap-3">
+          <Keyboard className="h-5 w-5 shrink-0" aria-hidden="true" />
+          <p>提示：在输入框中输入时，快捷键不会触发，避免误操作。</p>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -6,6 +6,7 @@ interface Props {
 
 import * as m from "@/paraglide/messages.js";
 import { getLocale, getTextDirection } from "@/paraglide/runtime.js";
+import '../styles/globals.css';
 
 const {
   title = `OuraPix - ${m.description()}`,
@@ -26,10 +27,9 @@ const direction = getTextDirection(locale);
     <meta name="description" content={description} />
     <title>{title}</title>
 
-    <!-- Geist Sans font - Anthropic's preferred font -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,600;9..144,700&family=IBM+Plex+Mono:wght@500;600&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   </head>
   <body class="font-sans antialiased min-h-screen bg-background text-foreground">
     <slot />
@@ -44,11 +44,3 @@ const direction = getTextDirection(locale);
     </script>
   </body>
 </html>
-
-<style>
-  @import '../styles/globals.css';
-
-  :root {
-    --font-sans: 'Geist', ui-sans-serif, system-ui, sans-serif;
-  }
-</style>

--- a/frontend/src/pages/api-keys.astro
+++ b/frontend/src/pages/api-keys.astro
@@ -1,8 +1,10 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import ApiKeysPage from '../components/keys/ApiKeysPage';
+import Navbar from '../components/Navbar';
 ---
 
 <Layout title="API Keys">
+  <Navbar client:load />
   <ApiKeysPage client:load />
 </Layout>

--- a/frontend/src/pages/categories.astro
+++ b/frontend/src/pages/categories.astro
@@ -1,8 +1,10 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import CategoriesPage from '../components/categories/CategoriesPage';
+import Navbar from '../components/Navbar';
 ---
 
 <Layout title="商品类目与模板">
+  <Navbar client:load />
   <CategoriesPage client:load />
 </Layout>

--- a/frontend/src/pages/collections.astro
+++ b/frontend/src/pages/collections.astro
@@ -1,8 +1,10 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import CollectionsPage from '../components/collections/CollectionsPage';
+import Navbar from '../components/Navbar';
 ---
 
 <Layout title="收藏夹">
+  <Navbar client:load />
   <CollectionsPage client:load />
 </Layout>

--- a/frontend/src/pages/competitors.astro
+++ b/frontend/src/pages/competitors.astro
@@ -2,9 +2,11 @@
 import Layout from '../layouts/Layout.astro';
 import CompetitorsPage from '../components/competitors/CompetitorsPage';
 import ErrorBoundary from '../components/ErrorBoundary';
+import Navbar from '../components/Navbar';
 ---
 
 <Layout title="竞品分析">
+  <Navbar client:load />
   <ErrorBoundary client:load>
     <CompetitorsPage client:load />
   </ErrorBoundary>

--- a/frontend/src/pages/errors.astro
+++ b/frontend/src/pages/errors.astro
@@ -1,8 +1,10 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import ErrorsDashboard from '../components/errors/ErrorsDashboard';
+import Navbar from '../components/Navbar';
 ---
 
 <Layout title="错误追踪">
+  <Navbar client:load />
   <ErrorsDashboard client:load />
 </Layout>

--- a/frontend/src/pages/favorites.astro
+++ b/frontend/src/pages/favorites.astro
@@ -1,11 +1,13 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import FavoritesPage from "../components/FavoritesPage";
+import Navbar from "../components/Navbar";
 import * as m from "@/paraglide/messages.js";
 
 const isLoggedIn = true; // TODO: Check session
 ---
 
 <Layout title={m.favorites_title()}>
+  <Navbar client:load />
   <FavoritesPage client:load />
 </Layout>

--- a/frontend/src/pages/generate.astro
+++ b/frontend/src/pages/generate.astro
@@ -2,12 +2,14 @@
 import Layout from '../layouts/Layout.astro';
 import GeneratePage from '../components/GeneratePage';
 import ErrorBoundary from '../components/ErrorBoundary';
+import Navbar from '../components/Navbar';
 
 const title = "Generate - OuraPix";
 const description = "Generate stunning product detail pages with AI";
 ---
 
 <Layout title={title} description={description}>
+  <Navbar client:load />
   <ErrorBoundary client:load>
     <GeneratePage client:load />
   </ErrorBoundary>

--- a/frontend/src/pages/history.astro
+++ b/frontend/src/pages/history.astro
@@ -2,12 +2,14 @@
 import Layout from "../layouts/Layout.astro";
 import HistoryPage from "../components/HistoryPage";
 import ErrorBoundary from "../components/ErrorBoundary";
+import Navbar from "../components/Navbar";
 import * as m from "@/paraglide/messages.js";
 
 const isLoggedIn = true; // TODO: Check session
 ---
 
 <Layout title={m.history_title()}>
+  <Navbar client:load />
   <ErrorBoundary client:load>
     <HistoryPage client:load />
   </ErrorBoundary>

--- a/frontend/src/pages/metrics.astro
+++ b/frontend/src/pages/metrics.astro
@@ -1,8 +1,10 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import MetricsDashboard from '../components/metrics/MetricsDashboard';
+import Navbar from '../components/Navbar';
 ---
 
 <Layout title="性能监控">
+  <Navbar client:load />
   <MetricsDashboard client:load />
 </Layout>

--- a/frontend/src/pages/pricing.astro
+++ b/frontend/src/pages/pricing.astro
@@ -1,11 +1,15 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import PricingPage from '../components/PricingPage';
+import Navbar from '../components/Navbar';
+import Footer from '../components/Footer';
 
 const title = "Pricing - OuraPix";
 const description = "Choose the right plan for your needs";
 ---
 
 <Layout title={title} description={description}>
+  <Navbar client:load />
   <PricingPage client:visible />
+  <Footer />
 </Layout>

--- a/frontend/src/pages/profile.astro
+++ b/frontend/src/pages/profile.astro
@@ -1,11 +1,13 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import ProfilePage from '../components/ProfilePage';
+import Navbar from '../components/Navbar';
 
 const title = "Profile - OuraPix";
 const description = "Manage your account and generation history";
 ---
 
 <Layout title={title} description={description}>
+  <Navbar client:load />
   <ProfilePage client:load />
 </Layout>

--- a/frontend/src/pages/stats.astro
+++ b/frontend/src/pages/stats.astro
@@ -1,8 +1,10 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import StatsPage from '../components/stats/StatsPage';
+import Navbar from '../components/Navbar';
 ---
 
 <Layout title="生成统计">
+  <Navbar client:load />
   <StatsPage client:load />
 </Layout>

--- a/frontend/src/pages/teams.astro
+++ b/frontend/src/pages/teams.astro
@@ -2,9 +2,11 @@
 import Layout from '../layouts/Layout.astro';
 import TeamsPage from '../components/teams/TeamsPage';
 import ErrorBoundary from '../components/ErrorBoundary';
+import Navbar from '../components/Navbar';
 ---
 
 <Layout title="团队">
+  <Navbar client:load />
   <ErrorBoundary client:load>
     <TeamsPage client:load />
   </ErrorBoundary>

--- a/frontend/src/pages/teams/[id].astro
+++ b/frontend/src/pages/teams/[id].astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import TeamDetailPage from '../../components/teams/TeamDetailPage';
+import Navbar from '../../components/Navbar';
 
 export const prerender = false;
 
@@ -8,5 +9,6 @@ const { id } = Astro.params;
 ---
 
 <Layout title="团队详情">
+  <Navbar client:load />
   <TeamDetailPage teamId={id ?? ''} client:load />
 </Layout>

--- a/frontend/src/pages/tools/background-remover.astro
+++ b/frontend/src/pages/tools/background-remover.astro
@@ -1,8 +1,10 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import BackgroundRemover from '../../components/tools/BackgroundRemover';
+import Navbar from '../../components/Navbar';
 ---
 
 <Layout title="智能去背景">
+  <Navbar client:load />
   <BackgroundRemover client:load />
 </Layout>

--- a/frontend/src/pages/tools/batch.astro
+++ b/frontend/src/pages/tools/batch.astro
@@ -1,8 +1,10 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import BatchProcessor from '../../components/tools/BatchProcessor';
+import Navbar from '../../components/Navbar';
 ---
 
 <Layout title="批量处理">
+  <Navbar client:load />
   <BatchProcessor client:load />
 </Layout>

--- a/frontend/src/pages/tools/border.astro
+++ b/frontend/src/pages/tools/border.astro
@@ -1,8 +1,10 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import ImageBorder from '../../components/tools/ImageBorder';
+import Navbar from '../../components/Navbar';
 ---
 
 <Layout title="智能边框">
+  <Navbar client:load />
   <ImageBorder client:load />
 </Layout>

--- a/frontend/src/pages/tools/collage.astro
+++ b/frontend/src/pages/tools/collage.astro
@@ -1,8 +1,10 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import CollageMaker from '../../components/tools/CollageMaker';
+import Navbar from '../../components/Navbar';
 ---
 
 <Layout title="图片拼图">
+  <Navbar client:load />
   <CollageMaker client:load />
 </Layout>

--- a/frontend/src/pages/tools/cutout.astro
+++ b/frontend/src/pages/tools/cutout.astro
@@ -1,8 +1,10 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import ImageCutout from '../../components/tools/ImageCutout';
+import Navbar from '../../components/Navbar';
 ---
 
 <Layout title="智能抠图">
+  <Navbar client:load />
   <ImageCutout client:load />
 </Layout>

--- a/frontend/src/pages/tools/export.astro
+++ b/frontend/src/pages/tools/export.astro
@@ -1,8 +1,10 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import ExportDemo from '../../components/tools/ExportDemo';
+import Navbar from '../../components/Navbar';
 ---
 
 <Layout title="导出图片">
+  <Navbar client:load />
   <ExportDemo client:load />
 </Layout>

--- a/frontend/src/pages/tools/shortcuts.astro
+++ b/frontend/src/pages/tools/shortcuts.astro
@@ -1,8 +1,10 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import ShortcutsDemo from '../../components/tools/ShortcutsDemo';
+import Navbar from '../../components/Navbar';
 ---
 
 <Layout title="快捷键参考">
+  <Navbar client:load />
   <ShortcutsDemo client:load />
 </Layout>

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -24,103 +24,78 @@
   --color-popover-foreground: hsl(var(--popover-foreground));
 }
 
-/* ========================================
-   Anthropic Design System - Global Styles
-   ======================================== */
-
 :root {
-  /* Core Colors - Dark theme by default */
-  --background: 225 15% 8%;
-  --background-secondary: 225 15% 11%;
-  --foreground: 220 15% 95%;
-  --foreground-muted: 220 10% 60%;
+  --background: 40 45% 94%;
+  --background-secondary: 38 38% 88%;
+  --foreground: 30 11% 8%;
+  --foreground-muted: 32 8% 39%;
 
-  /* Primary - Anthropic Purple */
-  --primary: 270 70% 65%;
-  --primary-hover: 270 70% 70%;
-  --primary-foreground: 0 0% 0%;
+  --primary: 221 83% 53%;
+  --primary-hover: 221 83% 44%;
+  --primary-foreground: 0 0% 100%;
 
-  /* Secondary */
-  --secondary: 225 15% 14%;
-  --secondary-hover: 225 15% 18%;
-  --secondary-foreground: 220 15% 95%;
+  --secondary: 37 31% 86%;
+  --secondary-hover: 37 28% 80%;
+  --secondary-foreground: 30 11% 8%;
 
-  /* Muted */
-  --muted: 225 15% 14%;
-  --muted-foreground: 220 10% 55%;
+  --muted: 38 28% 88%;
+  --muted-foreground: 32 8% 43%;
 
-  /* Accent */
-  --accent: 270 70% 65%;
-  --accent-foreground: 0 0% 0%;
+  --accent: 34 78% 44%;
+  --accent-foreground: 40 45% 96%;
 
-  /* Border & Input */
-  --border: 225 15% 18%;
-  --input: 225 15% 14%;
-  --ring: 270 70% 65%;
+  --border: 36 22% 80%;
+  --input: 45 100% 98%;
+  --ring: 221 83% 53%;
 
-  /* Cards */
-  --card: 225 15% 11%;
-  --card-foreground: 220 15% 95%;
+  --card: 45 100% 98%;
+  --card-foreground: 30 11% 8%;
+  --popover: 45 100% 98%;
+  --popover-foreground: 30 11% 8%;
 
-  /* Popover */
-  --popover: 225 15% 11%;
-  --popover-foreground: 220 15% 95%;
+  --color-success: 156 64% 34%;
+  --color-success-light: 150 45% 90%;
+  --color-warning: 34 90% 45%;
+  --color-warning-light: 38 70% 90%;
+  --color-error: 0 68% 47%;
+  --color-error-light: 0 66% 93%;
+  --color-info: 221 83% 53%;
+  --color-info-light: 218 90% 94%;
 
-  /* Semantic Colors */
-  --color-success: 160 60% 45%;
-  --color-success-light: 160 60% 15%;
-  --color-warning: 38 92% 50%;
-  --color-warning-light: 38 92% 15%;
-  --color-error: 0 72% 55%;
-  --color-error-light: 0 72% 18%;
-  --color-info: 210 80% 55%;
-  --color-info-light: 210 80% 18%;
+  --shadow-sm: 0 1px 2px 0 oklch(0 0 0 / 0.08);
+  --shadow-md: 0 8px 20px -16px oklch(0.22 0.04 65 / 0.35);
+  --shadow-lg: 0 18px 48px -28px oklch(0.22 0.04 65 / 0.45);
+  --shadow-xl: 0 26px 70px -36px oklch(0.22 0.04 65 / 0.55);
+  --shadow-glow: 0 0 0 1px hsl(var(--primary) / 0.18), 0 18px 60px -34px hsl(var(--primary) / 0.45);
 
-  /* Shadows */
-  --shadow-sm: 0 1px 2px 0 oklch(0 0 0 / 0.3);
-  --shadow-md: 0 4px 12px -2px oklch(0 0 0 / 0.4);
-  --shadow-lg: 0 12px 32px -4px oklch(0 0 0 / 0.5);
-  --shadow-xl: 0 24px 48px -8px oklch(0 0 0 / 0.6);
-  --shadow-glow: 0 0 40px hsl(var(--primary)/0.15);
-
-  /* Border radius */
-  --radius: 0.75rem;
-  --radius-sm: 0.5rem;
-  --radius-lg: 1rem;
+  --radius: 0.5rem;
+  --radius-sm: 0.375rem;
+  --radius-lg: 0.5rem;
   --radius-full: 9999px;
+
+  --font-display: "Fraunces", ui-serif, Georgia, serif;
+  --font-body: "Inter", ui-sans-serif, system-ui, sans-serif;
+  --font-utility: "IBM Plex Mono", ui-monospace, SFMono-Regular, monospace;
+  --font-sans: var(--font-body);
 }
 
-/* Light theme */
-.light {
-  --background: 0 0% 100%;
-  --background-secondary: 220 14% 96%;
-  --foreground: 225 15% 10%;
-  --foreground-muted: 220 10% 45%;
-  --primary: 270 70% 55%;
-  --primary-hover: 270 70% 60%;
-  --secondary: 220 14% 94%;
-  --secondary-hover: 220 14% 90%;
-  --secondary-foreground: 225 15% 10%;
-  --muted: 220 14% 94%;
-  --muted-foreground: 220 10% 45%;
-  --accent: 270 70% 55%;
-  --accent-foreground: 0 0% 100%;
-  --border: 220 14% 88%;
-  --input: 220 14% 94%;
-  --ring: 270 70% 55%;
-  --card: 0 0% 100%;
-  --card-foreground: 225 15% 10%;
-  --popover: 0 0% 100%;
-  --popover-foreground: 225 15% 10%;
-  --shadow-sm: 0 1px 2px 0 oklch(0 0 0 / 0.05);
-  --shadow-md: 0 4px 12px -2px oklch(0 0 0 / 0.08);
-  --shadow-lg: 0 12px 32px -4px oklch(0 0 0 / 0.1);
-  --shadow-xl: 0 24px 48px -8px oklch(0 0 0 / 0.12);
+.dark {
+  --background: 30 11% 8%;
+  --background-secondary: 30 10% 12%;
+  --foreground: 45 100% 96%;
+  --foreground-muted: 35 14% 68%;
+  --secondary: 32 11% 17%;
+  --secondary-hover: 32 11% 22%;
+  --secondary-foreground: 45 100% 96%;
+  --muted: 32 11% 17%;
+  --muted-foreground: 35 14% 68%;
+  --border: 32 10% 24%;
+  --input: 30 10% 12%;
+  --card: 30 10% 12%;
+  --card-foreground: 45 100% 96%;
+  --popover: 30 10% 12%;
+  --popover-foreground: 45 100% 96%;
 }
-
-/* ========================================
-   Base Styles
-   ======================================== */
 
 @layer base {
   * {
@@ -135,50 +110,56 @@
 
   body {
     @apply bg-background text-foreground;
+    background-image:
+      linear-gradient(hsl(var(--border) / 0.28) 1px, transparent 1px),
+      linear-gradient(90deg, hsl(var(--border) / 0.28) 1px, transparent 1px);
+    background-size: 56px 56px;
+    font-family: var(--font-body);
     font-feature-settings: "rlig" 1, "calt" 1;
   }
 
-  h1, h2, h3, h4, h5, h6 {
-    @apply font-semibold tracking-tight;
-    letter-spacing: -0.02em;
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply font-semibold;
+    letter-spacing: 0;
   }
 
   h1 {
     @apply text-4xl md:text-5xl lg:text-6xl;
-    line-height: 1.1;
+    line-height: 1.04;
   }
 
   h2 {
     @apply text-3xl md:text-4xl;
-    line-height: 1.2;
+    line-height: 1.12;
   }
 
   h3 {
     @apply text-2xl md:text-3xl;
-    line-height: 1.3;
+    line-height: 1.2;
   }
 
   h4 {
     @apply text-xl md:text-2xl;
-    line-height: 1.4;
+    line-height: 1.3;
   }
 
   p {
-    line-height: 1.6;
+    line-height: 1.65;
   }
 
   ::selection {
-    background: hsl(var(--primary)/0.3);
+    background: hsl(var(--primary) / 0.18);
   }
 }
 
-/* ========================================
-   Custom Scrollbar
-   ======================================== */
-
 ::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
+  width: 8px;
+  height: 8px;
 }
 
 ::-webkit-scrollbar-track {
@@ -186,122 +167,421 @@
 }
 
 ::-webkit-scrollbar-thumb {
-  @apply bg-foreground/20 rounded-full;
+  @apply rounded-full;
+  background: hsl(var(--foreground) / 0.2);
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  @apply bg-foreground/30;
+  background: hsl(var(--foreground) / 0.34);
 }
 
-/* ========================================
-   Utility Classes
-   ======================================== */
+.font-display {
+  font-family: var(--font-display);
+}
 
-@layer utilities {
-  /* Gradient text */
-  .gradient-text {
-    @apply bg-clip-text text-transparent bg-gradient-to-r from-[hsl(var(--primary))] to-violet-400;
-  }
+.font-utility {
+  font-family: var(--font-utility);
+}
 
-  /* Glass effect */
-  .glass {
-    @apply bg-background/80 backdrop-blur-xl;
-  }
+.gradient-text {
+  background: linear-gradient(90deg, hsl(var(--primary)), hsl(var(--accent)));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
 
-  /* Focus ring */
-  .focus-ring {
-    @apply focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background;
-  }
+.glass {
+  background: hsl(var(--background) / 0.9);
+  backdrop-filter: blur(18px);
+}
 
-  /* Glow effects */
-  .glow {
-    box-shadow: var(--shadow-glow);
-  }
+.focus-ring:focus {
+  outline: none;
+  box-shadow:
+    0 0 0 2px hsl(var(--background)),
+    0 0 0 4px hsl(var(--ring) / 0.82);
+}
 
-  .glow-sm {
-    box-shadow: 0 0 20px hsl(var(--primary)/0.1);
-  }
+.glow,
+.glow-sm {
+  box-shadow: var(--shadow-glow);
+}
 
-  /* Surface layers */
-  .surface-1 {
-    @apply bg-background;
-  }
+.surface-1 {
+  background: hsl(var(--background));
+}
 
-  .surface-2 {
-    @apply bg-background-secondary;
-  }
+.surface-2 {
+  background: hsl(var(--background-secondary));
+}
 
-  /* Anthropic button styles */
-  .btn-primary {
-    @apply inline-flex items-center justify-center rounded-lg px-5 py-2.5 text-sm font-medium transition-all duration-200;
-    background: hsl(var(--primary));
-    color: hsl(var(--primary-foreground));
-  }
+.bench-grid {
+  background-image:
+    linear-gradient(hsl(var(--border) / 0.42) 1px, transparent 1px),
+    linear-gradient(90deg, hsl(var(--border) / 0.42) 1px, transparent 1px);
+  background-size: 44px 44px;
+}
 
-  .btn-primary:hover {
-    background: hsl(var(--primary-hover));
-    transform: translateY(-1px);
-  }
+.proof-strip {
+  background:
+    repeating-linear-gradient(
+      -45deg,
+      hsl(var(--primary) / 0.92) 0 10px,
+      hsl(var(--primary) / 0.92) 10px 20px,
+      hsl(var(--card)) 20px 30px,
+      hsl(var(--card)) 30px 40px
+    );
+}
 
-  .btn-primary:active {
-    transform: translateY(0);
-  }
+.specimen-shadow {
+  box-shadow: 0 24px 80px -46px hsl(var(--foreground) / 0.56);
+}
 
-  .btn-secondary {
-    @apply inline-flex items-center justify-center rounded-lg px-5 py-2.5 text-sm font-medium transition-all duration-200;
-    background: hsl(var(--secondary));
-    color: hsl(var(--secondary-foreground));
-    border: 1px solid hsl(var(--border));
-  }
+.btn-primary,
+.btn-secondary,
+.btn-ghost {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius);
+  font-size: 0.875rem;
+  font-weight: 650;
+  line-height: 1.25rem;
+  text-decoration: none;
+  transition:
+    background-color 180ms ease,
+    border-color 180ms ease,
+    color 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
 
-  .btn-secondary:hover {
-    background: hsl(var(--secondary-hover));
-    border-color: hsl(var(--foreground-muted)/0.3);
-  }
+.btn-primary {
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  box-shadow: var(--shadow-md);
+}
 
-  .btn-ghost {
-    @apply inline-flex items-center justify-center rounded-lg px-5 py-2.5 text-sm font-medium transition-all duration-200;
-    color: hsl(var(--foreground-muted));
-  }
+.btn-primary:hover {
+  background: hsl(var(--primary-hover));
+  transform: translateY(-1px);
+}
 
-  .btn-ghost:hover {
-    color: hsl(var(--foreground));
-    background: hsl(var(--foreground)/0.05);
-  }
+.btn-primary:active {
+  transform: translateY(0);
+}
 
-  /* Card styles */
-  .card {
-    @apply rounded-xl border transition-all duration-200;
-    background: hsl(var(--card));
-    border-color: hsl(var(--border));
-  }
+.btn-secondary {
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--card));
+  color: hsl(var(--secondary-foreground));
+}
 
-  .card-hover {
-    @apply hover:border-primary/30 hover:shadow-lg;
-  }
+.btn-secondary:hover {
+  background: hsl(var(--secondary));
+  border-color: hsl(var(--foreground) / 0.22);
+}
 
-  /* Input styles */
-  .input {
-    @apply w-full rounded-lg border px-3 py-2.5 text-sm transition-colors;
-    background: hsl(var(--input));
-    border-color: hsl(var(--border));
-    color: hsl(var(--foreground));
-  }
+.btn-ghost {
+  color: hsl(var(--foreground-muted));
+}
 
-  .input::placeholder {
-    color: hsl(var(--foreground-muted));
-  }
+.btn-ghost:hover {
+  color: hsl(var(--foreground));
+  background: hsl(var(--foreground) / 0.06);
+}
 
-  .input:focus {
-    @apply outline-none ring-2;
-    border-color: hsl(var(--primary));
-    --tw-ring-color: hsl(var(--primary)/0.3);
+.card {
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius-lg);
+  background: hsl(var(--card));
+  box-shadow: var(--shadow-sm);
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.card-hover:hover {
+  border-color: hsl(var(--primary) / 0.5);
+  box-shadow: var(--shadow-md);
+  transform: translateY(-1px);
+}
+
+.input {
+  width: 100%;
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  background: hsl(var(--input));
+  color: hsl(var(--foreground));
+  padding: 0.625rem 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.input::placeholder {
+  color: hsl(var(--foreground-muted));
+}
+
+.input:focus {
+  outline: none;
+  border-color: hsl(var(--primary));
+  box-shadow: 0 0 0 3px hsl(var(--primary) / 0.24);
+}
+
+.workbench-page {
+  min-height: 100vh;
+  background: hsl(var(--background));
+}
+
+.workbench-container {
+  width: min(100%, 80rem);
+  margin-inline: auto;
+  padding: 2rem 1rem 3rem;
+}
+
+@media (min-width: 640px) {
+  .workbench-container {
+    padding-inline: 1.5rem;
   }
 }
 
-/* ========================================
-   Animation Keyframes
-   ======================================== */
+@media (min-width: 1024px) {
+  .workbench-container {
+    padding-inline: 2rem;
+  }
+}
+
+.page-kicker {
+  font-family: var(--font-utility);
+  color: hsl(var(--accent));
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.page-title {
+  font-family: var(--font-display);
+  color: hsl(var(--foreground));
+  font-size: clamp(2rem, 4vw, 4rem);
+  font-weight: 650;
+  line-height: 1.02;
+  letter-spacing: 0;
+}
+
+.page-description {
+  color: hsl(var(--foreground-muted));
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.panel {
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius-lg);
+  background: hsl(var(--card));
+  box-shadow: var(--shadow-sm);
+}
+
+.panel-muted {
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius-lg);
+  background: hsl(var(--secondary) / 0.66);
+}
+
+.panel-title {
+  color: hsl(var(--foreground));
+  font-size: 0.875rem;
+  font-weight: 700;
+  line-height: 1.25rem;
+}
+
+.panel-label {
+  color: hsl(var(--foreground-muted));
+  font-size: 0.75rem;
+  font-weight: 650;
+  line-height: 1rem;
+}
+
+.drop-zone {
+  border: 2px dashed hsl(var(--border));
+  border-radius: var(--radius-lg);
+  background: hsl(var(--card) / 0.76);
+  transition:
+    border-color 180ms ease,
+    background-color 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.drop-zone-active {
+  border-color: hsl(var(--primary));
+  background: hsl(var(--primary) / 0.08);
+  box-shadow: 0 0 0 4px hsl(var(--primary) / 0.1);
+}
+
+.checkerboard {
+  background-color: hsl(var(--input));
+  background-image:
+    linear-gradient(45deg, hsl(var(--border) / 0.5) 25%, transparent 25%),
+    linear-gradient(-45deg, hsl(var(--border) / 0.5) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, hsl(var(--border) / 0.5) 75%),
+    linear-gradient(-45deg, transparent 75%, hsl(var(--border) / 0.5) 75%);
+  background-position:
+    0 0,
+    0 8px,
+    8px -8px,
+    -8px 0;
+  background-size: 16px 16px;
+}
+
+.range {
+  width: 100%;
+  accent-color: hsl(var(--primary));
+}
+
+.swatch {
+  height: 2.25rem;
+  width: 100%;
+  cursor: pointer;
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  background: hsl(var(--input));
+}
+
+.segmented-option {
+  display: inline-flex;
+  min-height: 2.25rem;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: hsl(var(--secondary) / 0.72);
+  color: hsl(var(--foreground-muted));
+  padding: 0.375rem 0.625rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1rem;
+  transition:
+    background-color 180ms ease,
+    border-color 180ms ease,
+    color 180ms ease;
+}
+
+.segmented-option:hover {
+  border-color: hsl(var(--border));
+  color: hsl(var(--foreground));
+}
+
+.segmented-option-active {
+  border-color: hsl(var(--primary) / 0.28);
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+}
+
+.icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  color: hsl(var(--foreground-muted));
+  transition:
+    background-color 180ms ease,
+    color 180ms ease;
+}
+
+.icon-button:hover {
+  background: hsl(var(--foreground) / 0.06);
+  color: hsl(var(--foreground));
+}
+
+.error-banner,
+.success-banner,
+.info-banner,
+.warning-banner {
+  border-radius: var(--radius-lg);
+  padding: 0.875rem 1rem;
+  font-size: 0.875rem;
+  line-height: 1.35rem;
+}
+
+.error-banner {
+  border: 1px solid hsl(var(--color-error) / 0.28);
+  background: hsl(var(--color-error-light));
+  color: hsl(var(--color-error));
+}
+
+.success-banner {
+  border: 1px solid hsl(var(--color-success) / 0.28);
+  background: hsl(var(--color-success-light));
+  color: hsl(var(--color-success));
+}
+
+.info-banner {
+  border: 1px solid hsl(var(--color-info) / 0.24);
+  background: hsl(var(--color-info-light));
+  color: hsl(var(--color-info));
+}
+
+.warning-banner {
+  border: 1px solid hsl(var(--color-warning) / 0.28);
+  background: hsl(var(--color-warning-light));
+  color: hsl(var(--color-warning));
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: var(--radius-full);
+  padding: 0.125rem 0.625rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1rem;
+}
+
+.status-badge-neutral {
+  background: hsl(var(--secondary));
+  color: hsl(var(--foreground-muted));
+}
+
+.status-badge-success {
+  background: hsl(var(--color-success-light));
+  color: hsl(var(--color-success));
+}
+
+.status-badge-error {
+  background: hsl(var(--color-error-light));
+  color: hsl(var(--color-error));
+}
+
+.status-badge-info {
+  background: hsl(var(--color-info-light));
+  color: hsl(var(--color-info));
+}
+
+.status-badge-warning {
+  background: hsl(var(--color-warning-light));
+  color: hsl(var(--color-warning));
+}
+
+.table-shell {
+  overflow-x: auto;
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius-lg);
+  background: hsl(var(--card));
+  box-shadow: var(--shadow-sm);
+}
+
+.data-row {
+  border-top: 1px solid hsl(var(--border) / 0.72);
+  transition: background-color 160ms ease;
+}
+
+.data-row:hover {
+  background: hsl(var(--secondary) / 0.48);
+}
 
 @keyframes fade-in {
   from {
@@ -315,7 +595,7 @@
 @keyframes fade-in-up {
   from {
     opacity: 0;
-    transform: translateY(16px);
+    transform: translateY(12px);
   }
   to {
     opacity: 1;
@@ -326,7 +606,7 @@
 @keyframes scale-in {
   from {
     opacity: 0;
-    transform: scale(0.96);
+    transform: scale(0.98);
   }
   to {
     opacity: 1;
@@ -337,7 +617,7 @@
 @keyframes slide-in-right {
   from {
     opacity: 0;
-    transform: translateX(16px);
+    transform: translateX(12px);
   }
   to {
     opacity: 1;
@@ -345,124 +625,97 @@
   }
 }
 
-@keyframes float {
-  0%, 100% {
-    transform: translateY(0);
-  }
-  50% {
-    transform: translateY(-8px);
-  }
-}
-
-@keyframes pulse-glow {
-  0%, 100% {
-    box-shadow: 0 0 20px hsl(var(--primary)/0.15);
-  }
-  50% {
-    box-shadow: 0 0 40px hsl(var(--primary)/0.25);
-  }
-}
-
-@keyframes gradient-shift {
-  0% {
-    background-position: 0% 50%;
-  }
-  50% {
-    background-position: 100% 50%;
-  }
-  100% {
-    background-position: 0% 50%;
-  }
-}
-
 .animate-fade-in {
-  animation: fade-in 0.3s ease-out;
+  animation: fade-in 0.24s ease-out;
 }
 
 .animate-fade-in-up {
-  animation: fade-in-up 0.4s ease-out;
+  animation: fade-in-up 0.34s ease-out;
 }
 
 .animate-scale-in {
-  animation: scale-in 0.3s ease-out;
+  animation: scale-in 0.24s ease-out;
 }
 
 .animate-slide-in-right {
-  animation: slide-in-right 0.3s ease-out;
+  animation: slide-in-right 0.24s ease-out;
 }
 
-.animate-float {
-  animation: float 4s ease-in-out infinite;
+.stagger-1 {
+  animation-delay: 0.08s;
 }
 
-.animate-pulse-glow {
-  animation: pulse-glow 3s ease-in-out infinite;
+.stagger-2 {
+  animation-delay: 0.14s;
 }
 
-/* Staggered animations */
-.stagger-1 { animation-delay: 0.1s; }
-.stagger-2 { animation-delay: 0.2s; }
-.stagger-3 { animation-delay: 0.3s; }
-.stagger-4 { animation-delay: 0.4s; }
-.stagger-5 { animation-delay: 0.5s; }
-
-/* ========================================
-   Gradient Backgrounds
-   ======================================== */
-
-.gradient-anthropic {
-  background: linear-gradient(
-    135deg,
-    hsl(var(--background)) 0%,
-    hsl(var(--background-secondary)) 50%,
-    hsl(var(--background)) 100%
-  );
+.stagger-3 {
+  animation-delay: 0.2s;
 }
 
-.gradient-radial {
-  background: radial-gradient(
-    ellipse at center,
-    hsl(var(--primary)/0.08) 0%,
-    transparent 70%
-  );
+.stagger-4 {
+  animation-delay: 0.26s;
 }
 
+.stagger-5 {
+  animation-delay: 0.32s;
+}
+
+.gradient-anthropic,
+.gradient-radial,
 .gradient-mesh {
   background:
-    radial-gradient(at 20% 30%, hsl(var(--primary)/0.08) 0px, transparent 50%),
-    radial-gradient(at 80% 70%, hsl(270 70% 60% / 0.06) 0px, transparent 50%),
-    radial-gradient(at 50% 50%, hsl(var(--background-secondary)) 0px, transparent 70%);
+    linear-gradient(135deg, hsl(var(--background)) 0%, hsl(var(--background-secondary)) 100%),
+    linear-gradient(90deg, hsl(var(--primary) / 0.08), transparent);
 }
 
-/* ========================================
-   Component Specific Styles
-   ======================================== */
-
-/* Status indicators */
 .status-dot {
-  @apply h-2 w-2 rounded-full;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: var(--radius-full);
 }
 
 .status-dot-online {
   background: hsl(var(--color-success));
-  box-shadow: 0 0 8px hsl(var(--color-success)/0.5);
+  box-shadow: 0 0 0 4px hsl(var(--color-success) / 0.12);
 }
 
 .status-dot-offline {
   background: hsl(var(--foreground-muted));
 }
 
-/* Badge */
 .badge {
-  @apply inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium;
-  background: hsl(var(--primary)/0.15);
+  display: inline-flex;
+  align-items: center;
+  border-radius: var(--radius-full);
+  background: hsl(var(--primary) / 0.1);
   color: hsl(var(--primary));
+  padding: 0.125rem 0.625rem;
+  font-size: 0.75rem;
+  font-weight: 650;
+  line-height: 1rem;
 }
 
-/* Tooltip */
 .tooltip {
-  @apply absolute z-50 rounded-lg border px-3 py-2 text-sm shadow-lg;
+  position: absolute;
+  z-index: 50;
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
   background: hsl(var(--popover));
-  border-color: hsl(var(--border));
   color: hsl(var(--popover-foreground));
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  box-shadow: var(--shadow-lg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
 }


### PR DESCRIPTION
## 变更说明

- 将前端视觉体系重构为商品图工作台/校样风格，更新全局 token、字体、按钮、面板、状态提示与表格样式
- 覆盖首页、生成、定价、认证、历史/收藏/个人中心、工具页、管理页与团队/API Key 等页面
- 深层页面补齐统一导航；修复类目页 API 失败时只显示空白错误条的问题
- 调整团队卡片交互结构，避免链接内嵌按钮造成的可访问性问题

## CR 结论

- review depth: deep，范围符合 UI/UX 重构目标
- 已检查 rebase 冲突文件 `frontend/astro.config.mjs`，保留 `publicDir` 与 Cloudflare `imageService: passthrough`
- 未发现阻塞合并的问题

## 本地验证

- `pnpm build`
- `pnpm --filter @oura-pix/api lint`
- `pnpm --filter @oura-pix/api typecheck`
- `pnpm --filter @oura-pix/frontend lint`（仅保留既有 warning：`useKeyboardShortcuts.tsx:82` missing dependency `handlers`）
- `pnpm --filter @oura-pix/frontend typecheck`
- `pnpm test`
- 浏览器 smoke：桌面/移动抽查 `/`, `/generate`, `/categories`, `/teams`, `/api-keys`，无横向溢出、无空白屏、无嵌套交互；本地 API 未启动导致的 `localhost:8989` 请求失败为预期开发环境噪声
