### PR TITLE
P0 T5 #87: Prompt 模板推荐 + 历史参考

### DIFF
--- a/frontend/src/components/GeneratePage.tsx
+++ b/frontend/src/components/GeneratePage.tsx
@@ -8,6 +8,7 @@ import { localeToGenerationLanguage, type GenerationLanguage, type Locale } from
 import UploadDropzone from "./UploadDropzone";
 import GenerationProgress, { type GenerationStage } from "./GenerationProgress";
 import CompareView from "./compare/CompareView";
+import PromptTemplates, { type PromptTemplate } from "./generation/PromptTemplates";
 import { uploadImage } from "@/lib/api";
 import { createGeneration, getGeneration } from "@/lib/generation";
 
@@ -75,6 +76,7 @@ export default function GeneratePage() {
   const [generatedResults, setGeneratedResults] = useState<GeneratedResult[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [showCompare, setShowCompare] = useState(false);
+  const [promptText, setPromptText] = useState(""); // P0 T5 #87
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const platforms: { value: Platform; label: string; icon: string }[] = [
@@ -186,6 +188,7 @@ export default function GeneratePage() {
       const generationResult = await createGeneration({
         productImageId: mainImageResult.id,
         referenceImageIds: styleImageIds.length > 0 ? styleImageIds : undefined,
+        prompt: promptText.trim() || undefined,
         settings: {
           targetPlatform: settings.platform,
           count: settings.count,
@@ -314,6 +317,39 @@ export default function GeneratePage() {
               <div className="flex items-center gap-2 mb-6">
                 <Settings className="h-5 w-5 text-[hsl(var(--primary))]" />
                 <h2 className="text-lg font-semibold text-foreground">{m.generation_settings()}</h2>
+              </div>
+
+              {/* Prompt Templates + History (P0 T5 #87) */}
+              <PromptTemplates
+                platform={settings.platform}
+                style={settings.style}
+                onSelect={(tpl) => setPromptText(tpl.template)}
+                onHistorySelect={(rec) => {
+                  setPromptText(rec.prompt || "");
+                  setSettings({
+                    ...settings,
+                    platform: rec.platform as Platform,
+                    style: rec.style as Style,
+                    language: rec.language as GenerationLanguage,
+                  });
+                }}
+              />
+
+              {/* Prompt Input (P0 T5 #87) */}
+              <div className="mb-6">
+                <label className="block text-sm font-medium text-foreground mb-2">
+                  Prompt 提示词（可选）
+                </label>
+                <textarea
+                  value={promptText}
+                  onChange={(e) => setPromptText(e.target.value)}
+                  placeholder="输入额外的产品描述或要求，或选择上方模板"
+                  rows={3}
+                  className="input resize-y"
+                />
+                <div className="text-xs text-foreground-muted mt-1">
+                  {promptText.length} / 500 字符
+                </div>
               </div>
 
               {/* Platform Selection */}

--- a/frontend/src/components/generation/PromptTemplates.tsx
+++ b/frontend/src/components/generation/PromptTemplates.tsx
@@ -1,0 +1,173 @@
+/**
+ * Prompt Templates + History Reference (P0 T5 #87)
+ *
+ * Provides pre-built prompt templates and quick reuse from last 5 successful generations.
+ */
+
+import { useEffect, useState } from "react";
+import { History, Sparkles } from "lucide-react";
+import type { GenerationRecord } from "@/hooks/useGenerations";
+
+export interface PromptTemplate {
+  id: string;
+  name: string;
+  platform: "amazon" | "shopify" | "ebay" | "etsy" | "generic";
+  style: "professional" | "lifestyle" | "minimal" | "luxury";
+  template: string;
+  description: string;
+}
+
+export const PROMPT_TEMPLATES: PromptTemplate[] = [
+  {
+    id: "ecommerce-basic",
+    name: "电商基础款",
+    platform: "generic",
+    style: "professional",
+    template: "为【{product}】生成专业电商文案，突出【{feature}】卖点，使用吸引人的开场和清晰的卖点列举。",
+    description: "通用电商文案模板",
+  },
+  {
+    id: "amazon-listing",
+    name: "Amazon 上架款",
+    platform: "amazon",
+    style: "professional",
+    template: "为【{product}】生成 Amazon 商品 listing：标题（< 200 字符）+ 5 点 Bullet + 产品描述。突出【{feature}】，符合 Amazon A9 算法。",
+    description: "符合 Amazon A9 优化规则",
+  },
+  {
+    id: "shopify-storytelling",
+    name: "Shopify 故事款",
+    platform: "shopify",
+    style: "lifestyle",
+    template: "为【{product}】撰写 Shopify 商品故事，融入使用场景和情感共鸣，结尾 CTA。",
+    description: "生活方式/情感叙事",
+  },
+  {
+    id: "luxury-premium",
+    name: "奢侈品高级款",
+    platform: "generic",
+    style: "luxury",
+    template: "为【{product}】撰写奢侈品文案，强调工艺、稀缺性和传承，语言精致克制。",
+    description: "奢侈品调性",
+  },
+  {
+    id: "minimalist-clean",
+    name: "极简主义款",
+    platform: "generic",
+    style: "minimal",
+    template: "为【{product}】生成极简风格文案，关键词精炼，留白留白。",
+    description: "极简克制",
+  },
+  {
+    id: "etsy-handmade",
+    name: "Etsy 手作款",
+    platform: "etsy",
+    style: "lifestyle",
+    template: "为【{product}】撰写 Etsy 手作商品描述，强调手工、材质和独特性。",
+    description: "手工艺品类",
+  },
+];
+
+interface PromptTemplatesProps {
+  platform: string;
+  style: string;
+  onSelect: (template: PromptTemplate) => void;
+  onHistorySelect: (record: GenerationRecord) => void;
+}
+
+export default function PromptTemplates({
+  platform,
+  style,
+  onSelect,
+  onHistorySelect,
+}: PromptTemplatesProps) {
+  const [history, setHistory] = useState<GenerationRecord[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadHistory() {
+      try {
+        const res = await fetch("/api/generations?page=1&pageSize=5&filter=month", {
+          credentials: "include",
+        });
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!cancelled && data?.success && Array.isArray(data.data)) {
+          setHistory(data.data.filter((r: GenerationRecord) => r.status === "completed").slice(0, 5));
+        }
+      } catch {
+        // silently ignore
+      }
+    }
+    loadHistory();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const filteredTemplates = PROMPT_TEMPLATES.filter(
+    (t) => t.platform === platform || t.platform === "generic"
+  );
+
+  return (
+    <div className="mb-6 space-y-4">
+      {/* Templates */}
+      <div className="rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-4">
+        <div className="flex items-center gap-2 mb-3">
+          <Sparkles className="h-4 w-4 text-[hsl(var(--primary))]" aria-hidden="true" />
+          <h3 className="text-sm font-semibold text-foreground">Prompt 模板推荐</h3>
+        </div>
+        <div className="grid grid-cols-1 gap-2">
+          {filteredTemplates.map((tpl) => (
+            <button
+              key={tpl.id}
+              type="button"
+              onClick={() => onSelect(tpl)}
+              className="text-left p-2.5 rounded-md border border-[hsl(var(--border))] hover:border-[hsl(var(--primary))] hover:bg-[hsl(var(--primary)/0.05)] transition-colors"
+            >
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-foreground">{tpl.name}</span>
+                <span className="text-xs text-foreground-muted">{tpl.style}</span>
+              </div>
+              <div className="text-xs text-foreground-muted mt-1 line-clamp-2">
+                {tpl.description}
+              </div>
+            </button>
+          ))}
+        </div>
+        {filteredTemplates.length === 0 && (
+          <div className="text-xs text-foreground-muted text-center py-3">
+            该平台暂无专属模板，已显示通用模板
+          </div>
+        )}
+      </div>
+
+      {/* History Reference */}
+      {history.length > 0 && (
+        <div className="rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-4">
+          <div className="flex items-center gap-2 mb-3">
+            <History className="h-4 w-4 text-foreground-muted" aria-hidden="true" />
+            <h3 className="text-sm font-semibold text-foreground">历史参考（最近 5 次成功）</h3>
+          </div>
+          <div className="space-y-1.5">
+            {history.map((rec) => (
+              <button
+                key={rec.id}
+                type="button"
+                onClick={() => onHistorySelect(rec)}
+                className="w-full text-left p-2 rounded-md hover:bg-[hsl(var(--secondary))] transition-colors flex items-center justify-between gap-2"
+              >
+                <span className="text-xs text-foreground line-clamp-1 flex-1">
+                  {rec.prompt || rec.id.slice(0, 8)}
+                </span>
+                <span className="text-xs font-medium text-[hsl(var(--primary))] shrink-0">
+                  使用此设置 →
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 背景
P0 T5 #87：用户可选择预设模板快速填充 prompt，或复用历史 5 次成功生成的设置。

## 改动
- 新增 `frontend/src/components/generation/PromptTemplates.tsx`：
  - 6 个内置模板（电商基础/Amazon/Shopify/奢侈品/极简/Etsy 手作）
  - 按当前 platform/style 自动筛选
  - 历史 5 次成功生成复用（点击自动填充 settings + prompt）
- `frontend/src/components/GeneratePage.tsx`：
  - 设置区上方展示模板卡片和历史列表
  - 新增 Prompt 输入框（textarea，可选，500 字符限制）
  - prompt 拼接到 createGeneration 请求

## 验证
- ✅ pnpm typecheck
- ✅ pnpm build