### PR TITLE
fix: 底部栏 i18n 修复（替换硬编码英文为 Paraglide 翻译）

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -20,7 +20,7 @@ export default function Footer() {
               <span className="font-display text-xl font-semibold text-foreground">OuraPix</span>
             </div>
             <p className="mt-4 text-sm text-foreground-muted max-w-sm">
-              A product photo workbench for cross-border listings, scene assets, and marketplace-ready copy.
+              {m.footer_description()}
             </p>
           </div>
 
@@ -30,12 +30,12 @@ export default function Footer() {
             <ul className="mt-4 space-y-2">
               <li>
                 <a href={localizeHref("/generate")} className="text-sm text-foreground-muted transition-colors hover:text-foreground">
-                  Generate
+                  {m.footer_generate()}
                 </a>
               </li>
               <li>
                 <a href={localizeHref("/pricing")} className="text-sm text-foreground-muted transition-colors hover:text-foreground">
-                  Pricing
+                  {m.footer_pricing()}
                 </a>
               </li>
             </ul>
@@ -46,12 +46,12 @@ export default function Footer() {
             <ul className="mt-4 space-y-2">
               <li>
                 <a href={localizeHref("/docs")} className="text-sm text-foreground-muted transition-colors hover:text-foreground">
-                  Documentation
+                  {m.footer_documentation()}
                 </a>
               </li>
               <li>
                 <a href={localizeHref("/blog")} className="text-sm text-foreground-muted transition-colors hover:text-foreground">
-                  Blog
+                  {m.footer_blog()}
                 </a>
               </li>
             </ul>

--- a/packages/i18n/messages/ui/en.json
+++ b/packages/i18n/messages/ui/en.json
@@ -393,6 +393,8 @@
   "home_ctaSubtitle": "Create your first product page in minutes",
   "home_ctaButton": "Start Generating",
   "footer_description": "AI-powered cross-border e-commerce product detail page generator",
+  "footer_generate": "Generate",
+  "footer_pricing": "Pricing",
   "footer_product": "Product",
   "footer_support": "Support",
   "footer_documentation": "Documentation",

--- a/packages/i18n/messages/ui/ja.json
+++ b/packages/i18n/messages/ui/ja.json
@@ -393,6 +393,8 @@
   "home_ctaSubtitle": "数分で最初の商品ページを作成",
   "home_ctaButton": "生成を開始",
   "footer_description": "AI による越境 EC 商品詳細ページ生成ツール",
+  "footer_generate": "生成",
+  "footer_pricing": "料金プラン",
   "footer_product": "プロダクト",
   "footer_support": "サポート",
   "footer_documentation": "ドキュメント",

--- a/packages/i18n/messages/ui/zh-CN.json
+++ b/packages/i18n/messages/ui/zh-CN.json
@@ -393,6 +393,8 @@
   "home_ctaSubtitle": "几分钟内创建第一个商品页",
   "home_ctaButton": "开始生成",
   "footer_description": "AI 驱动的跨境电商商品详情页生成器",
+  "footer_generate": "生成",
+  "footer_pricing": "定价",
   "footer_product": "产品",
   "footer_support": "支持",
   "footer_documentation": "文档",


### PR DESCRIPTION
Task #82

## 改动
- **Footer.tsx**: 替换 5 处硬编码英文文本为 Paraglide i18n 函数：`footer_description()`, `footer_generate()`, `footer_pricing()`, `footer_documentation()`, `footer_blog()`
- **i18n messages**: 新增 `footer_generate`/ `footer_pricing` 键到 zh-CN、en、ja 三个语言文件
- Paraglide 已重新编译

## 验证
- `pnpm typecheck` ✅
- 无新增类型错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)