### PR TITLE
fix: support __Secure- prefixed session cookie names

### DIFF
--- a/api/src/lib/auth.ts
+++ b/api/src/lib/auth.ts
@@ -127,7 +127,8 @@ export function getSessionTokenFromHeaders(headers: Headers): string | null {
   if (!cookie) return null;
 
   const match =
-    cookie.match(/better-auth\.session_token=([^;]+)/) ||
+    // Matches: better-auth.session_token, __Secure-better-auth.session_token, __Host-better-auth.session-token
+    cookie.match(/(?:__Secure-|__Host-)?better-auth[.-]session[_-]token=([^;]+)/) ||
     cookie.match(/ourapix\.session=([^;]+)/);
   return match?.[1] ?? null;
 }


### PR DESCRIPTION
## Summary

**问题：** 线上环境所有受保护的 API 路由（ 等）返回 401 未授权。

**原因：** Better Auth 在生产环境设置 session cookie 名称为 ，但  只匹配 （无前缀）。

**修复：** 扩展正则，支持以下 cookie 名称格式：
- 
- 
- 

**测试验证：**
```bash
# Session 端点正常（之前已验证）
curl https://api.ourapix.jiahongw.com/api/auth/session   -H 'Cookie: __Secure-better-auth.session_token=<token>'
# → 返回有效 session

# Generations 端点修复后正常
curl https://api.ourapix.jiahongw.com/api/generations   -H 'Cookie: __Secure-better-auth.session_token=<token>'
# → 返回 200（修复后）
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)