### PR TITLE
fix(auth): 跨子域 Cookie 共享配置 (P0 #88)

### DIFF
--- a/api/src/lib/auth.ts
+++ b/api/src/lib/auth.ts
@@ -100,6 +100,21 @@ export function createAuth(
     advanced: {
       disableCSRFCheck: isLocalDev,
       useSecureCookies: !isLocalDev,
+      // P0 #88: 跨子域 Cookie 共享（仅生产环境）
+      // 前端 ourapix.jiahongw.com / API api.ourapix.jiahongw.com
+      // 共享主域 .jiahongw.com
+      ...(isLocalDev
+        ? {}
+        : {
+            crossSubDomainCookies: {
+              enabled: true,
+              domain: ".jiahongw.com",
+            },
+            defaultCookieAttributes: {
+              sameSite: "none",
+              secure: true,
+            },
+          }),
     },
   });
 }


### PR DESCRIPTION
## 问题
已登录用户访问团队页面，API 返回 401。

## 根因
前端 `ourapix.jiahongw.com` 与 API `api.ourapix.jiahongw.com` 不同子域，Better Auth session cookie 默认 `SameSite=Lax` 不跨子域发送。

## 修复
`api/src/lib/auth.ts` 中 Better Auth 配置：

```typescript
advanced: {
  // 仅生产环境启用跨子域 Cookie
  ...(isLocalDev ? {} : {
    crossSubDomainCookies: {
      enabled: true,
      domain: '.jiahongw.com',
    },
    defaultCookieAttributes: {
      sameSite: 'none',
      secure: true,
    },
  }),
}
```

## 备注
- Better Auth v1.5.x 使用 `advanced.crossSubDomainCookies`，不是 session.cookieOptions
- 本地开发保留 Lax 行为，避免破坏单元测试

## 验证
- ✅ pnpm typecheck
- ✅ pnpm test 20/20

## 上线后验证步骤
1. 退出登录
2. 重新登录获取新 cookie
3. 访问 https://ourapix.jiahongw.com/teams 应正常加载
4. DevTools 查看 Cookie 应有 `Domain=.jiahongw.com` 和 `SameSite=None`