### PR TITLE
feat(ui): 设置页移动端 Tab 导航 + 响应式 (P0 #90 T2)

### DIFF
--- a/frontend/src/components/settings/MobileSettingsTabs.tsx
+++ b/frontend/src/components/settings/MobileSettingsTabs.tsx
@@ -1,0 +1,68 @@
+/**
+ * MobileSettingsTabs Component (P0 #90 T2)
+ *
+ * Horizontal scrollable tab bar for /settings/* on mobile (< lg).
+ * Active tab auto-scrolls into view on mount and on change.
+ */
+
+"use client";
+
+import { useEffect, useRef } from "react";
+import { SETTINGS_NAV_ITEMS, type SettingsNavItem } from "./SettingsSidebar";
+
+interface MobileSettingsTabsProps {
+  currentKey?: string;
+}
+
+export default function MobileSettingsTabs({ currentKey }: MobileSettingsTabsProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const activeRef = useRef<HTMLAnchorElement>(null);
+
+  // Auto-scroll active tab into view
+  useEffect(() => {
+    if (activeRef.current && containerRef.current) {
+      const container = containerRef.current;
+      const active = activeRef.current;
+      const scrollLeft = active.offsetLeft - container.clientWidth / 2 + active.clientWidth / 2;
+      container.scrollTo({ left: scrollLeft, behavior: "smooth" });
+    }
+  }, [currentKey]);
+
+  return (
+    <nav
+      ref={containerRef}
+      aria-label="设置导航（移动端）"
+      className="lg:hidden overflow-x-auto border-b border-[hsl(var(--border))] bg-[hsl(var(--card))] -mx-4 px-4 sm:-mx-6 sm:px-6"
+      style={{ scrollbarWidth: "none" }}
+    >
+      <div className="flex gap-1 min-w-max py-2">
+        {SETTINGS_NAV_ITEMS.map((item: SettingsNavItem) => {
+          const isActive = item.key === currentKey;
+          return (
+            <a
+              key={item.key}
+              ref={isActive ? activeRef : undefined}
+              href={item.href}
+              aria-current={isActive ? "page" : undefined}
+              className={`
+                shrink-0 px-4 py-2 rounded-lg text-sm font-medium transition-colors relative
+                ${isActive
+                  ? "text-[hsl(var(--primary))] bg-[hsl(var(--primary)/0.1)]"
+                  : "text-foreground-muted hover:text-foreground hover:bg-[hsl(var(--secondary))]"
+                }
+              `}
+            >
+              {item.label}
+              {isActive && (
+                <span
+                  className="absolute bottom-0 left-2 right-2 h-0.5 rounded-full bg-[hsl(var(--primary))]"
+                  aria-hidden="true"
+                />
+              )}
+            </a>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/frontend/src/layouts/SettingsLayout.astro
+++ b/frontend/src/layouts/SettingsLayout.astro
@@ -1,12 +1,13 @@
 ---
 /**
- * SettingsLayout (P0 #89)
+ * SettingsLayout (P0 #89 desktop + #90 mobile)
  *
- * Desktop: 2-column layout (sidebar + content)
- * Mobile: stacked (sidebar collapses to top tabs - T2 task)
+ * Desktop (>= lg): sidebar + content
+ * Mobile (< lg): top tabs + content (auto-scroll active tab into view)
  */
 import Navbar from '../components/Navbar';
 import SettingsSidebar from '../components/settings/SettingsSidebar';
+import MobileSettingsTabs from '../components/settings/MobileSettingsTabs';
 import ErrorBoundary from '../components/ErrorBoundary';
 
 interface Props {
@@ -20,30 +21,26 @@ const { title, currentKey } = Astro.props;
 <div class="min-h-screen bg-[hsl(var(--background))]">
   <Navbar client:load />
 
-  <main class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+  <main class="mx-auto max-w-7xl px-4 py-4 sm:px-6 sm:py-8 lg:px-8">
     <div class="hidden lg:block mb-6">
       <h1 class="text-2xl font-bold text-foreground">个人中心</h1>
       <p class="mt-1 text-sm text-foreground-muted">管理你的账号、订阅和偏好设置</p>
     </div>
 
-    <div class="flex gap-8">
+    <!-- Mobile tabs (full-width sticky) -->
+    <div class="lg:hidden sticky top-0 z-30 -mx-4 sm:-mx-6 mb-4 bg-[hsl(var(--background))]">
+      <MobileSettingsTabs client:load currentKey={currentKey} />
+    </div>
+
+    <div class="lg:flex lg:gap-8">
+      <!-- Desktop sidebar -->
       <aside class="hidden lg:block w-56 shrink-0">
         <div class="sticky top-24">
           <SettingsSidebar client:load currentKey={currentKey} />
         </div>
       </aside>
 
-      <!-- Mobile horizontal tabs (T2 task will refine) -->
-      <nav class="lg:hidden mb-4 overflow-x-auto" aria-label="设置导航">
-        <div class="flex gap-1 min-w-max">
-          <a href="/settings/account" class={`px-3 py-2 text-sm rounded-md whitespace-nowrap ${currentKey === 'account' ? 'bg-[hsl(var(--primary)/0.1)] text-[hsl(var(--primary))] font-semibold' : 'text-foreground'}`}>账号</a>
-          <a href="/settings/subscription" class={`px-3 py-2 text-sm rounded-md whitespace-nowrap ${currentKey === 'subscription' ? 'bg-[hsl(var(--primary)/0.1)] text-[hsl(var(--primary))] font-semibold' : 'text-foreground'}`}>订阅</a>
-          <a href="/settings/api-keys" class={`px-3 py-2 text-sm rounded-md whitespace-nowrap ${currentKey === 'api-keys' ? 'bg-[hsl(var(--primary)/0.1)] text-[hsl(var(--primary))] font-semibold' : 'text-foreground'}`}>API Keys</a>
-          <a href="/settings/teams" class={`px-3 py-2 text-sm rounded-md whitespace-nowrap ${currentKey === 'teams' ? 'bg-[hsl(var(--primary)/0.1)] text-[hsl(var(--primary))] font-semibold' : 'text-foreground'}`}>团队</a>
-          <a href="/settings/preferences" class={`px-3 py-2 text-sm rounded-md whitespace-nowrap ${currentKey === 'preferences' ? 'bg-[hsl(var(--primary)/0.1)] text-[hsl(var(--primary))] font-semibold' : 'text-foreground'}`}>偏好</a>
-        </div>
-      </nav>
-
+      <!-- Content -->
       <section class="flex-1 min-w-0">
         <ErrorBoundary client:load>
           <slot />


### PR DESCRIPTION
## 改动
- 新增 `components/settings/MobileSettingsTabs.tsx`:
  - 横向滚动 tab（< lg）
  - 激活 tab 自动滚动到可视中心
  - 底部颜色条指示
- `layouts/SettingsLayout.astro` 重构：移动端 tab sticky 顶部，桌面端 lg+ 侧边栏

## 验证
- ✅ pnpm typecheck
- ✅ pnpm build