### PR TITLE
P0 T4 #86: 生成前预览功能

### DIFF
--- a/api/src/routes/generations.ts
+++ b/api/src/routes/generations.ts
@@ -19,6 +19,7 @@ import {
   createGeneration,
   processGeneration,
 } from "../services/generation-service";
+import { generateProductCopy } from "../services/geminiService";
 import { getTeamForUser } from "../services/teamService";
 
 const router = new Hono<{
@@ -280,5 +281,115 @@ router.delete("/:id", async (c) => {
     success: true,
   });
 });
+
+// POST /api/generations/preview - Preview one variant (P0 T4 #86)
+export const previewGenerationSchema = z.object({
+  productImageId: z.string().optional(),
+  prompt: z.string().optional(),
+  settings: z.object({
+    targetPlatform: z.enum(["amazon", "ebay", "shopify", "etsy", "generic"]),
+    language: z.enum(["zh", "en", "ja"]),
+    uiLocale: z.enum(["zh-CN", "en", "ja"]).optional(),
+    style: z.enum(["professional", "lifestyle", "minimal", "luxury"]),
+    count: z.number().min(1).max(10).optional(),
+  }),
+});
+
+const validatePreviewGeneration = zValidator("json", previewGenerationSchema, (result, c) => {
+  if (!result.success) {
+    const locale = getLocale(c);
+    return c.json(
+      {
+        success: false,
+        error: {
+          code: "BAD_REQUEST",
+          message: serverMessage(locale, "badRequest"),
+          details: z.flattenError(result.error),
+        },
+      },
+      400
+    );
+  }
+});
+
+router.post(
+  "/preview",
+  validatePreviewGeneration,
+  async (c) => {
+    const locale = getLocale(c);
+    const user = getUser(c);
+    if (!user) {
+      return c.json(
+        {
+          success: false,
+          error: { code: "UNAUTHORIZED", message: serverMessage(locale, "unauthorized") },
+        },
+        401
+      );
+    }
+
+    const body = c.req.valid("json");
+    const db = createDb(c.env.DB);
+
+    try {
+      let productImage: { url: string; mimeType: string } | null = null;
+      if (body.productImageId) {
+        const image = await db.query.images.findFirst({
+          where: (images, { eq }) => eq(images.id, body.productImageId!),
+        });
+        if (image) {
+          productImage = { url: image.url, mimeType: image.mimeType };
+        }
+      }
+
+      const settings = {
+        targetPlatform: body.settings.targetPlatform,
+        language: body.settings.language,
+        uiLocale: body.settings.uiLocale,
+        count: 1, // Preview forces count=1
+        style: body.settings.style,
+        generateImages: false,
+      };
+
+      const results = await generateProductCopy({
+        env: c.env,
+        productImage,
+        referenceImages: [],
+        prompt: body.prompt,
+        settings,
+      });
+
+      const first = results[0];
+      if (!first) {
+        return c.json(
+          {
+            success: false,
+            error: { code: "INTERNAL_ERROR", message: serverMessage(locale, "internalError") },
+          },
+          500
+        );
+      }
+      return c.json({
+        success: true,
+        data: {
+          preview: {
+            title: first.title,
+            description: first.description,
+            keywords: first.tags ?? [],
+          },
+        },
+      });
+    } catch (error) {
+      console.error("[API] Preview generation error:", error);
+      return c.json(
+        {
+          success: false,
+          error: { code: "INTERNAL_ERROR", message: serverMessage(locale, "internalError") },
+        },
+        500
+      );
+    }
+  }
+);
 
 export default router;

--- a/frontend/src/components/GeneratePage.tsx
+++ b/frontend/src/components/GeneratePage.tsx
@@ -9,7 +9,7 @@ import UploadDropzone from "./UploadDropzone";
 import GenerationProgress, { type GenerationStage } from "./GenerationProgress";
 import CompareView from "./compare/CompareView";
 import { uploadImage } from "@/lib/api";
-import { createGeneration, getGeneration } from "@/lib/generation";
+import { createGeneration, getGeneration, previewGeneration } from "@/lib/generation";
 
 type Platform = "amazon" | "shopify" | "ebay" | "etsy" | "generic";
 
@@ -75,6 +75,8 @@ export default function GeneratePage() {
   const [generatedResults, setGeneratedResults] = useState<GeneratedResult[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [showCompare, setShowCompare] = useState(false);
+  const [isPreviewing, setIsPreviewing] = useState(false);
+  const [previewResult, setPreviewResult] = useState<{ title: string; description: string; keywords: string[] } | null>(null);
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const platforms: { value: Platform; label: string; icon: string }[] = [
@@ -220,6 +222,47 @@ export default function GeneratePage() {
   };
 
   const canGenerate = mainImage.length > 0 && !isGenerating && !isUploading;
+
+  // P0 T4 #86 - Preview one variant
+  const handlePreview = async () => {
+    if (mainImage.length === 0) {
+      setError(m.generation_error_noImage());
+      return;
+    }
+    setError(null);
+    setIsPreviewing(true);
+    setPreviewResult(null);
+
+    try {
+      let productImageId: string | undefined;
+      const mainImageResult = await uploadImage(mainImage[0], "product");
+      if (mainImageResult?.id) {
+        productImageId = mainImageResult.id;
+      }
+
+      const result = await previewGeneration({
+        productImageId,
+        prompt: undefined,
+        settings: {
+          targetPlatform: settings.platform,
+          language: settings.language,
+          uiLocale: currentUiLocale(),
+          style: settings.style as "professional" | "lifestyle" | "minimal" | "luxury",
+        },
+      });
+
+      if (!result.success || !result.data) {
+        setError(result.error || "预览失败");
+        return;
+      }
+
+      setPreviewResult(result.data.preview);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "预览失败");
+    } finally {
+      setIsPreviewing(false);
+    }
+  };
 
   return (
     <div className="flex min-h-screen flex-col">
@@ -503,39 +546,107 @@ export default function GeneratePage() {
                 </div>
               )}
 
-              {/* Generate Button */}
-              <button
-                type="button"
-                onClick={handleGenerate}
-                disabled={!canGenerate}
-                className={`
-                  btn-primary w-full h-12 text-base flex items-center justify-center gap-2
-                  ${canGenerate
-                    ? ""
-                    : "opacity-50 cursor-not-allowed"
-                  }
-                `}
-              >
-                {isUploading ? (
-                  <>
-                    <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24">
-                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
-                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                    </svg>
-                    {m.generation_uploadingBtn()}
-                  </>
-                ) : isGenerating ? (
-                  <>
-                    <Sparkles className="h-5 w-5 animate-pulse" />
-                    {m.generation_generatingBtn()}
-                  </>
-                ) : (
-                  <>
-                    <Sparkles className="h-5 w-5" />
-                    {m.generation_generateBtn()}
-                  </>
-                )}
-              </button>
+              {/* Preview & Generate Buttons (P0 T4 #86) */}
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={handlePreview}
+                  disabled={!canGenerate || isPreviewing || isUploading}
+                  className={`
+                    btn-secondary flex-1 h-12 text-base flex items-center justify-center gap-2
+                    ${!canGenerate || isPreviewing || isUploading
+                      ? "opacity-50 cursor-not-allowed"
+                      : ""
+                    }
+                  `}
+                >
+                  {isPreviewing ? (
+                    <>
+                      <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24">
+                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                      </svg>
+                      预览中...
+                    </>
+                  ) : (
+                    <>
+                      <Eye className="h-5 w-5" />
+                      预览
+                    </>
+                  )}
+                </button>
+                <button
+                  type="button"
+                  onClick={handleGenerate}
+                  disabled={!canGenerate}
+                  className={`
+                    btn-primary flex-1 h-12 text-base flex items-center justify-center gap-2
+                    ${canGenerate
+                      ? ""
+                      : "opacity-50 cursor-not-allowed"
+                    }
+                  `}
+                >
+                  {isUploading ? (
+                    <>
+                      <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24">
+                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                      </svg>
+                      {m.generation_uploadingBtn()}
+                    </>
+                  ) : isGenerating ? (
+                    <>
+                      <Sparkles className="h-5 w-5 animate-pulse" />
+                      {m.generation_generatingBtn()}
+                    </>
+                  ) : (
+                    <>
+                      <Sparkles className="h-5 w-5" />
+                      {m.generation_generateBtn()}
+                    </>
+                  )}
+                </button>
+              </div>
+
+              {/* Preview Result (P0 T4 #86) */}
+              {previewResult && (
+                <div className="mt-4 p-4 rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--card))] space-y-3">
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs font-semibold text-foreground-muted uppercase tracking-wide">
+                      预览示例
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => setPreviewResult(null)}
+                      className="text-xs text-foreground-muted hover:text-foreground"
+                      aria-label="关闭预览"
+                    >
+                      ✕ 关闭
+                    </button>
+                  </div>
+                  <div>
+                    <div className="text-xs font-medium text-foreground-muted mb-1">标题</div>
+                    <div className="text-sm font-semibold text-foreground">{previewResult.title}</div>
+                  </div>
+                  <div>
+                    <div className="text-xs font-medium text-foreground-muted mb-1">描述</div>
+                    <div className="text-sm text-foreground">{previewResult.description}</div>
+                  </div>
+                  {previewResult.keywords.length > 0 && (
+                    <div>
+                      <div className="text-xs font-medium text-foreground-muted mb-1">关键词</div>
+                      <div className="flex flex-wrap gap-1">
+                        {previewResult.keywords.map((kw, idx) => (
+                          <span key={idx} className="status-badge status-badge-neutral text-xs">
+                            {kw}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
               </div>
             </div>
 

--- a/frontend/src/lib/generation.ts
+++ b/frontend/src/lib/generation.ts
@@ -46,6 +46,54 @@ function apiErrorMessage(error: unknown, fallback: string): string {
   return fallback;
 }
 
+// Preview generation (P0 T4 #86)
+export interface PreviewGenerationRequest {
+  productImageId?: string;
+  prompt?: string;
+  settings: {
+    targetPlatform: "amazon" | "ebay" | "shopify" | "etsy" | "generic";
+    language: GenerationLanguage;
+    uiLocale?: Locale;
+    style: "professional" | "lifestyle" | "minimal" | "luxury";
+  };
+}
+
+export interface PreviewGenerationResponse {
+  success: boolean;
+  data?: {
+    preview: {
+      title: string;
+      description: string;
+      keywords: string[];
+    };
+  };
+  error?: string;
+}
+
+export async function previewGeneration(
+  request: PreviewGenerationRequest
+): Promise<PreviewGenerationResponse> {
+  try {
+    const response = await api.post("/api/generations/preview", request);
+    const data = response.data;
+    if (!data.success || !data.data) {
+      return {
+        success: false,
+        error: apiErrorMessage(data.error, m.common_createFailed()),
+      };
+    }
+    return {
+      success: true,
+      data: data.data,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : m.common_createFailed(),
+    };
+  }
+}
+
 export interface GetGenerationResponse {
   success: boolean;
   data?: {


### PR DESCRIPTION
## 背景
P0 T4 #86：用户填写表单后可点击「预览」生成 1 条示例，确认无误再正式生成。

## 改动
- `api/src/routes/generations.ts`: POST /api/generations/preview，强制 count=1，不入库
- `frontend/src/lib/generation.ts`: previewGeneration client API
- `frontend/src/components/GeneratePage.tsx`:
  - 生成按钮旁加「预览」按钮（带 loading 态）
  - 预览结果下方展示（标题/描述/关键词标签，可关闭）

## 验收
- 点击预览按钮可生成 1 条示例
- 预览结果不写入历史
- 表单可调整后再次预览
- 正式生成按钮保持原行为