### PR TITLE
feat(ui): 个人中心桌面端侧边栏 + 5 个分组页面骨架 (P0 #89)

### DIFF
--- a/frontend/src/components/settings/SettingsSidebar.tsx
+++ b/frontend/src/components/settings/SettingsSidebar.tsx
@@ -1,0 +1,61 @@
+/**
+ * SettingsSidebar Component (P0 #89)
+ *
+ * Desktop sidebar navigation for /settings/* pages
+ */
+
+"use client";
+
+import { User, CreditCard, Key, Users, Settings } from "lucide-react";
+
+export interface SettingsNavItem {
+  href: string;
+  icon: typeof User;
+  label: string;
+  key: string;
+}
+
+export const SETTINGS_NAV_ITEMS: SettingsNavItem[] = [
+  { href: "/settings/account", icon: User, label: "账号", key: "account" },
+  { href: "/settings/subscription", icon: CreditCard, label: "订阅", key: "subscription" },
+  { href: "/settings/api-keys", icon: Key, label: "API Keys", key: "api-keys" },
+  { href: "/settings/teams", icon: Users, label: "团队", key: "teams" },
+  { href: "/settings/preferences", icon: Settings, label: "偏好", key: "preferences" },
+];
+
+interface SettingsSidebarProps {
+  currentKey?: string;
+}
+
+export default function SettingsSidebar({ currentKey }: SettingsSidebarProps) {
+  return (
+    <nav aria-label="设置导航" className="space-y-1">
+      <div className="px-3 py-2 mb-2">
+        <h2 className="text-xs font-semibold text-foreground-muted uppercase tracking-wide">
+          个人中心
+        </h2>
+      </div>
+      {SETTINGS_NAV_ITEMS.map((item) => {
+        const Icon = item.icon;
+        const isActive = currentKey === item.key;
+        return (
+          <a
+            key={item.key}
+            href={item.href}
+            aria-current={isActive ? "page" : undefined}
+            className={`
+              flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium transition-colors
+              ${isActive
+                ? "bg-[hsl(var(--primary)/0.1)] text-[hsl(var(--primary))]"
+                : "text-foreground hover:bg-[hsl(var(--secondary))]"
+              }
+            `}
+          >
+            <Icon className="h-4 w-4" aria-hidden="true" />
+            <span>{item.label}</span>
+          </a>
+        );
+      })}
+    </nav>
+  );
+}

--- a/frontend/src/layouts/SettingsLayout.astro
+++ b/frontend/src/layouts/SettingsLayout.astro
@@ -1,0 +1,54 @@
+---
+/**
+ * SettingsLayout (P0 #89)
+ *
+ * Desktop: 2-column layout (sidebar + content)
+ * Mobile: stacked (sidebar collapses to top tabs - T2 task)
+ */
+import Navbar from '../components/Navbar';
+import SettingsSidebar from '../components/settings/SettingsSidebar';
+import ErrorBoundary from '../components/ErrorBoundary';
+
+interface Props {
+  title: string;
+  currentKey: 'account' | 'subscription' | 'api-keys' | 'teams' | 'preferences';
+}
+
+const { title, currentKey } = Astro.props;
+---
+
+<div class="min-h-screen bg-[hsl(var(--background))]">
+  <Navbar client:load />
+
+  <main class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+    <div class="hidden lg:block mb-6">
+      <h1 class="text-2xl font-bold text-foreground">个人中心</h1>
+      <p class="mt-1 text-sm text-foreground-muted">管理你的账号、订阅和偏好设置</p>
+    </div>
+
+    <div class="flex gap-8">
+      <aside class="hidden lg:block w-56 shrink-0">
+        <div class="sticky top-24">
+          <SettingsSidebar client:load currentKey={currentKey} />
+        </div>
+      </aside>
+
+      <!-- Mobile horizontal tabs (T2 task will refine) -->
+      <nav class="lg:hidden mb-4 overflow-x-auto" aria-label="设置导航">
+        <div class="flex gap-1 min-w-max">
+          <a href="/settings/account" class={`px-3 py-2 text-sm rounded-md whitespace-nowrap ${currentKey === 'account' ? 'bg-[hsl(var(--primary)/0.1)] text-[hsl(var(--primary))] font-semibold' : 'text-foreground'}`}>账号</a>
+          <a href="/settings/subscription" class={`px-3 py-2 text-sm rounded-md whitespace-nowrap ${currentKey === 'subscription' ? 'bg-[hsl(var(--primary)/0.1)] text-[hsl(var(--primary))] font-semibold' : 'text-foreground'}`}>订阅</a>
+          <a href="/settings/api-keys" class={`px-3 py-2 text-sm rounded-md whitespace-nowrap ${currentKey === 'api-keys' ? 'bg-[hsl(var(--primary)/0.1)] text-[hsl(var(--primary))] font-semibold' : 'text-foreground'}`}>API Keys</a>
+          <a href="/settings/teams" class={`px-3 py-2 text-sm rounded-md whitespace-nowrap ${currentKey === 'teams' ? 'bg-[hsl(var(--primary)/0.1)] text-[hsl(var(--primary))] font-semibold' : 'text-foreground'}`}>团队</a>
+          <a href="/settings/preferences" class={`px-3 py-2 text-sm rounded-md whitespace-nowrap ${currentKey === 'preferences' ? 'bg-[hsl(var(--primary)/0.1)] text-[hsl(var(--primary))] font-semibold' : 'text-foreground'}`}>偏好</a>
+        </div>
+      </nav>
+
+      <section class="flex-1 min-w-0">
+        <ErrorBoundary client:load>
+          <slot />
+        </ErrorBoundary>
+      </section>
+    </div>
+  </main>
+</div>

--- a/frontend/src/pages/settings/account.astro
+++ b/frontend/src/pages/settings/account.astro
@@ -1,0 +1,15 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import SettingsLayout from '../../layouts/SettingsLayout.astro';
+import ProfilePage from '../../components/ProfilePage';
+import * as m from "@/paraglide/messages.js";
+
+const title = m.meta_profileTitle();
+const description = m.meta_profileDescription();
+---
+
+<Layout title={title} description={description}>
+  <SettingsLayout title={title} currentKey="account">
+    <ProfilePage client:load />
+  </SettingsLayout>
+</Layout>

--- a/frontend/src/pages/settings/api-keys.astro
+++ b/frontend/src/pages/settings/api-keys.astro
@@ -1,0 +1,14 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import SettingsLayout from '../../layouts/SettingsLayout.astro';
+import ApiKeysPage from '../../components/keys/ApiKeysPage';
+import * as m from "@/paraglide/messages.js";
+
+const title = m.meta_apiKeysTitle();
+---
+
+<Layout title={title}>
+  <SettingsLayout title={title} currentKey="api-keys">
+    <ApiKeysPage client:load />
+  </SettingsLayout>
+</Layout>

--- a/frontend/src/pages/settings/index.astro
+++ b/frontend/src/pages/settings/index.astro
@@ -1,0 +1,4 @@
+---
+// P0 #89: /settings 默认重定向到 /settings/account
+return Astro.redirect('/settings/account', 302);
+---

--- a/frontend/src/pages/settings/preferences.astro
+++ b/frontend/src/pages/settings/preferences.astro
@@ -1,0 +1,76 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import SettingsLayout from '../../layouts/SettingsLayout.astro';
+
+const title = "偏好设置 - 个人中心";
+---
+
+<Layout title={title}>
+  <SettingsLayout title={title} currentKey="preferences">
+    <div class="space-y-6">
+      <div>
+        <h2 class="text-xl font-semibold text-foreground">偏好设置</h2>
+        <p class="mt-1 text-sm text-foreground-muted">个性化你的体验</p>
+      </div>
+
+      <div class="card p-6 space-y-4">
+        <h3 class="text-sm font-semibold text-foreground">语言与时区</h3>
+        <div class="space-y-3">
+          <div>
+            <label class="block text-xs font-medium text-foreground-muted mb-1">界面语言</label>
+            <select class="input">
+              <option value="zh-CN">简体中文</option>
+              <option value="en">English</option>
+              <option value="ja">日本語</option>
+            </select>
+          </div>
+          <div>
+            <label class="block text-xs font-medium text-foreground-muted mb-1">时区</label>
+            <select class="input">
+              <option value="Asia/Shanghai">UTC+8 北京</option>
+              <option value="UTC">UTC</option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      <div class="card p-6 space-y-4">
+        <h3 class="text-sm font-semibold text-foreground">通知</h3>
+        <div class="space-y-3">
+          <label class="flex items-center gap-2 text-sm">
+            <input type="checkbox" class="rounded" />
+            <span>邮件通知 - 新功能</span>
+          </label>
+          <label class="flex items-center gap-2 text-sm">
+            <input type="checkbox" class="rounded" />
+            <span>邮件通知 - 生成完成</span>
+          </label>
+        </div>
+      </div>
+
+      <div class="card p-6 space-y-4">
+        <h3 class="text-sm font-semibold text-foreground">默认生成设置</h3>
+        <div class="space-y-3">
+          <div>
+            <label class="block text-xs font-medium text-foreground-muted mb-1">默认平台</label>
+            <select class="input">
+              <option value="amazon">Amazon</option>
+              <option value="shopify">Shopify</option>
+              <option value="ebay">eBay</option>
+              <option value="etsy">Etsy</option>
+            </select>
+          </div>
+          <div>
+            <label class="block text-xs font-medium text-foreground-muted mb-1">默认风格</label>
+            <select class="input">
+              <option value="minimal">极简</option>
+              <option value="luxury">高级</option>
+              <option value="lifestyle">生活方式</option>
+              <option value="professional">专业</option>
+            </select>
+          </div>
+        </div>
+      </div>
+    </div>
+  </SettingsLayout>
+</Layout>

--- a/frontend/src/pages/settings/subscription.astro
+++ b/frontend/src/pages/settings/subscription.astro
@@ -1,0 +1,45 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import SettingsLayout from '../../layouts/SettingsLayout.astro';
+import * as m from "@/paraglide/messages.js";
+
+const title = "订阅管理 - 个人中心";
+---
+
+<Layout title={title}>
+  <SettingsLayout title={title} currentKey="subscription">
+    <div class="space-y-6">
+      <div>
+        <h2 class="text-xl font-semibold text-foreground">订阅管理</h2>
+        <p class="mt-1 text-sm text-foreground-muted">查看和管理你的订阅计划</p>
+      </div>
+
+      <div class="card p-6">
+        <div class="flex items-center justify-between mb-4">
+          <div>
+            <div class="text-sm font-medium text-foreground-muted">当前计划</div>
+            <div class="mt-1 text-2xl font-bold text-foreground">免费版</div>
+          </div>
+          <a href="/pricing" class="btn-primary px-4 py-2">升级</a>
+        </div>
+        <div class="border-t border-[hsl(var(--border))] pt-4 space-y-2">
+          <div class="flex justify-between text-sm">
+            <span class="text-foreground-muted">本月已用</span>
+            <span class="font-medium text-foreground">0 / 100 次</span>
+          </div>
+          <div class="flex justify-between text-sm">
+            <span class="text-foreground-muted">图片生成</span>
+            <span class="font-medium text-foreground">未启用</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="card p-6">
+        <h3 class="text-sm font-semibold text-foreground mb-3">账单历史</h3>
+        <div class="text-sm text-foreground-muted text-center py-6">
+          暂无账单记录
+        </div>
+      </div>
+    </div>
+  </SettingsLayout>
+</Layout>

--- a/frontend/src/pages/settings/teams.astro
+++ b/frontend/src/pages/settings/teams.astro
@@ -1,0 +1,14 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import SettingsLayout from '../../layouts/SettingsLayout.astro';
+import TeamsPage from '../../components/teams/TeamsPage';
+import * as m from "@/paraglide/messages.js";
+
+const title = "团队管理 - 个人中心";
+---
+
+<Layout title={title}>
+  <SettingsLayout title={title} currentKey="teams">
+    <TeamsPage client:load />
+  </SettingsLayout>
+</Layout>


### PR DESCRIPTION
## 背景
P0 #89：基于 Steven 产品方案设计个人中心布局。

## 改动
- 新增 `components/settings/SettingsSidebar.tsx`：5 项导航（账号/订阅/API Keys/团队/偏好）
- 新增 `layouts/SettingsLayout.astro`：双栏布局（桌面 lg+ 侧边栏，移动端横向 tab 占位）
- 新增 5 个分组页面 `pages/settings/*.astro`：
  - account: 复用 ProfilePage
  - subscription: 骨架（当前计划 + 账单历史占位）
  - api-keys: 复用 ApiKeysPage
  - teams: 复用 TeamsPage
  - preferences: 骨架（语言/时区/通知/默认设置占位）
- 新增 `pages/settings/index.astro`: 302 重定向到 /settings/account

## 验证
- ✅ pnpm typecheck
- ✅ pnpm build

## 后续 T2-T7
- T2: 移动端导航优化
- T3-T7: 各分组页面功能填充