### PR TITLE
refactor: upgrade ESLint warn rules to error

### DIFF
--- a/api/eslint.config.js
+++ b/api/eslint.config.js
@@ -12,9 +12,9 @@ export default tseslint.config(
       },
     },
     rules: {
-      '@typescript-eslint/no-explicit-any': 'warn',
-      '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
-      'no-console': ['warn', { allow: ['warn', 'error', 'info'] }],
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+      'no-console': ['error', { allow: ['warn', 'error', 'info'] }],
     },
   },
   {

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -12,9 +12,9 @@ export default tseslint.config(
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
-      '@typescript-eslint/no-explicit-any': 'warn',
-      '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
-      'no-console': ['warn', { allow: ['warn', 'error', 'info'] }],
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      'no-console': ['error', { allow: ['warn', 'error', 'info'] }],
     },
   },
   {


### PR DESCRIPTION
## 变更

将 warn 级别规则升级为 error：

- `@typescript-eslint/no-explicit-any`: warn → error
- `@typescript-eslint/no-unused-vars`: warn → error  
- `no-console`: warn → error

## 验证

升级后 lint 0 errors，无违规。

🤖 Generated with [Claude Code](https://claude.com/claude-code)