### PR TITLE
P0 T1 #83: 隐藏图片生成选项 + 上线提示

### DIFF
--- a/frontend/src/components/GeneratePage.tsx
+++ b/frontend/src/components/GeneratePage.tsx
@@ -192,7 +192,7 @@ export default function GeneratePage() {
           style: settings.style as "professional" | "lifestyle" | "minimal" | "luxury",
           language: settings.language,
           uiLocale: currentUiLocale(),
-          generateImages: settings.generateImages,
+          generateImages: false, // P0 T1 #83: 图片生成功能隐藏中，强制关闭
           imageCount: settings.imageCount,
           aspectRatio: settings.aspectRatio,
           allowPersons: settings.allowPersons,
@@ -423,7 +423,8 @@ export default function GeneratePage() {
                 </select>
               </div>
 
-              {/* Image Generation Toggle */}
+              {/* Image Generation Toggle - HIDDEN for launch (P0 T1 #83) */}
+              {/* Original code preserved below, uncomment when launching image generation
               <div className="mb-6 rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--background)/0.42)] p-4">
                 <div className="flex items-center justify-between mb-4">
                   <div>
@@ -494,6 +495,14 @@ export default function GeneratePage() {
                     </div>
                   </div>
                 )}
+              </div>
+              */}
+
+              {/* Coming Soon Notice (P0 T1 #83) */}
+              <div className="p-4 bg-amber-50 dark:bg-amber-950/30 rounded-lg mb-6">
+                <p className="text-sm text-amber-800 dark:text-amber-300">
+                  🚧 图片生成功能即将上线，敬请期待
+                </p>
               </div>
 
               {/* Error Message */}


### PR DESCRIPTION
## 背景
P0 T1 #83 任务：图片生成功能上线前需要在前端隐藏选项并展示上线提示。

## 改动
- `frontend/src/components/GeneratePage.tsx`：
  - 注释图片生成 UI（保留代码以便后续开启）
  - 在原位置添加图片生成功能即将上线，敬请期待提示
  - 强制 API 请求 `generateImages: false`，避免误触发图片生成

## 验证
- ✅ pnpm typecheck 通过
- ✅ pnpm build 通过

## 验收
- 图片生成选项不再展示
- 提示信息正确显示
- API 请求不再触发图片生成