### PR TITLE
feat: HistoryPage image edit save with R2 upload

### DIFF
--- a/api/src/routes/generations.ts
+++ b/api/src/routes/generations.ts
@@ -6,8 +6,9 @@
 
 import { Hono } from "hono";
 import { z } from "zod";
+import { eq } from "drizzle-orm";
 import { zValidator } from "@hono/zod-validator";
-import { createDb } from "@oura-pix/database";
+import { createDb, schema } from "@oura-pix/database";
 import { resolveLocale, serverMessage, type Locale } from "@oura-pix/i18n";
 import { getUser } from "../middleware/auth";
 import {
@@ -24,6 +25,8 @@ import { getTeamForUser } from "../services/teamService";
 const router = new Hono<{
   Bindings: {
     DB: D1Database;
+    R2: R2Bucket;
+    CLOUDFLARE_R2_PUBLIC_URL: string;
     GEMINI_API_KEY?: string;
     GEMINI_BASE_URL?: string;
     GEMINI_MODEL?: string;
@@ -245,6 +248,104 @@ router.post("/:id/cancel", async (c) => {
   }
 
   return c.json({ success: true });
+});
+
+// PATCH /api/generations/:id/image - Update generation result image with edited version
+router.patch("/:id/image", async (c) => {
+  const locale = getLocale(c);
+  const user = getUser(c);
+  if (!user) {
+    return c.json(
+      {
+        success: false,
+        error: { code: "UNAUTHORIZED", message: serverMessage(locale, "unauthorized") },
+      },
+      401
+    );
+  }
+
+  const id = c.req.param("id");
+  const db = createDb(c.env.DB);
+
+  const generation = await getGenerationById(db, id, user.id);
+  if (!generation) {
+    return c.json(
+      {
+        success: false,
+        error: { code: "NOT_FOUND", message: serverMessage(locale, "generationNotFound") },
+      },
+      404
+    );
+  }
+
+  const formData = await c.req.formData();
+  const imageFile = formData.get("image") as File | null;
+  const imageIndexStr = formData.get("imageIndex");
+  const imageIndex = imageIndexStr ? parseInt(imageIndexStr as string, 10) : 0;
+
+  if (!imageFile) {
+    return c.json(
+      {
+        success: false,
+        error: { code: "BAD_REQUEST", message: serverMessage(locale, "badRequest") },
+      },
+      400
+    );
+  }
+
+  const { R2, CLOUDFLARE_R2_PUBLIC_URL } = c.env;
+  const ext = (imageFile.name || "png").split(".").pop() || "png";
+  const key = `edits/${user.id}/${crypto.randomUUID()}.${ext}`;
+
+  try {
+    await R2.put(key, imageFile, {
+      httpMetadata: {
+        contentType: imageFile.type || "image/png",
+      },
+    });
+
+    const editedImageUrl = `${CLOUDFLARE_R2_PUBLIC_URL}/${key}`;
+
+    const currentResults = generation.results ?? [];
+    const updatedResults = [...currentResults];
+
+    if (updatedResults[imageIndex]) {
+      updatedResults[imageIndex] = {
+        ...updatedResults[imageIndex],
+        imageUrl: editedImageUrl,
+      };
+    } else {
+      updatedResults.push({
+        id: crypto.randomUUID(),
+        title: updatedResults[0]?.title ?? "",
+        description: updatedResults[0]?.description ?? "",
+        tags: updatedResults[0]?.tags ?? [],
+        imageUrl: editedImageUrl,
+      });
+    }
+
+    await db
+      .update(schema.generations)
+      .set({
+        results: updatedResults,
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.generations.id, id));
+
+    return c.json({
+      success: true,
+      data: { imageUrl: editedImageUrl },
+    });
+  } catch (error) {
+    console.error("[API] Update generation image error:", error);
+    return c.json(
+      {
+        success: false,
+        error: { code: "INTERNAL_ERROR", message: serverMessage(locale, "internalError") },
+      },
+      500
+    );
+  }
 });
 
 // DELETE /api/generations/:id - Delete generation

--- a/frontend/src/components/GenerationCard.tsx
+++ b/frontend/src/components/GenerationCard.tsx
@@ -14,7 +14,7 @@ interface GenerationCardProps {
   generation: GenerationRecord;
   onViewDetail: (id: string) => void;
   onRegenerate: (id: string) => void;
-  onEdit: (imageUrl: string) => void;
+  onEdit: (genId: string, imageUrl: string, imageIndex?: number) => void;
   onDelete: (id: string) => void;
 }
 
@@ -146,7 +146,7 @@ export default function GenerationCard({
           <button
             onClick={() => {
               const imageUrl = generation.generatedImages[0] || generation.productImageUrl;
-              if (imageUrl) onEdit(imageUrl);
+              if (imageUrl) onEdit(generation.id, imageUrl, 0);
             }}
             className="icon-button h-10 w-10 bg-[hsl(var(--card)/0.92)] text-foreground hover:bg-[hsl(var(--card))]"
             title={m.editor_editImage()}

--- a/frontend/src/components/HistoryPage.tsx
+++ b/frontend/src/components/HistoryPage.tsx
@@ -12,7 +12,7 @@ import { useGenerations } from "@/hooks/useGenerations";
 import FilterBar from "./FilterBar";
 import GenerationCard from "./GenerationCard";
 import ImageEditor from "./editor/ImageEditor";
-import { deleteGeneration } from "@/lib/api";
+import { deleteGeneration, updateGenerationImage } from "@/lib/api";
 
 function SkeletonCard() {
   return (
@@ -71,7 +71,7 @@ export default function HistoryPage() {
     refresh,
   } = useGenerations();
 
-  const [editingImage, setEditingImage] = useState<string | null>(null);
+  const [editingContext, setEditingContext] = useState<{ genId: string; imageUrl: string; imageIndex: number } | null>(null);
 
   const handleViewDetail = useCallback((id: string) => {
     window.location.href = localizeHref(`/generate?history=${id}`);
@@ -81,8 +81,8 @@ export default function HistoryPage() {
     window.location.href = localizeHref(`/generate?regenerate=${id}`);
   }, []);
 
-  const handleEdit = useCallback((imageUrl: string) => {
-    setEditingImage(imageUrl);
+  const handleEdit = useCallback((genId: string, imageUrl: string, imageIndex = 0) => {
+    setEditingContext({ genId, imageUrl, imageIndex });
   }, []);
 
   const handleDelete = useCallback(
@@ -195,13 +195,20 @@ export default function HistoryPage() {
       </div>
 
       {/* Image Editor Modal */}
-      {editingImage && (
+      {editingContext && (
         <ImageEditor
-          imageUrl={editingImage}
-          onClose={() => setEditingImage(null)}
-          onSave={async (_blob) => {
-            // TODO: Implement save to backend
-            setEditingImage(null);
+          imageUrl={editingContext.imageUrl}
+          onClose={() => setEditingContext(null)}
+          onSave={async (blob) => {
+            if (!editingContext) return;
+            try {
+              await updateGenerationImage(editingContext.genId, blob, editingContext.imageIndex);
+              refresh();
+            } catch (err) {
+              console.error("Save edited image failed:", err);
+              alert(err instanceof Error ? err.message : "Save failed");
+            }
+            setEditingContext(null);
           }}
         />
       )}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -140,6 +140,27 @@ export async function deleteGeneration(id: string) {
   return response.data;
 }
 
+export async function updateGenerationImage(
+  id: string,
+  image: Blob,
+  imageIndex = 0
+): Promise<{ imageUrl: string }> {
+  const formData = new FormData();
+  formData.append("image", image);
+  formData.append("imageIndex", String(imageIndex));
+
+  const response = await api.patch<{ imageUrl: string }>(
+    `${ENDPOINTS.generations.get(id)}/image`,
+    formData,
+    {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    }
+  );
+  return response.data;
+}
+
 // ============================================
 // Upload APIs
 // ============================================


### PR DESCRIPTION
## Summary

实现 HistoryPage 图片编辑器保存功能。

### Backend
-  - 上传编辑后图片到 R2，更新 
- 认证、ownership 验证、错误处理

### Frontend
-  API 函数
- HistoryPage:  状态替换 ，保存时调用 API 并 refresh
- GenerationCard:  签名更新为 

## Files
- 
- 
- 
- 

🤖 Generated with [Claude Code](https://claude.com/claude-code)