### PR TITLE
feat: 数据库迁移 CI 自动触发 (#81)

### DIFF
--- a/.github/workflows/database-migrate.yml
+++ b/.github/workflows/database-migrate.yml
@@ -1,6 +1,12 @@
 name: Migrate Database
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'drizzle/migrations/*.sql'
+      - 'drizzle/migrations/meta/*.json'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
**任务 #81：数据库 Migration 集成到 CI 流水线**

## 改动

更新 ：

**触发条件：**
- 推送到 main 分支
- 且  或  有变更
- 支持手动触发（workflow_dispatch）

**执行步骤：**
1. 验证 Cloudflare 配置
2. Type check database package
3. 执行 
> oura-pix@0.2.0 db:migrate:prod /Users/victor/Desktop/project/github/oura-pix
> pnpm --filter=@oura-pix/database db:migrate:prod


> @oura-pix/database@0.1.0 db:migrate:prod /Users/victor/Desktop/project/github/oura-pix/packages/database
> wrangler d1 migrations apply oura-pix-db --remote --config ../../api/wrangler.jsonc


 ⛅️ wrangler 4.73.0 (update available 4.105.0)
──────────────────────────────────────────────
Resource location: remote 

Migrations to be applied:
┌────────────────────────────┐
│ name                       │
├────────────────────────────┤
│ 0018_large_bloodstrike.sql │
└────────────────────────────┘
? About to apply 1 migration(s)
Your database may not be available to serve requests during the migration, continue?
🤖 Using fallback value in non-interactive context: yes
🌀 Executing on remote database oura-pix-db (0f79f5d4-d714-4ffc-8747-f52a4461fecb):
🌀 To execute on your local development database, remove the --remote flag from your wrangler command.
🚣 Executed 12 commands in 3.09ms
┌────────────────────────────┬────────┐
│ name                       │ status │
├────────────────────────────┼────────┤
│ 0018_large_bloodstrike.sql │ ✅     │
└────────────────────────────┴────────┘

**优势：**
- ✅ 迁移与 API 部署解耦
- ✅ 失败影响范围可控
- ✅ 可单独重试迁移
- ✅ 清晰的审计日志

## 验证

- [ ] 推送迁移文件变更触发 CI
- [ ] 迁移成功执行
- [ ] 失败时正确报错